### PR TITLE
Remove a few Interlocked.Exchange where the result is not checked and unnecessary to use it

### DIFF
--- a/docfx/packages/threading/benchmarks/asyncautoresetevent-set.md
+++ b/docfx/packages/threading/benchmarks/asyncautoresetevent-set.md
@@ -1,7 +1,7 @@
 ﻿| Description                         | Mean        | Ratio  | Allocated | 
 |------------------------------------ |------------:|-------:|----------:|
-| Set · AsyncAutoReset · ProtoPromise |   0.5934 ns |   0.29 |         - | 
-| Set · AsyncAutoReset · Pooled       |   2.0424 ns |   1.00 |         - | 
-| Set · AsyncAutoReset · RefImpl      |   4.3435 ns |   2.13 |         - | 
-| Set · AsyncAutoReset · Nito.AsyncEx |   4.4263 ns |   2.17 |         - | 
-| Set · AutoResetEvent · System       | 219.9599 ns | 107.70 |         - |
+| Set · AsyncAutoReset · ProtoPromise |   0.5349 ns |   0.79 |         - | 
+| Set · AsyncAutoReset · Pooled       |   0.6812 ns |   1.00 |         - | 
+| Set · AsyncAutoReset · RefImpl      |   4.1678 ns |   6.12 |         - | 
+| Set · AsyncAutoReset · Nito.AsyncEx |   4.2622 ns |   6.26 |         - | 
+| Set · AutoResetEvent · System       | 217.0665 ns | 318.79 |         - |

--- a/docfx/packages/threading/benchmarks/asyncautoresetevent-setthenw.md
+++ b/docfx/packages/threading/benchmarks/asyncautoresetevent-setthenw.md
@@ -1,7 +1,7 @@
 ﻿| Description                                       | Mean      | Ratio | Allocated | 
 |-------------------------------------------------- |----------:|------:|----------:|
-| SetThenWait · AsyncAutoReset · ProtoPromise       |  5.561 ns |  0.74 |         - | 
-| SetThenWait · AsyncAutoReset · Pooled (ValueTask) |  7.546 ns |  1.00 |         - | 
-| SetThenWait · AsyncAutoReset · Pooled (AsTask)    |  8.743 ns |  1.16 |         - | 
-| SetThenWait · AsyncAutoReset · Nito.AsyncEx       | 14.318 ns |  1.90 |         - | 
-| SetThenWait · AsyncAutoReset · RefImpl            | 15.575 ns |  2.06 |         - |
+| SetThenWait · AsyncAutoReset · ProtoPromise       |  5.294 ns |  0.84 |         - | 
+| SetThenWait · AsyncAutoReset · Pooled (ValueTask) |  6.303 ns |  1.00 |         - | 
+| SetThenWait · AsyncAutoReset · Pooled (AsTask)    |  7.069 ns |  1.12 |         - | 
+| SetThenWait · AsyncAutoReset · Nito.AsyncEx       | 13.545 ns |  2.15 |         - | 
+| SetThenWait · AsyncAutoReset · RefImpl            | 14.940 ns |  2.37 |         - |

--- a/docfx/packages/threading/benchmarks/asyncautoresetevent-waitthenset.md
+++ b/docfx/packages/threading/benchmarks/asyncautoresetevent-waitthenset.md
@@ -1,77 +1,77 @@
 ﻿| Description                                                  | Iterations | cancellationType | Mean          | Ratio | Allocated | 
 |------------------------------------------------------------- |----------- |----------------- |--------------:|------:|----------:|
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 1          | None             |      23.67 ns |  0.92 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 1          | None             |      23.76 ns |  0.92 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 1          | None             |      25.51 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 1          | None             |      25.68 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · RefImpl                       | 1          | None             |      28.91 ns |  1.13 |      96 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 1          | None             |      29.48 ns |  1.15 |         - | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 1          | None             |      36.83 ns |  1.43 |     160 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 1          | None             |      39.48 ns |  1.54 |      80 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 1          | None             |     437.51 ns | 17.03 |     231 B | 
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 1          | None             |      23.11 ns |  0.92 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 1          | None             |      23.12 ns |  0.92 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 1          | None             |      23.21 ns |  0.92 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 1          | None             |      25.04 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 1          | None             |      25.11 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · RefImpl                       | 1          | None             |      27.91 ns |  1.11 |      96 B | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 1          | None             |      33.73 ns |  1.34 |     160 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 1          | None             |      35.44 ns |  1.41 |      80 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 1          | None             |     447.19 ns | 17.81 |     231 B | 
 |                                                              |            |                  |               |       |           | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 1          | NotCancelled     |      40.45 ns |  0.98 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 1          | NotCancelled     |      41.07 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 1          | NotCancelled     |      41.15 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 1          | NotCancelled     |      41.49 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 1          | NotCancelled     |      45.61 ns |  1.10 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 1          | NotCancelled     |      60.56 ns |  1.46 |      80 B | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 1          | NotCancelled     |     304.86 ns |  7.35 |     400 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 1          | NotCancelled     |     494.77 ns | 11.93 |     232 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 1          | NotCancelled     |      38.70 ns |  0.96 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 1          | NotCancelled     |      38.71 ns |  0.96 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 1          | NotCancelled     |      40.22 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 1          | NotCancelled     |      40.32 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 1          | NotCancelled     |      44.87 ns |  1.11 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 1          | NotCancelled     |      58.77 ns |  1.46 |      80 B | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 1          | NotCancelled     |     303.38 ns |  7.53 |     400 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 1          | NotCancelled     |     492.10 ns | 12.21 |     232 B | 
 |                                                              |            |                  |               |       |           | 
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 2          | None             |      46.20 ns |  0.74 |         - | 
-| WaitThenSet · AsyncAutoReset · RefImpl                       | 2          | None             |      57.68 ns |  0.92 |     192 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 2          | None             |      60.76 ns |  0.97 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 2          | None             |      61.78 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 2          | None             |      62.51 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 2          | None             |      69.01 ns |  1.10 |         - | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 2          | None             |      92.97 ns |  1.49 |     320 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 2          | None             |      94.70 ns |  1.51 |     160 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 2          | None             |     758.54 ns | 12.13 |     343 B | 
+| WaitThenSet · AsyncAutoReset · RefImpl                       | 2          | None             |      52.17 ns |  0.84 |     192 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 2          | None             |      56.13 ns |  0.91 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 2          | None             |      57.55 ns |  0.93 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 2          | None             |      60.42 ns |  0.98 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 2          | None             |      61.89 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 2          | None             |      62.63 ns |  1.01 |     320 B | 
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 2          | None             |      87.36 ns |  1.41 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 2          | None             |      91.08 ns |  1.47 |     160 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 2          | None             |     753.69 ns | 12.18 |     343 B | 
 |                                                              |            |                  |               |       |           | 
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 2          | NotCancelled     |      90.24 ns |  0.92 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 2          | NotCancelled     |      95.85 ns |  0.98 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 2          | NotCancelled     |      97.10 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 2          | NotCancelled     |      98.20 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 2          | NotCancelled     |     100.12 ns |  1.02 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 2          | NotCancelled     |     141.96 ns |  1.45 |     160 B | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 2          | NotCancelled     |     559.48 ns |  5.70 |     800 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 2          | NotCancelled     |     816.18 ns |  8.31 |     344 B | 
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 2          | NotCancelled     |      88.06 ns |  0.91 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 2          | NotCancelled     |      92.75 ns |  0.96 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 2          | NotCancelled     |      94.59 ns |  0.98 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 2          | NotCancelled     |      96.28 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 2          | NotCancelled     |      96.54 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 2          | NotCancelled     |     138.99 ns |  1.44 |     160 B | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 2          | NotCancelled     |     583.75 ns |  6.05 |     800 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 2          | NotCancelled     |     873.77 ns |  9.05 |     344 B | 
 |                                                              |            |                  |               |       |           | 
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 10         | None             |     238.66 ns |  0.69 |         - | 
-| WaitThenSet · AsyncAutoReset · RefImpl                       | 10         | None             |     278.11 ns |  0.80 |     960 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 10         | None             |     322.31 ns |  0.93 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 10         | None             |     324.45 ns |  0.93 |         - | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 10         | None             |     331.23 ns |  0.95 |    1600 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 10         | None             |     348.15 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 10         | None             |     350.61 ns |  1.01 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 10         | None             |     509.40 ns |  1.46 |     800 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 10         | None             |   2,027.40 ns |  5.82 |    1239 B | 
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 10         | None             |     233.91 ns |  0.59 |         - | 
+| WaitThenSet · AsyncAutoReset · RefImpl                       | 10         | None             |     268.65 ns |  0.68 |     960 B | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 10         | None             |     303.53 ns |  0.76 |    1600 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 10         | None             |     312.26 ns |  0.79 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 10         | None             |     317.88 ns |  0.80 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 10         | None             |     342.02 ns |  0.86 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 10         | None             |     397.56 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 10         | None             |     514.99 ns |  1.30 |     800 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 10         | None             |   2,049.85 ns |  5.16 |    1236 B | 
 |                                                              |            |                  |               |       |           | 
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 10         | NotCancelled     |     443.78 ns |  0.84 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 10         | NotCancelled     |     510.85 ns |  0.96 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 10         | NotCancelled     |     522.37 ns |  0.98 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 10         | NotCancelled     |     527.66 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 10         | NotCancelled     |     530.53 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 10         | NotCancelled     |     749.94 ns |  1.41 |     800 B | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 10         | NotCancelled     |   2,641.41 ns |  4.98 |    4000 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 10         | NotCancelled     |   2,783.51 ns |  5.25 |    1239 B | 
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 10         | NotCancelled     |     437.31 ns |  0.85 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 10         | NotCancelled     |     491.00 ns |  0.96 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 10         | NotCancelled     |     496.15 ns |  0.97 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 10         | NotCancelled     |     513.49 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 10         | NotCancelled     |     515.71 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 10         | NotCancelled     |     751.00 ns |  1.46 |     800 B | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 10         | NotCancelled     |   2,627.47 ns |  5.12 |    4000 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 10         | NotCancelled     |   2,716.97 ns |  5.29 |    1238 B | 
 |                                                              |            |                  |               |       |           | 
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 100        | None             |   2,276.40 ns |  0.67 |         - | 
-| WaitThenSet · AsyncAutoReset · RefImpl                       | 100        | None             |   2,830.92 ns |  0.84 |    9600 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 100        | None             |   3,015.75 ns |  0.89 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 100        | None             |   3,116.66 ns |  0.92 |         - | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 100        | None             |   3,358.72 ns |  0.99 |   16000 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 100        | None             |   3,364.45 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 100        | None             |   3,383.75 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 100        | None             |   5,046.55 ns |  1.49 |    8000 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 100        | None             |  15,938.99 ns |  4.71 |   11320 B | 
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 100        | None             |   2,202.94 ns |  0.66 |         - | 
+| WaitThenSet · AsyncAutoReset · RefImpl                       | 100        | None             |   2,686.45 ns |  0.81 |    9600 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 100        | None             |   2,922.77 ns |  0.88 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 100        | None             |   2,947.52 ns |  0.89 |         - | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 100        | None             |   3,133.24 ns |  0.94 |   16000 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 100        | None             |   3,296.53 ns |  0.99 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 100        | None             |   3,323.51 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 100        | None             |   4,866.06 ns |  1.46 |    8000 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 100        | None             |  15,749.32 ns |  4.74 |   11320 B | 
 |                                                              |            |                  |               |       |           | 
-| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 100        | NotCancelled     |   4,369.55 ns |  0.84 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 100        | NotCancelled     |   4,995.37 ns |  0.96 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 100        | NotCancelled     |   5,085.51 ns |  0.98 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 100        | NotCancelled     |   5,120.61 ns |  0.99 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 100        | NotCancelled     |   5,192.85 ns |  1.00 |         - | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 100        | NotCancelled     |   7,536.83 ns |  1.45 |    8000 B | 
-| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 100        | NotCancelled     |  25,212.43 ns |  4.86 |   40000 B | 
-| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 100        | NotCancelled     | 261,463.56 ns | 50.36 |   11324 B |
+| WaitThenSet · AsyncAutoReset · ProtoPromise                  | 100        | NotCancelled     |   4,322.77 ns |  0.85 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask)          | 100        | NotCancelled     |   4,821.08 ns |  0.95 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsValueTask SyncCont) | 100        | NotCancelled     |   4,975.09 ns |  0.98 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (ValueTask)            | 100        | NotCancelled     |   5,076.02 ns |  1.00 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (SyncCont)             | 100        | NotCancelled     |   5,438.26 ns |  1.07 |         - | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask SyncCont)      | 100        | NotCancelled     |   7,519.64 ns |  1.48 |    8000 B | 
+| WaitThenSet · AsyncAutoReset · Nito.AsyncEx                  | 100        | NotCancelled     |  33,761.27 ns |  6.65 |   40000 B | 
+| WaitThenSet · AsyncAutoReset · Pooled (AsTask)               | 100        | NotCancelled     | 407,038.78 ns | 80.20 |   11326 B |

--- a/docfx/packages/threading/benchmarks/asyncbarrier-signalandwait.md
+++ b/docfx/packages/threading/benchmarks/asyncbarrier-signalandwait.md
@@ -1,9 +1,9 @@
-﻿| Description                            | ParticipantCount | Mean        | Ratio | Allocated | 
-|--------------------------------------- |----------------- |------------:|------:|----------:|
-| SignalAndWait · AsyncBarrier · Pooled  | 1                |    11.05 ns |  1.00 |         - | 
-| SignalAndWait · Barrier · System       | 1                |   447.08 ns | 40.47 |     238 B | 
-| SignalAndWait · AsyncBarrier · RefImpl | 1                |   945.56 ns | 85.60 |    8362 B | 
-|                                        |                  |             |       |           | 
-| SignalAndWait · AsyncBarrier · Pooled  | 10               |   281.96 ns |  1.00 |         - | 
-| SignalAndWait · AsyncBarrier · RefImpl | 10               | 1,647.19 ns |  5.84 |    9991 B | 
-| SignalAndWait · Barrier · System       | 10               | 4,273.74 ns | 15.16 |    1392 B |
+﻿| Description                            | ParticipantCount | Mean         | Ratio  | Allocated | 
+|--------------------------------------- |----------------- |-------------:|-------:|----------:|
+| SignalAndWait · AsyncBarrier · Pooled  | 1                |     10.85 ns |   1.00 |         - | 
+| SignalAndWait · Barrier · System       | 1                |    452.84 ns |  41.73 |     238 B | 
+| SignalAndWait · AsyncBarrier · RefImpl | 1                |    936.26 ns |  86.29 |    8347 B | 
+|                                        |                  |              |        |           | 
+| SignalAndWait · AsyncBarrier · Pooled  | 10               |    254.53 ns |   1.00 |         - | 
+| SignalAndWait · AsyncBarrier · RefImpl | 10               |  1,667.41 ns |   6.55 |   10252 B | 
+| SignalAndWait · Barrier · System       | 10               | 40,505.19 ns | 159.16 |    1446 B |

--- a/docfx/packages/threading/benchmarks/asynccountdownevent-signal.md
+++ b/docfx/packages/threading/benchmarks/asynccountdownevent-signal.md
@@ -1,15 +1,15 @@
 ﻿| Description                                     | ParticipantCount | Mean      | Ratio | Allocated | 
 |------------------------------------------------ |----------------- |----------:|------:|----------:|
-| SignalAndWait · CountdownEvent · System         | 1                |  6.939 ns |  0.80 |         - | 
-| SignalAndWait · AsyncCountdownEv · ProtoPromise | 1                |  7.493 ns |  0.86 |         - | 
-| SignalAndWait · AsyncCountdownEv · Pooled       | 1                |  8.691 ns |  1.00 |         - | 
-| SignalAndWait · AsyncCountdownEv · RefImpl      | 1                | 16.718 ns |  1.92 |      96 B | 
-| WaitAndSignal · AsyncCountdownEv · ProtoPromise | 1                | 19.096 ns |  2.20 |         - | 
-| WaitAndSignal · AsyncCountdownEv · Pooled       | 1                | 41.424 ns |  4.77 |         - | 
+| SignalAndWait · CountdownEvent · System         | 1                |  6.661 ns |  0.83 |         - | 
+| SignalAndWait · AsyncCountdownEv · ProtoPromise | 1                |  7.370 ns |  0.92 |         - | 
+| SignalAndWait · AsyncCountdownEv · Pooled       | 1                |  8.016 ns |  1.00 |         - | 
+| SignalAndWait · AsyncCountdownEv · RefImpl      | 1                | 15.803 ns |  1.97 |      96 B | 
+| WaitAndSignal · AsyncCountdownEv · ProtoPromise | 1                | 18.378 ns |  2.29 |         - | 
+| WaitAndSignal · AsyncCountdownEv · Pooled       | 1                | 43.926 ns |  5.48 |         - | 
 |                                                 |                  |           |       |           | 
-| SignalAndWait · AsyncCountdownEv · ProtoPromise | 10               | 17.113 ns |  0.73 |         - | 
-| SignalAndWait · CountdownEvent · System         | 10               | 20.424 ns |  0.87 |         - | 
-| SignalAndWait · AsyncCountdownEv · Pooled       | 10               | 23.508 ns |  1.00 |         - | 
-| WaitAndSignal · AsyncCountdownEv · ProtoPromise | 10               | 28.820 ns |  1.23 |         - | 
-| SignalAndWait · AsyncCountdownEv · RefImpl      | 10               | 29.256 ns |  1.24 |      96 B | 
-| WaitAndSignal · AsyncCountdownEv · Pooled       | 10               | 57.756 ns |  2.46 |         - |
+| SignalAndWait · AsyncCountdownEv · ProtoPromise | 10               | 17.067 ns |  0.77 |         - | 
+| SignalAndWait · CountdownEvent · System         | 10               | 20.834 ns |  0.94 |         - | 
+| SignalAndWait · AsyncCountdownEv · Pooled       | 10               | 22.233 ns |  1.00 |         - | 
+| WaitAndSignal · AsyncCountdownEv · ProtoPromise | 10               | 28.077 ns |  1.26 |         - | 
+| SignalAndWait · AsyncCountdownEv · RefImpl      | 10               | 28.195 ns |  1.27 |      96 B | 
+| WaitAndSignal · AsyncCountdownEv · Pooled       | 10               | 57.694 ns |  2.60 |         - |

--- a/docfx/packages/threading/benchmarks/asynclock-multiple.md
+++ b/docfx/packages/threading/benchmarks/asynclock-multiple.md
@@ -1,77 +1,77 @@
 ﻿| Description                               | Iterations | cancellationType | Mean          | Ratio | Allocated | 
 |------------------------------------------ |----------- |----------------- |--------------:|------:|----------:|
-| Multiple · AsyncLock · Pooled (ValueTask) | 0          | None             |      9.982 ns |  1.00 |         - | 
-| Multiple · AsyncLock · ProtoPromise       | 0          | None             |     11.288 ns |  1.13 |         - | 
-| Multiple · AsyncLock · Pooled (Task)      | 0          | None             |     11.512 ns |  1.15 |         - | 
-| Multiple · SemaphoreSlim · System         | 0          | None             |     18.415 ns |  1.84 |         - | 
-| Multiple · AsyncLock · RefImpl            | 0          | None             |     19.814 ns |  1.98 |         - | 
-| Multiple · AsyncSemaphore · VS.Threading  | 0          | None             |     19.926 ns |  2.00 |         - | 
-| Multiple · AsyncLock · NonKeyed           | 0          | None             |     21.421 ns |  2.15 |         - | 
-| Multiple · AsyncLock · Nito               | 0          | None             |     40.493 ns |  4.06 |     320 B | 
-| Multiple · AsyncLock · NeoSmart           | 0          | None             |     61.062 ns |  6.12 |     208 B | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 0          | None             |      9.944 ns |  1.00 |         - | 
+| Multiple · AsyncLock · Pooled (Task)      | 0          | None             |     10.279 ns |  1.03 |         - | 
+| Multiple · AsyncLock · ProtoPromise       | 0          | None             |     11.144 ns |  1.12 |         - | 
+| Multiple · SemaphoreSlim · System         | 0          | None             |     17.640 ns |  1.77 |         - | 
+| Multiple · AsyncSemaphore · VS.Threading  | 0          | None             |     18.594 ns |  1.87 |         - | 
+| Multiple · AsyncLock · RefImpl            | 0          | None             |     19.394 ns |  1.95 |         - | 
+| Multiple · AsyncLock · NonKeyed           | 0          | None             |     20.600 ns |  2.07 |         - | 
+| Multiple · AsyncLock · Nito               | 0          | None             |     39.078 ns |  3.93 |     320 B | 
+| Multiple · AsyncLock · NeoSmart           | 0          | None             |     58.457 ns |  5.88 |     208 B | 
 |                                           |            |                  |               |       |           | 
-| Multiple · AsyncLock · Pooled (ValueTask) | 0          | NotCancelled     |      9.961 ns |  1.00 |         - | 
-| Multiple · AsyncLock · Pooled (Task)      | 0          | NotCancelled     |     11.654 ns |  1.17 |         - | 
-| Multiple · AsyncLock · ProtoPromise       | 0          | NotCancelled     |     12.486 ns |  1.25 |         - | 
-| Multiple · SemaphoreSlim · System         | 0          | NotCancelled     |     19.151 ns |  1.92 |         - | 
-| Multiple · AsyncSemaphore · VS.Threading  | 0          | NotCancelled     |     20.561 ns |  2.06 |         - | 
-| Multiple · AsyncLock · NonKeyed           | 0          | NotCancelled     |     21.864 ns |  2.19 |         - | 
-| Multiple · AsyncLock · Nito               | 0          | NotCancelled     |     39.537 ns |  3.97 |     320 B | 
-| Multiple · AsyncLock · NeoSmart           | 0          | NotCancelled     |     63.557 ns |  6.38 |     208 B | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 0          | NotCancelled     |     10.323 ns |  1.00 |         - | 
+| Multiple · AsyncLock · Pooled (Task)      | 0          | NotCancelled     |     10.642 ns |  1.03 |         - | 
+| Multiple · AsyncLock · ProtoPromise       | 0          | NotCancelled     |     11.886 ns |  1.15 |         - | 
+| Multiple · SemaphoreSlim · System         | 0          | NotCancelled     |     17.517 ns |  1.70 |         - | 
+| Multiple · AsyncSemaphore · VS.Threading  | 0          | NotCancelled     |     19.447 ns |  1.88 |         - | 
+| Multiple · AsyncLock · NonKeyed           | 0          | NotCancelled     |     21.326 ns |  2.07 |         - | 
+| Multiple · AsyncLock · Nito               | 0          | NotCancelled     |     38.806 ns |  3.76 |     320 B | 
+| Multiple · AsyncLock · NeoSmart           | 0          | NotCancelled     |     56.755 ns |  5.50 |     208 B | 
 |                                           |            |                  |               |       |           | 
-| Multiple · AsyncLock · Pooled (ValueTask) | 1          | None             |     32.036 ns |  1.00 |         - | 
-| Multiple · AsyncLock · ProtoPromise       | 1          | None             |     39.483 ns |  1.23 |         - | 
-| Multiple · SemaphoreSlim · System         | 1          | None             |     64.189 ns |  2.00 |      88 B | 
-| Multiple · AsyncSemaphore · VS.Threading  | 1          | None             |     67.815 ns |  2.12 |     168 B | 
-| Multiple · AsyncLock · RefImpl            | 1          | None             |     80.841 ns |  2.52 |     216 B | 
-| Multiple · AsyncLock · Nito               | 1          | None             |     97.514 ns |  3.04 |     728 B | 
-| Multiple · AsyncLock · NeoSmart           | 1          | None             |    120.123 ns |  3.75 |     416 B | 
-| Multiple · AsyncLock · Pooled (Task)      | 1          | None             |    465.730 ns | 14.54 |     272 B | 
-| Multiple · AsyncLock · NonKeyed           | 1          | None             |    541.835 ns | 16.91 |     352 B | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 1          | None             |     28.165 ns |  1.00 |         - | 
+| Multiple · AsyncLock · ProtoPromise       | 1          | None             |     36.486 ns |  1.30 |         - | 
+| Multiple · SemaphoreSlim · System         | 1          | None             |     42.075 ns |  1.49 |      88 B | 
+| Multiple · AsyncSemaphore · VS.Threading  | 1          | None             |     64.412 ns |  2.29 |     168 B | 
+| Multiple · AsyncLock · RefImpl            | 1          | None             |     76.101 ns |  2.70 |     216 B | 
+| Multiple · AsyncLock · Nito               | 1          | None             |     91.453 ns |  3.25 |     728 B | 
+| Multiple · AsyncLock · NeoSmart           | 1          | None             |    116.605 ns |  4.14 |     416 B | 
+| Multiple · AsyncLock · Pooled (Task)      | 1          | None             |    480.060 ns | 17.05 |     271 B | 
+| Multiple · AsyncLock · NonKeyed           | 1          | None             |    543.285 ns | 19.29 |     352 B | 
 |                                           |            |                  |               |       |           | 
-| Multiple · AsyncLock · Pooled (ValueTask) | 1          | NotCancelled     |     48.392 ns |  1.00 |         - | 
-| Multiple · AsyncLock · ProtoPromise       | 1          | NotCancelled     |     63.314 ns |  1.31 |         - | 
-| Multiple · AsyncSemaphore · VS.Threading  | 1          | NotCancelled     |     84.703 ns |  1.75 |     168 B | 
-| Multiple · AsyncLock · NeoSmart           | 1          | NotCancelled     |    123.076 ns |  2.54 |     416 B | 
-| Multiple · AsyncLock · Nito               | 1          | NotCancelled     |    383.019 ns |  7.92 |     968 B | 
-| Multiple · AsyncLock · Pooled (Task)      | 1          | NotCancelled     |    527.330 ns | 10.90 |     272 B | 
-| Multiple · SemaphoreSlim · System         | 1          | NotCancelled     |    615.076 ns | 12.71 |     504 B | 
-| Multiple · AsyncLock · NonKeyed           | 1          | NotCancelled     |    690.744 ns | 14.27 |     640 B | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 1          | NotCancelled     |     46.467 ns |  1.00 |         - | 
+| Multiple · AsyncLock · ProtoPromise       | 1          | NotCancelled     |     78.408 ns |  1.69 |         - | 
+| Multiple · AsyncSemaphore · VS.Threading  | 1          | NotCancelled     |     79.121 ns |  1.70 |     168 B | 
+| Multiple · AsyncLock · NeoSmart           | 1          | NotCancelled     |    119.281 ns |  2.57 |     416 B | 
+| Multiple · AsyncLock · Nito               | 1          | NotCancelled     |    394.059 ns |  8.48 |     968 B | 
+| Multiple · AsyncLock · Pooled (Task)      | 1          | NotCancelled     |    516.424 ns | 11.12 |     272 B | 
+| Multiple · SemaphoreSlim · System         | 1          | NotCancelled     |    565.700 ns | 12.18 |     504 B | 
+| Multiple · AsyncLock · NonKeyed           | 1          | NotCancelled     |    660.724 ns | 14.22 |     640 B | 
 |                                           |            |                  |               |       |           | 
-| Multiple · AsyncLock · ProtoPromise       | 10         | None             |    273.653 ns |  0.86 |         - | 
-| Multiple · SemaphoreSlim · System         | 10         | None             |    306.379 ns |  0.96 |     880 B | 
-| Multiple · AsyncLock · Pooled (ValueTask) | 10         | None             |    319.273 ns |  1.00 |         - | 
-| Multiple · AsyncLock · Nito               | 10         | None             |    548.522 ns |  1.72 |    4400 B | 
-| Multiple · AsyncSemaphore · VS.Threading  | 10         | None             |    563.387 ns |  1.76 |    1680 B | 
-| Multiple · AsyncLock · NeoSmart           | 10         | None             |    638.643 ns |  2.00 |    2288 B | 
-| Multiple · AsyncLock · RefImpl            | 10         | None             |    680.233 ns |  2.13 |    2160 B | 
-| Multiple · AsyncLock · Pooled (Task)      | 10         | None             |  3,153.577 ns |  9.88 |    1352 B | 
-| Multiple · AsyncLock · NonKeyed           | 10         | None             |  3,500.843 ns | 10.97 |    2296 B | 
+| Multiple · AsyncLock · ProtoPromise       | 10         | None             |    261.829 ns |  0.84 |         - | 
+| Multiple · SemaphoreSlim · System         | 10         | None             |    270.938 ns |  0.87 |     880 B | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 10         | None             |    309.915 ns |  1.00 |         - | 
+| Multiple · AsyncSemaphore · VS.Threading  | 10         | None             |    511.846 ns |  1.65 |    1680 B | 
+| Multiple · AsyncLock · Nito               | 10         | None             |    542.904 ns |  1.75 |    4400 B | 
+| Multiple · AsyncLock · RefImpl            | 10         | None             |    619.827 ns |  2.00 |    2160 B | 
+| Multiple · AsyncLock · NeoSmart           | 10         | None             |    634.247 ns |  2.05 |    2288 B | 
+| Multiple · AsyncLock · Pooled (Task)      | 10         | None             |  3,191.047 ns | 10.30 |    1352 B | 
+| Multiple · AsyncLock · NonKeyed           | 10         | None             |  3,509.004 ns | 11.32 |    2296 B | 
 |                                           |            |                  |               |       |           | 
-| Multiple · AsyncLock · ProtoPromise       | 10         | NotCancelled     |    500.333 ns |  0.98 |         - | 
-| Multiple · AsyncLock · Pooled (ValueTask) | 10         | NotCancelled     |    509.105 ns |  1.00 |         - | 
-| Multiple · AsyncLock · NeoSmart           | 10         | NotCancelled     |    648.018 ns |  1.27 |    2288 B | 
-| Multiple · AsyncSemaphore · VS.Threading  | 10         | NotCancelled     |    770.817 ns |  1.51 |    1680 B | 
-| Multiple · AsyncLock · Nito               | 10         | NotCancelled     |  3,184.195 ns |  6.25 |    6800 B | 
-| Multiple · AsyncLock · Pooled (Task)      | 10         | NotCancelled     |  3,437.208 ns |  6.75 |    1352 B | 
-| Multiple · SemaphoreSlim · System         | 10         | NotCancelled     |  4,461.538 ns |  8.76 |    3888 B | 
-| Multiple · AsyncLock · NonKeyed           | 10         | NotCancelled     |  4,953.170 ns |  9.73 |    5176 B | 
+| Multiple · AsyncLock · ProtoPromise       | 10         | NotCancelled     |    466.087 ns |  0.91 |         - | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 10         | NotCancelled     |    515.058 ns |  1.00 |         - | 
+| Multiple · AsyncLock · NeoSmart           | 10         | NotCancelled     |    628.808 ns |  1.22 |    2288 B | 
+| Multiple · AsyncSemaphore · VS.Threading  | 10         | NotCancelled     |    700.242 ns |  1.36 |    1680 B | 
+| Multiple · AsyncLock · Nito               | 10         | NotCancelled     |  3,204.949 ns |  6.22 |    6800 B | 
+| Multiple · AsyncLock · Pooled (Task)      | 10         | NotCancelled     |  3,474.221 ns |  6.75 |    1352 B | 
+| Multiple · SemaphoreSlim · System         | 10         | NotCancelled     |  4,349.064 ns |  8.45 |    3888 B | 
+| Multiple · AsyncLock · NonKeyed           | 10         | NotCancelled     |  4,972.770 ns |  9.66 |    5176 B | 
 |                                           |            |                  |               |       |           | 
-| Multiple · SemaphoreSlim · System         | 100        | None             |  2,572.538 ns |  0.85 |    8800 B | 
-| Multiple · AsyncLock · ProtoPromise       | 100        | None             |  2,719.887 ns |  0.90 |         - | 
-| Multiple · AsyncLock · Pooled (ValueTask) | 100        | None             |  3,026.152 ns |  1.00 |         - | 
-| Multiple · AsyncSemaphore · VS.Threading  | 100        | None             |  4,976.758 ns |  1.64 |   21120 B | 
-| Multiple · AsyncLock · Nito               | 100        | None             |  5,319.848 ns |  1.76 |   41120 B | 
-| Multiple · AsyncLock · NeoSmart           | 100        | None             |  6,013.208 ns |  1.99 |   21008 B | 
-| Multiple · AsyncLock · RefImpl            | 100        | None             |  6,270.949 ns |  2.07 |   21600 B | 
-| Multiple · AsyncLock · Pooled (Task)      | 100        | None             | 33,983.552 ns | 11.23 |   12215 B | 
-| Multiple · AsyncLock · NonKeyed           | 100        | None             | 35,457.147 ns | 11.72 |   21799 B | 
+| Multiple · AsyncLock · ProtoPromise       | 100        | None             |  2,582.434 ns |  0.81 |         - | 
+| Multiple · SemaphoreSlim · System         | 100        | None             |  2,587.874 ns |  0.82 |    8800 B | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 100        | None             |  3,169.397 ns |  1.00 |         - | 
+| Multiple · AsyncSemaphore · VS.Threading  | 100        | None             |  4,740.432 ns |  1.50 |   21120 B | 
+| Multiple · AsyncLock · Nito               | 100        | None             |  5,232.310 ns |  1.65 |   41120 B | 
+| Multiple · AsyncLock · RefImpl            | 100        | None             |  6,004.082 ns |  1.89 |   21600 B | 
+| Multiple · AsyncLock · NeoSmart           | 100        | None             |  6,037.141 ns |  1.91 |   21008 B | 
+| Multiple · AsyncLock · Pooled (Task)      | 100        | None             | 34,158.735 ns | 10.78 |   12215 B | 
+| Multiple · AsyncLock · NonKeyed           | 100        | None             | 35,626.170 ns | 11.24 |   21800 B | 
 |                                           |            |                  |               |       |           | 
-| Multiple · AsyncLock · Pooled (ValueTask) | 100        | NotCancelled     |  5,037.526 ns |  1.00 |         - | 
-| Multiple · AsyncLock · ProtoPromise       | 100        | NotCancelled     |  5,172.330 ns |  1.03 |         - | 
-| Multiple · AsyncLock · NeoSmart           | 100        | NotCancelled     |  5,992.105 ns |  1.19 |   21008 B | 
-| Multiple · AsyncSemaphore · VS.Threading  | 100        | NotCancelled     |  7,191.230 ns |  1.43 |   21120 B | 
-| Multiple · AsyncLock · Nito               | 100        | NotCancelled     | 33,415.924 ns |  6.63 |   65120 B | 
-| Multiple · AsyncLock · Pooled (Task)      | 100        | NotCancelled     | 34,985.282 ns |  6.95 |   12215 B | 
-| Multiple · SemaphoreSlim · System         | 100        | NotCancelled     | 45,791.255 ns |  9.09 |   37792 B | 
-| Multiple · AsyncLock · NonKeyed           | 100        | NotCancelled     | 52,995.111 ns | 10.52 |   50600 B |
+| Multiple · AsyncLock · ProtoPromise       | 100        | NotCancelled     |  4,536.588 ns |  0.91 |         - | 
+| Multiple · AsyncLock · Pooled (ValueTask) | 100        | NotCancelled     |  4,987.139 ns |  1.00 |         - | 
+| Multiple · AsyncLock · NeoSmart           | 100        | NotCancelled     |  5,916.785 ns |  1.19 |   21008 B | 
+| Multiple · AsyncSemaphore · VS.Threading  | 100        | NotCancelled     |  6,643.265 ns |  1.33 |   21120 B | 
+| Multiple · AsyncLock · Pooled (Task)      | 100        | NotCancelled     | 33,360.289 ns |  6.69 |   12216 B | 
+| Multiple · AsyncLock · Nito               | 100        | NotCancelled     | 33,478.485 ns |  6.71 |   65120 B | 
+| Multiple · SemaphoreSlim · System         | 100        | NotCancelled     | 43,340.455 ns |  8.69 |   37792 B | 
+| Multiple · AsyncLock · NonKeyed           | 100        | NotCancelled     | 51,865.969 ns | 10.40 |   50600 B |

--- a/docfx/packages/threading/benchmarks/asynclock-single.md
+++ b/docfx/packages/threading/benchmarks/asynclock-single.md
@@ -1,21 +1,21 @@
 ﻿| Description                               | Mean       | Ratio | Allocated | 
 |------------------------------------------ |-----------:|------:|----------:|
-| Lock · Increment · System                 |  0.0057 ns | 0.001 |         - | 
-| Lock · Interlocked.Inc · System           |  0.1969 ns | 0.022 |         - | 
-| Lock · Interlocked.Add · System           |  0.2077 ns | 0.023 |         - | 
-| Lock · Interlocked.Exchange · System      |  0.5198 ns | 0.059 |         - | 
-| Lock · Interlocked.CmpX · System          |  0.8646 ns | 0.098 |         - | 
-| Lock · Lock · System                      |  3.2511 ns | 0.367 |         - | 
-| Lock · Lock.EnterScope · System           |  3.2787 ns | 0.370 |         - | 
-| SpinLock · SpinLock · CryptoHives         |  3.5416 ns | 0.400 |         - | 
-| Lock · lock() · System                    |  4.0188 ns | 0.454 |         - | 
-| LockAsync · AsyncLock · ProtoPromise      |  7.6080 ns | 0.859 |         - | 
-| LockAsync · AsyncLock · Pooled            |  8.8620 ns | 1.000 |         - | 
-| LockAsync · AsyncSemaphore · VS.Threading | 16.5497 ns | 1.868 |         - | 
-| LockAsync · SemaphoreSlim · System        | 17.1878 ns | 1.940 |         - | 
-| LockAsync · AsyncLock · RefImpl           | 18.3916 ns | 2.076 |         - | 
-| LockAsync · AsyncLock · NonKeyed          | 20.6801 ns | 2.334 |         - | 
-| LockAsync · AsyncLock · Nito.AsyncEx      | 39.5383 ns | 4.463 |     320 B | 
-| SpinWait · SpinOnce · System              | 42.1165 ns | 4.754 |         - | 
-| SpinLock · SpinLock · System              | 45.8585 ns | 5.176 |         - | 
-| LockAsync · AsyncLock · NeoSmart          | 62.5712 ns | 7.063 |     208 B |
+| Lock · Increment · System                 |  0.0010 ns | 0.000 |         - | 
+| Lock · Interlocked.Add · System           |  0.1764 ns | 0.021 |         - | 
+| Lock · Interlocked.Inc · System           |  0.1925 ns | 0.023 |         - | 
+| Lock · Interlocked.Exchange · System      |  0.5166 ns | 0.062 |         - | 
+| Lock · Interlocked.CmpX · System          |  0.8476 ns | 0.102 |         - | 
+| Lock · Lock · System                      |  3.0566 ns | 0.368 |         - | 
+| Lock · Lock.EnterScope · System           |  3.1459 ns | 0.379 |         - | 
+| SpinLock · SpinLock · CryptoHives         |  3.2782 ns | 0.395 |         - | 
+| Lock · lock() · System                    |  4.0113 ns | 0.483 |         - | 
+| LockAsync · AsyncLock · ProtoPromise      |  7.0620 ns | 0.851 |         - | 
+| LockAsync · AsyncLock · Pooled            |  8.3011 ns | 1.000 |         - | 
+| LockAsync · AsyncSemaphore · VS.Threading | 15.7214 ns | 1.894 |         - | 
+| LockAsync · SemaphoreSlim · System        | 16.4273 ns | 1.979 |         - | 
+| LockAsync · AsyncLock · RefImpl           | 17.8237 ns | 2.147 |         - | 
+| LockAsync · AsyncLock · NonKeyed          | 19.4962 ns | 2.349 |         - | 
+| LockAsync · AsyncLock · Nito.AsyncEx      | 37.5934 ns | 4.529 |     320 B | 
+| SpinWait · SpinOnce · System              | 41.3498 ns | 4.981 |         - | 
+| SpinLock · SpinLock · System              | 44.9287 ns | 5.412 |         - | 
+| LockAsync · AsyncLock · NeoSmart          | 55.3936 ns | 6.673 |     208 B |

--- a/docfx/packages/threading/benchmarks/asyncmanualresetevent-setreset.md
+++ b/docfx/packages/threading/benchmarks/asyncmanualresetevent-setreset.md
@@ -1,8 +1,8 @@
 ﻿| Description                                | Mean       | Ratio  | Allocated | 
 |------------------------------------------- |-----------:|-------:|----------:|
-| SetReset · AsyncManualReset · ProtoPromise |   1.496 ns |   0.72 |         - | 
-| SetReset · AsyncManualReset · Pooled       |   2.092 ns |   1.00 |         - | 
-| SetReset · ManualResetEventSlim · System   |   5.658 ns |   2.71 |         - | 
-| SetReset · AsyncManualReset · RefImpl      |  10.298 ns |   4.92 |      96 B | 
-| SetReset · AsyncManualReset · Nito.AsyncEx |  17.483 ns |   8.36 |      96 B | 
-| SetReset · ManualResetEvent · System       | 435.467 ns | 208.23 |         - |
+| SetReset · AsyncManualReset · ProtoPromise |   1.424 ns |   0.70 |         - | 
+| SetReset · AsyncManualReset · Pooled       |   2.043 ns |   1.00 |         - | 
+| SetReset · ManualResetEventSlim · System   |   5.633 ns |   2.76 |         - | 
+| SetReset · AsyncManualReset · RefImpl      |  10.499 ns |   5.14 |      96 B | 
+| SetReset · AsyncManualReset · Nito.AsyncEx |  17.007 ns |   8.33 |      96 B | 
+| SetReset · ManualResetEvent · System       | 426.864 ns | 208.98 |         - |

--- a/docfx/packages/threading/benchmarks/asyncmanualresetevent-setthenw.md
+++ b/docfx/packages/threading/benchmarks/asyncmanualresetevent-setthenw.md
@@ -1,7 +1,7 @@
 ﻿| Description                                         | Mean      | Ratio | Allocated | 
 |---------------------------------------------------- |----------:|------:|----------:|
-| SetThenWait · AsyncManualReset · ProtoPromise       |  6.566 ns |  0.87 |         - | 
-| SetThenWait · AsyncManualReset · Pooled (ValueTask) |  7.536 ns |  1.00 |         - | 
-| SetThenWait · AsyncManualReset · Pooled (AsTask)    |  8.976 ns |  1.19 |         - | 
-| SetThenWait · AsyncManualReset · RefImpl            | 14.156 ns |  1.88 |      96 B | 
-| SetThenWait · AsyncManualReset · Nito.AsyncEx       | 24.939 ns |  3.31 |      96 B |
+| SetThenWait · AsyncManualReset · ProtoPromise       |  6.130 ns |  0.71 |         - | 
+| SetThenWait · AsyncManualReset · Pooled (ValueTask) |  8.679 ns |  1.00 |         - | 
+| SetThenWait · AsyncManualReset · Pooled (AsTask)    | 10.352 ns |  1.19 |         - | 
+| SetThenWait · AsyncManualReset · RefImpl            | 14.084 ns |  1.62 |      96 B | 
+| SetThenWait · AsyncManualReset · Nito.AsyncEx       | 24.532 ns |  2.83 |      96 B |

--- a/docfx/packages/threading/benchmarks/asyncmanualresetevent-waitthenset.md
+++ b/docfx/packages/threading/benchmarks/asyncmanualresetevent-waitthenset.md
@@ -1,77 +1,77 @@
 ﻿| Description                                                    | Iterations | cancellationType | Mean          | Ratio | Allocated | 
 |--------------------------------------------------------------- |----------- |----------------- |--------------:|------:|----------:|
-| WaitThenSet · AsyncManualReset · RefImpl                       | 1          | None             |      19.16 ns |  0.75 |      96 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 1          | None             |      23.69 ns |  0.92 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 1          | None             |      23.73 ns |  0.93 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 1          | None             |      25.63 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 1          | None             |      26.12 ns |  1.02 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 1          | None             |      27.18 ns |  1.06 |         - | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 1          | None             |      32.37 ns |  1.26 |      96 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 1          | None             |      38.19 ns |  1.49 |      80 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 1          | None             |     437.21 ns | 17.06 |     231 B | 
+| WaitThenSet · AsyncManualReset · RefImpl                       | 1          | None             |      21.77 ns |  0.85 |      96 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 1          | None             |      23.40 ns |  0.92 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 1          | None             |      24.13 ns |  0.94 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 1          | None             |      25.07 ns |  0.98 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 1          | None             |      25.56 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 1          | None             |      26.57 ns |  1.04 |         - | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 1          | None             |      28.83 ns |  1.13 |      96 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 1          | None             |      36.29 ns |  1.42 |      80 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 1          | None             |     442.78 ns | 17.33 |     231 B | 
 |                                                                |            |                  |               |       |           | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 1          | NotCancelled     |      39.75 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 1          | NotCancelled     |      40.26 ns |  1.01 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 1          | NotCancelled     |      40.97 ns |  1.03 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 1          | NotCancelled     |      41.90 ns |  1.05 |         - | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 1          | NotCancelled     |      47.81 ns |  1.20 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 1          | NotCancelled     |      60.03 ns |  1.51 |      80 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 1          | NotCancelled     |     494.19 ns | 12.43 |     232 B | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 1          | NotCancelled     |     624.73 ns | 15.72 |     808 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 1          | NotCancelled     |      38.68 ns |  0.94 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 1          | NotCancelled     |      40.45 ns |  0.99 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 1          | NotCancelled     |      40.63 ns |  0.99 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 1          | NotCancelled     |      41.05 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 1          | NotCancelled     |      49.45 ns |  1.21 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 1          | NotCancelled     |      60.87 ns |  1.48 |      80 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 1          | NotCancelled     |     492.64 ns | 12.01 |     232 B | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 1          | NotCancelled     |     650.27 ns | 15.85 |     808 B | 
 |                                                                |            |                  |               |       |           | 
-| WaitThenSet · AsyncManualReset · RefImpl                       | 2          | None             |      24.39 ns |  0.44 |      96 B | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 2          | None             |      45.66 ns |  0.82 |         - | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 2          | None             |      47.29 ns |  0.85 |      96 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 2          | None             |      54.74 ns |  0.99 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 2          | None             |      55.07 ns |  0.99 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 2          | None             |      55.53 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 2          | None             |      57.27 ns |  1.03 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 2          | None             |      94.17 ns |  1.70 |     160 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 2          | None             |     736.75 ns | 13.27 |     343 B | 
+| WaitThenSet · AsyncManualReset · RefImpl                       | 2          | None             |      26.16 ns |  0.46 |      96 B | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 2          | None             |      39.16 ns |  0.69 |      96 B | 
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 2          | None             |      46.20 ns |  0.81 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 2          | None             |      51.22 ns |  0.90 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 2          | None             |      53.31 ns |  0.93 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 2          | None             |      54.87 ns |  0.96 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 2          | None             |      57.20 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 2          | None             |      82.64 ns |  1.45 |     160 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 2          | None             |     714.79 ns | 12.50 |     343 B | 
 |                                                                |            |                  |               |       |           | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 2          | NotCancelled     |      91.90 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 2          | NotCancelled     |      92.20 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 2          | NotCancelled     |      93.77 ns |  1.02 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 2          | NotCancelled     |      93.98 ns |  1.02 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 2          | NotCancelled     |      95.10 ns |  1.03 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 2          | NotCancelled     |     141.70 ns |  1.54 |     160 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 2          | NotCancelled     |     853.04 ns |  9.28 |     344 B | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 2          | NotCancelled     |   1,117.73 ns | 12.16 |    1488 B | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 2          | NotCancelled     |      89.91 ns |  0.96 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 2          | NotCancelled     |      91.04 ns |  0.97 |         - | 
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 2          | NotCancelled     |      91.89 ns |  0.98 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 2          | NotCancelled     |      93.81 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 2          | NotCancelled     |      95.38 ns |  1.02 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 2          | NotCancelled     |     129.08 ns |  1.38 |     160 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 2          | NotCancelled     |     803.51 ns |  8.57 |     344 B | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 2          | NotCancelled     |   1,185.20 ns | 12.64 |    1488 B | 
 |                                                                |            |                  |               |       |           | 
-| WaitThenSet · AsyncManualReset · RefImpl                       | 10         | None             |      64.88 ns |  0.20 |      96 B | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 10         | None             |     133.61 ns |  0.40 |      96 B | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 10         | None             |     212.81 ns |  0.64 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 10         | None             |     298.39 ns |  0.90 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 10         | None             |     299.78 ns |  0.91 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 10         | None             |     330.73 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 10         | None             |     334.91 ns |  1.01 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 10         | None             |     467.12 ns |  1.41 |     800 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 10         | None             |   1,994.96 ns |  6.03 |    1239 B | 
+| WaitThenSet · AsyncManualReset · RefImpl                       | 10         | None             |      64.93 ns |  0.20 |      96 B | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 10         | None             |     110.41 ns |  0.34 |      96 B | 
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 10         | None             |     214.27 ns |  0.66 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 10         | None             |     298.82 ns |  0.92 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 10         | None             |     300.43 ns |  0.93 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 10         | None             |     324.51 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 10         | None             |     325.91 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 10         | None             |     453.70 ns |  1.40 |     800 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 10         | None             |   1,971.93 ns |  6.08 |    1239 B | 
 |                                                                |            |                  |               |       |           | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 10         | NotCancelled     |     442.95 ns |  0.68 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 10         | NotCancelled     |     498.04 ns |  0.77 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 10         | NotCancelled     |     498.55 ns |  0.77 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 10         | NotCancelled     |     506.37 ns |  0.78 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 10         | NotCancelled     |     650.51 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 10         | NotCancelled     |     737.49 ns |  1.13 |     800 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 10         | NotCancelled     |   2,788.17 ns |  4.29 |    1240 B | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 10         | NotCancelled     |   3,291.43 ns |  5.06 |    6464 B | 
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 10         | NotCancelled     |     454.68 ns |  0.88 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 10         | NotCancelled     |     482.97 ns |  0.94 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 10         | NotCancelled     |     497.87 ns |  0.97 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 10         | NotCancelled     |     515.24 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 10         | NotCancelled     |     531.65 ns |  1.03 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 10         | NotCancelled     |     737.97 ns |  1.43 |     800 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 10         | NotCancelled     |   3,031.89 ns |  5.88 |    1240 B | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 10         | NotCancelled     |   4,436.31 ns |  8.61 |    6464 B | 
 |                                                                |            |                  |               |       |           | 
-| WaitThenSet · AsyncManualReset · RefImpl                       | 100        | None             |     546.51 ns |  0.17 |      96 B | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 100        | None             |   1,161.72 ns |  0.36 |      96 B | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 100        | None             |   2,135.10 ns |  0.67 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 100        | None             |   2,857.22 ns |  0.90 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 100        | None             |   2,864.68 ns |  0.90 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 100        | None             |   3,190.88 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 100        | None             |   3,237.04 ns |  1.01 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 100        | None             |   4,664.25 ns |  1.46 |    8000 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 100        | None             |  16,745.68 ns |  5.25 |   11320 B | 
+| WaitThenSet · AsyncManualReset · RefImpl                       | 100        | None             |     533.53 ns |  0.15 |      96 B | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 100        | None             |     928.28 ns |  0.27 |      96 B | 
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 100        | None             |   2,275.95 ns |  0.65 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 100        | None             |   2,857.04 ns |  0.82 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 100        | None             |   2,901.30 ns |  0.83 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 100        | None             |   3,161.49 ns |  0.91 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 100        | None             |   3,482.75 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 100        | None             |   4,674.61 ns |  1.34 |    8000 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 100        | None             |  15,704.57 ns |  4.51 |   11320 B | 
 |                                                                |            |                  |               |       |           | 
-| WaitThenSet · AsyncManualReset · ProtoPromise                  | 100        | NotCancelled     |   4,202.12 ns |  0.84 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 100        | NotCancelled     |   4,887.02 ns |  0.97 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 100        | NotCancelled     |   4,908.90 ns |  0.98 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 100        | NotCancelled     |   5,028.86 ns |  1.00 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 100        | NotCancelled     |   5,065.07 ns |  1.01 |         - | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 100        | NotCancelled     |   7,197.61 ns |  1.43 |    8000 B | 
-| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 100        | NotCancelled     | 128,081.54 ns | 25.47 |   61618 B | 
-| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 100        | NotCancelled     | 220,155.60 ns | 43.78 |   11322 B |
+| WaitThenSet · AsyncManualReset · ProtoPromise                  | 100        | NotCancelled     |   4,415.36 ns |  0.88 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask SyncCont) | 100        | NotCancelled     |   4,908.97 ns |  0.98 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (SyncCont)             | 100        | NotCancelled     |   4,971.60 ns |  0.99 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsValueTask)          | 100        | NotCancelled     |   4,996.67 ns |  0.99 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (ValueTask)            | 100        | NotCancelled     |   5,026.19 ns |  1.00 |         - | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask SyncCont)      | 100        | NotCancelled     |   7,174.00 ns |  1.43 |    8000 B | 
+| WaitThenSet · AsyncManualReset · Nito.AsyncEx                  | 100        | NotCancelled     | 115,582.83 ns | 23.00 |   61617 B | 
+| WaitThenSet · AsyncManualReset · Pooled (AsTask)               | 100        | NotCancelled     | 263,666.83 ns | 52.46 |   11327 B |

--- a/docfx/packages/threading/benchmarks/asyncreaderwriterlock-reader.md
+++ b/docfx/packages/threading/benchmarks/asyncreaderwriterlock-reader.md
@@ -1,49 +1,49 @@
 ﻿| Description                               | Iterations | cancellationType | Mean          | Ratio | Allocated | 
 |------------------------------------------ |----------- |----------------- |--------------:|------:|----------:|
-| ReaderLock · RWLockSlim · System          | 0          | None             |      6.800 ns |  0.40 |         - | 
-| ReaderLock · AsyncRWLock · Pooled         | 0          | None             |     16.867 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 0          | None             |     18.174 ns |  1.08 |         - | 
-| ReaderLock · AsyncRWLock · RefImpl        | 0          | None             |     19.318 ns |  1.15 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 0          | None             |     40.387 ns |  2.39 |     320 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 0          | None             |    225.585 ns | 13.37 |     208 B | 
+| ReaderLock · RWLockSlim · System          | 0          | None             |      6.774 ns |  0.40 |         - | 
+| ReaderLock · AsyncRWLock · Pooled         | 0          | None             |     17.075 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · Proto.Promises | 0          | None             |     18.400 ns |  1.08 |         - | 
+| ReaderLock · AsyncRWLock · RefImpl        | 0          | None             |     18.917 ns |  1.11 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 0          | None             |     40.428 ns |  2.37 |     320 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 0          | None             |    224.937 ns | 13.17 |     208 B | 
 |                                           |            |                  |               |       |           | 
-| ReaderLock · AsyncRWLock · Pooled         | 0          | NotCancelled     |     16.988 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 0          | NotCancelled     |     18.014 ns |  1.06 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 0          | NotCancelled     |     40.282 ns |  2.37 |     320 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 0          | NotCancelled     |    226.048 ns | 13.31 |     208 B | 
+| ReaderLock · AsyncRWLock · Pooled         | 0          | NotCancelled     |     16.943 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · Proto.Promises | 0          | NotCancelled     |     18.193 ns |  1.07 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 0          | NotCancelled     |     39.961 ns |  2.36 |     320 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 0          | NotCancelled     |    224.973 ns | 13.28 |     208 B | 
 |                                           |            |                  |               |       |           | 
-| ReaderLock · RWLockSlim · System          | 1          | None             |     12.387 ns |  0.36 |         - | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 1          | None             |     29.325 ns |  0.86 |         - | 
-| ReaderLock · AsyncRWLock · RefImpl        | 1          | None             |     33.699 ns |  0.99 |         - | 
-| ReaderLock · AsyncRWLock · Pooled         | 1          | None             |     34.127 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 1          | None             |     84.006 ns |  2.46 |     640 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 1          | None             |    522.893 ns | 15.32 |     416 B | 
+| ReaderLock · RWLockSlim · System          | 1          | None             |     12.461 ns |  0.36 |         - | 
+| ReaderLock · AsyncRWLock · Proto.Promises | 1          | None             |     28.467 ns |  0.82 |         - | 
+| ReaderLock · AsyncRWLock · Pooled         | 1          | None             |     34.709 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · RefImpl        | 1          | None             |     34.977 ns |  1.01 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 1          | None             |     84.985 ns |  2.45 |     640 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 1          | None             |    518.755 ns | 14.95 |     416 B | 
 |                                           |            |                  |               |       |           | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 1          | NotCancelled     |     28.669 ns |  0.82 |         - | 
-| ReaderLock · AsyncRWLock · Pooled         | 1          | NotCancelled     |     34.782 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 1          | NotCancelled     |     86.581 ns |  2.49 |     640 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 1          | NotCancelled     |    532.275 ns | 15.30 |     416 B | 
+| ReaderLock · AsyncRWLock · Proto.Promises | 1          | NotCancelled     |     28.772 ns |  0.84 |         - | 
+| ReaderLock · AsyncRWLock · Pooled         | 1          | NotCancelled     |     34.054 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 1          | NotCancelled     |     81.086 ns |  2.38 |     640 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 1          | NotCancelled     |    518.476 ns | 15.23 |     416 B | 
 |                                           |            |                  |               |       |           | 
-| ReaderLock · RWLockSlim · System          | 10         | None             |     61.879 ns |  0.32 |         - | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 10         | None             |    141.070 ns |  0.72 |         - | 
-| ReaderLock · AsyncRWLock · RefImpl        | 10         | None             |    142.681 ns |  0.73 |         - | 
-| ReaderLock · AsyncRWLock · Pooled         | 10         | None             |    195.850 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 10         | None             |    460.532 ns |  2.35 |    3520 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 10         | None             |  3,685.355 ns | 18.82 |    2288 B | 
+| ReaderLock · RWLockSlim · System          | 10         | None             |     61.761 ns |  0.31 |         - | 
+| ReaderLock · AsyncRWLock · Proto.Promises | 10         | None             |    142.806 ns |  0.72 |         - | 
+| ReaderLock · AsyncRWLock · RefImpl        | 10         | None             |    144.870 ns |  0.74 |         - | 
+| ReaderLock · AsyncRWLock · Pooled         | 10         | None             |    197.022 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 10         | None             |    481.419 ns |  2.44 |    3520 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 10         | None             |  3,703.521 ns | 18.80 |    2288 B | 
 |                                           |            |                  |               |       |           | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 10         | NotCancelled     |    145.449 ns |  0.74 |         - | 
-| ReaderLock · AsyncRWLock · Pooled         | 10         | NotCancelled     |    195.787 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 10         | NotCancelled     |    454.584 ns |  2.32 |    3520 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 10         | NotCancelled     |  3,659.978 ns | 18.69 |    2288 B | 
+| ReaderLock · AsyncRWLock · Proto.Promises | 10         | NotCancelled     |    147.119 ns |  0.74 |         - | 
+| ReaderLock · AsyncRWLock · Pooled         | 10         | NotCancelled     |    197.696 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 10         | NotCancelled     |    473.137 ns |  2.39 |    3520 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 10         | NotCancelled     |  3,614.872 ns | 18.29 |    2288 B | 
 |                                           |            |                  |               |       |           | 
-| ReaderLock · RWLockSlim · System          | 100        | None             |    560.227 ns |  0.33 |         - | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 100        | None             |  1,224.584 ns |  0.72 |         - | 
-| ReaderLock · AsyncRWLock · RefImpl        | 100        | None             |  1,248.803 ns |  0.73 |         - | 
-| ReaderLock · AsyncRWLock · Pooled         | 100        | None             |  1,699.640 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 100        | None             |  4,373.784 ns |  2.57 |   32320 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 100        | None             | 87,165.879 ns | 51.29 |   21008 B | 
+| ReaderLock · RWLockSlim · System          | 100        | None             |    559.414 ns |  0.33 |         - | 
+| ReaderLock · AsyncRWLock · RefImpl        | 100        | None             |  1,220.891 ns |  0.72 |         - | 
+| ReaderLock · AsyncRWLock · Proto.Promises | 100        | None             |  1,236.741 ns |  0.73 |         - | 
+| ReaderLock · AsyncRWLock · Pooled         | 100        | None             |  1,700.744 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 100        | None             |  4,495.417 ns |  2.64 |   32320 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 100        | None             | 87,591.125 ns | 51.50 |   21008 B | 
 |                                           |            |                  |               |       |           | 
-| ReaderLock · AsyncRWLock · Proto.Promises | 100        | NotCancelled     |  1,249.120 ns |  0.74 |         - | 
-| ReaderLock · AsyncRWLock · Pooled         | 100        | NotCancelled     |  1,698.662 ns |  1.00 |         - | 
-| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 100        | NotCancelled     |  4,366.415 ns |  2.57 |   32320 B | 
-| ReaderLock · AsyncRWLock · VS.Threading   | 100        | NotCancelled     | 86,288.797 ns | 50.80 |   21008 B |
+| ReaderLock · AsyncRWLock · Proto.Promises | 100        | NotCancelled     |  1,256.133 ns |  0.74 |         - | 
+| ReaderLock · AsyncRWLock · Pooled         | 100        | NotCancelled     |  1,698.319 ns |  1.00 |         - | 
+| ReaderLock · AsyncRWLock · Nito.AsyncEx   | 100        | NotCancelled     |  4,403.054 ns |  2.59 |   32320 B | 
+| ReaderLock · AsyncRWLock · VS.Threading   | 100        | NotCancelled     | 86,857.592 ns | 51.14 |   21008 B |

--- a/docfx/packages/threading/benchmarks/asyncreaderwriterlock-upgradeablereader.md
+++ b/docfx/packages/threading/benchmarks/asyncreaderwriterlock-upgradeablereader.md
@@ -1,40 +1,37 @@
 ﻿| Description                                          | Iterations | cancellationType | Mean         | Ratio | Allocated | 
 |----------------------------------------------------- |----------- |----------------- |-------------:|------:|----------:|
-| UpgradeableReaderLock · RWLockSlim · System          | 0          | None             |     6.720 ns |  0.41 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 0          | None             |    16.237 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 0          | None             |    18.677 ns |  1.15 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 0          | None             | 1,114.737 ns | 68.65 |     616 B | 
+| UpgradeableReaderLock · RWLockSlim · System          | 0          | None             |     6.855 ns |  0.43 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 0          | None             |    15.959 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 0          | None             |    20.142 ns |  1.26 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 0          | None             | 1,096.171 ns | 68.69 |     616 B | 
 |                                                      |            |                  |              |       |           | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 0          | NotCancelled     |    16.364 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 0          | NotCancelled     |    17.959 ns |  1.10 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 0          | NotCancelled     | 1,126.715 ns | 68.85 |     616 B | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 0          | NotCancelled     |    16.321 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 0          | NotCancelled     |    18.987 ns |  1.16 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 0          | NotCancelled     | 1,127.899 ns | 69.11 |     616 B | 
 |                                                      |            |                  |              |       |           | 
-| UpgradeableReaderLock · RWLockSlim · System          | 1          | None             |     6.710 ns |  0.37 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 1          | None             |    17.597 ns |  0.96 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 1          | None             |    18.245 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 1          | None             | 1,111.874 ns | 60.94 |     616 B | 
+| UpgradeableReaderLock · RWLockSlim · System          | 1          | None             |     6.745 ns |  0.37 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 1          | None             |    18.139 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 1          | None             |    19.333 ns |  1.07 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 1          | None             | 1,089.110 ns | 60.04 |     616 B | 
 |                                                      |            |                  |              |       |           | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 1          | NotCancelled     |    17.597 ns |  0.96 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 1          | NotCancelled     |    18.317 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 1          | NotCancelled     | 1,159.959 ns | 63.33 |     616 B | 
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 1          | NotCancelled     |    17.789 ns |  0.90 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 1          | NotCancelled     |    19.749 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 1          | NotCancelled     | 1,138.793 ns | 57.77 |     616 B | 
 |                                                      |            |                  |              |       |           | 
-| UpgradeableReaderLock · RWLockSlim · System          | 2          | None             |     6.764 ns |  0.37 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 2          | None             |    18.080 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 2          | None             |    18.644 ns |  1.03 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 2          | None             | 1,076.556 ns | 59.55 |     616 B | 
+| UpgradeableReaderLock · RWLockSlim · System          | 2          | None             |     6.822 ns |  0.37 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 2          | None             |    17.518 ns |  0.96 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 2          | None             |    18.268 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 2          | None             | 1,082.163 ns | 59.24 |     616 B | 
 |                                                      |            |                  |              |       |           | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 2          | NotCancelled     |    17.586 ns |  0.96 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 2          | NotCancelled     |    18.241 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 2          | NotCancelled     | 1,168.589 ns | 64.07 |     616 B | 
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 2          | NotCancelled     |    17.317 ns |  0.93 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 2          | NotCancelled     |    18.599 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 2          | NotCancelled     | 1,124.084 ns | 60.44 |     616 B | 
 |                                                      |            |                  |              |       |           | 
-| UpgradeableReaderLock · RWLockSlim · System          | 5          | None             |           NA |     ? |        NA | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 5          | None             |    52.123 ns |  0.77 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 5          | None             |    67.764 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 5          | None             | 2,495.261 ns | 36.82 |    1240 B | 
+| UpgradeableReaderLock · RWLockSlim · System          | 5          | None             |    24.061 ns |  0.35 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 5          | None             |    54.872 ns |  0.80 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 5          | None             |    68.248 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 5          | None             | 2,631.592 ns | 38.56 |    1240 B | 
 |                                                      |            |                  |              |       |           | 
-| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 5          | NotCancelled     |    54.339 ns |  0.79 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · Pooled         | 5          | NotCancelled     |    68.793 ns |  1.00 |         - | 
-| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 5          | NotCancelled     | 2,606.119 ns | 37.88 |    1240 B | 
-
-Benchmarks with issues:
-  AsyncReaderWriterLockUpgradeableReaderBenchmark.ReadLockReaderWriterLockSlim: .NET 10.0(Runtime=.NET 10.0, Toolchain=net10.0) [Iterations=5, cancellationType=None]
+| UpgradeableReaderLock · AsyncRWLock · Proto.Promises | 5          | NotCancelled     |    53.997 ns |  0.80 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · Pooled         | 5          | NotCancelled     |    67.902 ns |  1.00 |         - | 
+| UpgradeableReaderLock · AsyncRWLock · VS.Threading   | 5          | NotCancelled     | 2,693.549 ns | 39.67 |    1240 B |

--- a/docfx/packages/threading/benchmarks/asyncreaderwriterlock-upgradedwriter.md
+++ b/docfx/packages/threading/benchmarks/asyncreaderwriterlock-upgradedwriter.md
@@ -1,37 +1,37 @@
 ﻿| Description                                       | Iterations | cancellationType | Mean        | Ratio | Allocated | 
 |-------------------------------------------------- |----------- |----------------- |------------:|------:|----------:|
 | UpgradedWriterLock · RWLockSlim · System          | 0          | None             |    13.46 ns |  0.60 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 0          | None             |    22.39 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 0          | None             |    23.22 ns |  1.04 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 0          | None             | 1,752.55 ns | 78.28 |     824 B | 
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 0          | None             |    21.66 ns |  0.97 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 0          | None             |    22.44 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 0          | None             | 1,823.37 ns | 81.24 |     824 B | 
 |                                                   |            |                  |             |       |           | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 0          | NotCancelled     |    22.58 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 0          | NotCancelled     |    24.85 ns |  1.10 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 0          | NotCancelled     | 1,853.92 ns | 82.11 |     824 B | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 0          | NotCancelled     |    22.76 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 0          | NotCancelled     |    24.61 ns |  1.08 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 0          | NotCancelled     | 1,910.35 ns | 83.95 |     824 B | 
 |                                                   |            |                  |             |       |           | 
-| UpgradedWriterLock · RWLockSlim · System          | 1          | None             |    20.14 ns |  0.42 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 1          | None             |    43.41 ns |  0.91 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 1          | None             |    47.75 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 1          | None             | 2,243.33 ns | 46.99 |    1032 B | 
+| UpgradedWriterLock · RWLockSlim · System          | 1          | None             |    20.15 ns |  0.41 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 1          | None             |    43.06 ns |  0.87 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 1          | None             |    49.25 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 1          | None             | 2,325.23 ns | 47.21 |    1032 B | 
 |                                                   |            |                  |             |       |           | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 1          | NotCancelled     |    61.09 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 1          | NotCancelled     |    69.98 ns |  1.15 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 1          | NotCancelled     | 2,365.77 ns | 38.73 |    1032 B | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 1          | NotCancelled     |    60.90 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 1          | NotCancelled     |    70.48 ns |  1.16 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 1          | NotCancelled     | 2,406.80 ns | 39.52 |    1032 B | 
 |                                                   |            |                  |             |       |           | 
-| UpgradedWriterLock · RWLockSlim · System          | 2          | None             |    25.64 ns |  0.41 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 2          | None             |    53.39 ns |  0.84 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 2          | None             |    63.32 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 2          | None             | 2,764.66 ns | 43.66 |    1240 B | 
+| UpgradedWriterLock · RWLockSlim · System          | 2          | None             |    25.36 ns |  0.37 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 2          | None             |    54.15 ns |  0.80 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 2          | None             |    68.01 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 2          | None             | 2,823.31 ns | 41.56 |    1240 B | 
 |                                                   |            |                  |             |       |           | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 2          | NotCancelled     |    76.78 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 2          | NotCancelled     |    80.58 ns |  1.05 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 2          | NotCancelled     | 2,838.88 ns | 36.97 |    1240 B | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 2          | NotCancelled     |    76.14 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 2          | NotCancelled     |    86.37 ns |  1.13 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 2          | NotCancelled     | 2,948.51 ns | 38.73 |    1240 B | 
 |                                                   |            |                  |             |       |           | 
-| UpgradedWriterLock · RWLockSlim · System          | 5          | None             |    41.79 ns |  0.34 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 5          | None             |    92.84 ns |  0.75 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 5          | None             |   124.00 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 5          | None             | 4,526.63 ns | 36.50 |    1864 B | 
+| UpgradedWriterLock · RWLockSlim · System          | 5          | None             |    41.38 ns |  0.33 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 5          | None             |    92.94 ns |  0.75 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 5          | None             |   123.96 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 5          | None             | 4,468.96 ns | 36.05 |    1864 B | 
 |                                                   |            |                  |             |       |           | 
-| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 5          | NotCancelled     |   116.05 ns |  0.89 |         - | 
-| UpgradedWriterLock · AsyncRWLock · Pooled         | 5          | NotCancelled     |   130.90 ns |  1.00 |         - | 
-| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 5          | NotCancelled     | 4,501.15 ns | 34.39 |    1864 B |
+| UpgradedWriterLock · AsyncRWLock · Proto.Promises | 5          | NotCancelled     |   116.85 ns |  0.90 |         - | 
+| UpgradedWriterLock · AsyncRWLock · Pooled         | 5          | NotCancelled     |   130.50 ns |  1.00 |         - | 
+| UpgradedWriterLock · AsyncRWLock · VS.Threading   | 5          | NotCancelled     | 4,578.74 ns | 35.09 |    1864 B |

--- a/docfx/packages/threading/benchmarks/asyncreaderwriterlock-writer.md
+++ b/docfx/packages/threading/benchmarks/asyncreaderwriterlock-writer.md
@@ -1,8 +1,8 @@
-﻿| Description                              | Mean         | Ratio  | Allocated | 
-|----------------------------------------- |-------------:|-------:|----------:|
-| WriterLock · RWLockSlim · System         |     6.947 ns |   0.68 |         - | 
-| WriterLock · AsyncRWLock · ProtoPromises |     8.378 ns |   0.82 |         - | 
-| WriterLock · AsyncRWLock · Pooled        |    10.164 ns |   1.00 |         - | 
-| WriterLock · AsyncRWLock · RefImpl       |    19.056 ns |   1.87 |         - | 
-| WriterLock · AsyncRWLock · Nito.AsyncEx  |    53.690 ns |   5.28 |     496 B | 
-| WriterLock · AsyncRWLock · VS.Threading  | 1,103.223 ns | 108.54 |     584 B |
+﻿| Description                               | Mean         | Ratio | Allocated | 
+|------------------------------------------ |-------------:|------:|----------:|
+| WriterLock · RWLockSlim · System          |     6.905 ns |  0.66 |         - | 
+| WriterLock · AsyncRWLock · Proto.Promises |     8.379 ns |  0.80 |         - | 
+| WriterLock · AsyncRWLock · Pooled         |    10.460 ns |  1.00 |         - | 
+| WriterLock · AsyncRWLock · RefImpl        |    18.797 ns |  1.80 |         - | 
+| WriterLock · AsyncRWLock · Nito.AsyncEx   |    54.581 ns |  5.22 |     496 B | 
+| WriterLock · AsyncRWLock · VS.Threading   | 1,027.868 ns | 98.27 |     584 B |

--- a/docfx/packages/threading/benchmarks/asyncsemaphore-single.md
+++ b/docfx/packages/threading/benchmarks/asyncsemaphore-single.md
@@ -1,7 +1,7 @@
 ﻿| Description                                 | Mean      | Ratio | Allocated | 
 |-------------------------------------------- |----------:|------:|----------:|
-| WaitRelease · AsyncSemaphore · ProtoPromise |  6.407 ns |  0.71 |         - | 
-| WaitRelease · AsyncSemaphore · Pooled       |  9.047 ns |  1.00 |         - | 
-| WaitRelease · AsyncSemaphore · Nito.AsyncEx | 15.286 ns |  1.69 |         - | 
-| WaitRelease · SemaphoreSlim · System        | 16.991 ns |  1.88 |         - | 
-| WaitRelease · AsyncSemaphore · RefImpl      | 18.945 ns |  2.09 |         - |
+| WaitRelease · AsyncSemaphore · ProtoPromise |  6.506 ns |  0.71 |         - | 
+| WaitRelease · AsyncSemaphore · Pooled       |  9.162 ns |  1.00 |         - | 
+| WaitRelease · AsyncSemaphore · Nito.AsyncEx | 14.745 ns |  1.61 |         - | 
+| WaitRelease · SemaphoreSlim · System        | 16.958 ns |  1.85 |         - | 
+| WaitRelease · AsyncSemaphore · RefImpl      | 18.116 ns |  1.98 |         - |

--- a/scripts/update-benchmark-docs.ps1
+++ b/scripts/update-benchmark-docs.ps1
@@ -1,4 +1,4 @@
-﻿# SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+# SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 # SPDX-License-Identifier: MIT
 
 # update-benchmark-docs.ps1
@@ -46,7 +46,6 @@ $packageConfigurations = @{
             @{ Source = "AsyncReaderWriterLockUpgradeableReaderBenchmark-report.md"; Target = "asyncreaderwriterlock-upgradeablereader.md" }
             @{ Source = "AsyncReaderWriterLockUpgradedWriterBenchmark-report.md"; Target = "asyncreaderwriterlock-upgradedwriter.md" }
             @{ Source = "AsyncReaderWriterLockWriterBenchmark-report.md"; Target = "asyncreaderwriterlock-writer.md" }
-            @{ Source = "AsyncReaderWriterLockContentionBenchmark-report.md"; Target = "asyncreaderwriterlock-contention.md" }
         )
     }
 

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -267,7 +267,7 @@ public sealed class AsyncAutoResetEvent : IResettable
         {
             if (_waiters.Count == 0)
             {
-                _ = Interlocked.Exchange(ref _signaled, 1);
+                _signaled = 1;
                 return;
             }
 
@@ -291,7 +291,7 @@ public sealed class AsyncAutoResetEvent : IResettable
     /// </summary>
     internal void Reset()
     {
-        _ = Interlocked.Exchange(ref _signaled, 0);
+        _signaled = 0;
     }
 
     /// <summary>
@@ -306,7 +306,7 @@ public sealed class AsyncAutoResetEvent : IResettable
         {
             if (_waiters.Count == 0)
             {
-                _ = Interlocked.Exchange(ref _signaled, 1);
+                _signaled = 1;
                 return;
             }
 

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -8,6 +8,7 @@ namespace CryptoHives.Foundation.Threading.Async.Pooled;
 using CryptoHives.Foundation.Threading.Pools;
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
@@ -123,7 +124,19 @@ public sealed class AsyncCountdownEvent
     /// </remarks>
     /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when the countdown reaches zero.</returns>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask WaitAsync(CancellationToken cancellationToken = default)
+    {
+        if (Volatile.Read(ref _currentCount) == 0)
+        {
+            return default;
+        }
+
+        return WaitAsyncImpl(cancellationToken);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask WaitAsyncImpl(CancellationToken cancellationToken)
     {
         _spinLock.Enter();
         try

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -264,7 +264,7 @@ public sealed class AsyncLock : IResettable
         {
             if (_waiters.Count == 0)
             {
-                Interlocked.Exchange(ref _taken, 0);
+                _taken = 0;
                 return;
             }
 

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -191,19 +191,8 @@ public sealed class AsyncManualResetEvent : IResettable
     /// </remarks>
     /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask"/> that is used for the asynchronous wait operation.</returns>
-    [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask WaitAsync(CancellationToken cancellationToken = default)
-    {
-        if (_signaled)
-        {
-            return default;
-        }
-
-        return WaitAsyncImpl(cancellationToken);
-    }
-
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImpl(CancellationToken cancellationToken = default)
+    public ValueTask WaitAsync(CancellationToken cancellationToken = default)
     {
         _spinLock.Enter();
         try


### PR DESCRIPTION
This pull request focuses on performance and code clarity improvements in the asynchronous threading primitives. The main changes involve replacing unnecessary atomic operations with simple assignments in several synchronization classes and optimizing the async wait path in `AsyncCountdownEvent`.

**Performance and code clarity improvements:**

*Atomic operation simplifications:*
- Replaced `Interlocked.Exchange` with direct field assignments for `_signaled` in `AsyncAutoResetEvent` methods `Set`, `Reset`, and `PulseAll`, as well as for `_taken` in `AsyncLock.ReleaseLock()`, to reduce overhead where atomicity is not needed. 


