### PR TITLE
Improve Blake2b/Blake2s perf

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="OpenGost.Security.Cryptography" Version="0.3.0" />
     <PackageVersion Include="ProtoPromise" Version="3.5.1" />
     <PackageVersion Include="SharpFuzz" Version="2.2.0" />
+    <PackageVersion Include="SauceControl.Blake2Fast" Version="2.0.0" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.6.37125.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
     <PackageVersion Include="NaCl.Core" Version="2.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      90.54 ns |     0.129 ns |     0.115 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     100.16 ns |     0.286 ns |     0.239 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.74 ns |     0.141 ns |     0.132 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     199.10 ns |     0.024 ns |     0.020 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     579.72 ns |     2.870 ns |     2.685 ns |    1120 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     168.18 ns |     0.296 ns |     0.277 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     191.67 ns |     0.612 ns |     0.573 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     232.10 ns |     0.171 ns |     0.160 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     396.95 ns |     0.057 ns |     0.054 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,081.79 ns |     7.000 ns |     6.547 ns |    1136 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     647.12 ns |     0.889 ns |     0.831 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     738.60 ns |     2.757 ns |     2.579 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     870.66 ns |     0.513 ns |     0.455 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,574.03 ns |     0.538 ns |     0.449 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,733.44 ns |    12.863 ns |    12.032 ns |    2016 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     732.90 ns |     0.242 ns |     0.202 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |     834.94 ns |     2.764 ns |     2.585 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     974.82 ns |     0.973 ns |     0.760 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,776.75 ns |     3.835 ns |     3.587 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,562.50 ns |    77.601 ns |    60.586 ns |    2024 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,153.23 ns |     7.491 ns |     7.007 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   5,902.34 ns |    18.288 ns |    16.212 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,798.92 ns |     5.093 ns |     4.764 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  12,553.19 ns |     1.524 ns |     1.351 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,089.84 ns |    80.900 ns |    67.556 ns |    9184 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,453.09 ns |    64.655 ns |    60.479 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        |  94,219.24 ns |   248.982 ns |   232.898 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,461.29 ns |    43.033 ns |    40.253 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 200,854.82 ns |    27.419 ns |    24.306 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 470,320.69 ns | 1,518.969 ns | 1,420.844 ns |  132092 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev     | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-----------:|----------:|
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      90.90 ns |     0.207 ns |   0.184 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     101.73 ns |     0.541 ns |   0.452 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.74 ns |     0.372 ns |   0.291 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     179.82 ns |     0.212 ns |   0.165 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     591.61 ns |     3.247 ns |   3.037 ns |    1120 B |
+|                                                         |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     168.83 ns |     0.273 ns |   0.255 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     194.41 ns |     0.373 ns |   0.349 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     232.50 ns |     0.315 ns |   0.279 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     367.16 ns |     5.079 ns |   4.751 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,096.63 ns |     5.112 ns |   4.781 ns |    1136 B |
+|                                                         |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     652.19 ns |     0.451 ns |   0.422 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     748.17 ns |     3.101 ns |   2.901 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     870.96 ns |     0.438 ns |   0.365 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,495.02 ns |    28.773 ns |  28.259 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,806.08 ns |    14.258 ns |  11.906 ns |    2016 B |
+|                                                         |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     733.72 ns |     0.350 ns |   0.327 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |     840.34 ns |     1.190 ns |   1.055 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     978.66 ns |     4.261 ns |   3.327 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,646.28 ns |     0.190 ns |   0.168 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,326.51 ns |    25.883 ns |  22.945 ns |    2024 B |
+|                                                         |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,157.42 ns |     2.080 ns |   1.946 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   5,906.62 ns |    10.009 ns |   8.873 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,801.51 ns |     3.021 ns |   2.678 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  11,730.70 ns |     1.449 ns |   1.210 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,176.01 ns |    82.221 ns |  76.910 ns |    9184 B |
+|                                                         |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,468.86 ns |    43.385 ns |  40.582 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        |  94,453.34 ns |   186.377 ns | 174.337 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,483.67 ns |    35.816 ns |  31.750 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 187,789.85 ns |    19.117 ns |  15.963 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 472,230.04 ns | 1,100.842 ns | 975.867 ns |  132092 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
@@ -1,37 +1,31 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      90.96 ns |     0.143 ns |     0.127 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     100.12 ns |     0.206 ns |     0.183 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.66 ns |     0.199 ns |     0.166 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     179.52 ns |     0.150 ns |     0.133 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     588.01 ns |     2.687 ns |     2.382 ns |    1120 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     169.56 ns |     0.185 ns |     0.164 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     189.56 ns |     0.536 ns |     0.447 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     232.34 ns |     0.183 ns |     0.162 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     363.24 ns |     0.357 ns |     0.316 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,093.35 ns |     4.095 ns |     3.831 ns |    1136 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     658.28 ns |     9.849 ns |     8.731 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     734.46 ns |     2.547 ns |     2.258 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     871.98 ns |     0.738 ns |     0.616 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,463.59 ns |     0.947 ns |     0.840 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,808.96 ns |    25.041 ns |    22.198 ns |    2016 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     735.37 ns |     2.306 ns |     2.044 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |     833.66 ns |     1.851 ns |     1.545 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     976.85 ns |     0.923 ns |     0.770 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,649.24 ns |     2.762 ns |     2.156 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,319.33 ns |    37.199 ns |    31.063 ns |    2024 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,156.92 ns |     3.900 ns |     3.458 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   5,904.21 ns |    33.923 ns |    30.072 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,816.14 ns |    18.407 ns |    14.371 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  11,755.03 ns |    42.104 ns |    32.872 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,391.40 ns |    81.526 ns |    76.259 ns |    9184 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,852.38 ns | 1,010.721 ns |   843.998 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        |  93,993.86 ns |   192.576 ns |   170.713 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,499.08 ns |    63.177 ns |    52.756 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 187,858.44 ns |   111.401 ns |    93.025 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 474,934.19 ns | 1,809.229 ns | 1,412.527 ns |  132092 B |
+﻿| Description                                             | TestDataSize | Mean          | Error      | StdDev     | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-----------:|-----------:|----------:|
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      91.35 ns |   0.149 ns |   0.132 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     101.47 ns |   0.328 ns |   0.291 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     127.44 ns |   0.209 ns |   0.196 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     606.90 ns |   1.204 ns |   1.067 ns |    1120 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     170.83 ns |   0.185 ns |   0.144 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     191.93 ns |   0.236 ns |   0.221 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     233.62 ns |   0.295 ns |   0.276 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,127.90 ns |   2.557 ns |   2.392 ns |    1136 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     654.86 ns |   0.264 ns |   0.220 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     749.41 ns |   5.204 ns |   4.345 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     876.42 ns |   2.203 ns |   1.720 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,898.12 ns |   6.467 ns |   5.733 ns |    2016 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     736.09 ns |   1.758 ns |   1.372 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |     841.12 ns |   1.345 ns |   1.123 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     981.16 ns |   2.586 ns |   2.292 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,434.21 ns |  10.701 ns |   9.486 ns |    2024 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,184.93 ns |   2.994 ns |   2.337 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   5,933.50 ns |   2.825 ns |   2.359 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,834.26 ns |   3.791 ns |   2.960 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  30,126.48 ns |  65.990 ns |  51.520 ns |    9184 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  83,035.25 ns |  50.312 ns |  39.280 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        |  94,969.22 ns |  70.839 ns |  59.154 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 109,170.07 ns |  84.487 ns |  74.896 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 486,165.40 ns | 776.979 ns | 688.772 ns |  132092 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |     103.0 ns |     1.16 ns |     0.97 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.8 ns |     0.28 ns |     0.23 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     199.6 ns |     0.86 ns |     0.76 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     392.1 ns |     5.81 ns |     4.85 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     593.0 ns |     3.02 ns |     2.67 ns |    1120 B |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     181.9 ns |     0.40 ns |     0.31 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     235.7 ns |     4.70 ns |     4.83 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     397.6 ns |     0.38 ns |     0.29 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     782.1 ns |     5.77 ns |     4.50 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,109.6 ns |     5.79 ns |     4.84 ns |    1136 B |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     667.5 ns |     6.27 ns |     5.56 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     876.0 ns |     8.01 ns |     7.10 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,588.9 ns |    19.28 ns |    16.10 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   3,163.7 ns |    41.05 ns |    38.40 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,836.7 ns |    25.79 ns |    22.87 ns |    2016 B |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     746.1 ns |     0.53 ns |     0.41 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     981.0 ns |     7.13 ns |     5.57 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,776.3 ns |     4.71 ns |     3.67 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   3,522.7 ns |     9.16 ns |     7.15 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,367.5 ns |    22.16 ns |    17.30 ns |    2024 B |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,180.7 ns |     1.47 ns |     1.23 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,824.1 ns |    22.94 ns |    17.91 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  12,594.0 ns |    40.08 ns |    35.53 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |  24,981.7 ns |    71.58 ns |    59.77 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,598.6 ns |    93.78 ns |    83.14 ns |    9184 B |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,728.5 ns |   143.32 ns |   111.89 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,753.0 ns |   392.36 ns |   306.33 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 201,168.1 ns |   245.54 ns |   217.67 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 399,233.6 ns | 1,129.07 ns |   942.83 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 481,868.6 ns | 2,136.43 ns | 1,784.01 ns |  132092 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      90.54 ns |     0.129 ns |     0.115 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     100.16 ns |     0.286 ns |     0.239 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.74 ns |     0.141 ns |     0.132 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     199.10 ns |     0.024 ns |     0.020 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     579.72 ns |     2.870 ns |     2.685 ns |    1120 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     168.18 ns |     0.296 ns |     0.277 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     191.67 ns |     0.612 ns |     0.573 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     232.10 ns |     0.171 ns |     0.160 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     396.95 ns |     0.057 ns |     0.054 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,081.79 ns |     7.000 ns |     6.547 ns |    1136 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     647.12 ns |     0.889 ns |     0.831 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     738.60 ns |     2.757 ns |     2.579 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     870.66 ns |     0.513 ns |     0.455 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,574.03 ns |     0.538 ns |     0.449 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,733.44 ns |    12.863 ns |    12.032 ns |    2016 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     732.90 ns |     0.242 ns |     0.202 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |     834.94 ns |     2.764 ns |     2.585 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     974.82 ns |     0.973 ns |     0.760 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,776.75 ns |     3.835 ns |     3.587 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,562.50 ns |    77.601 ns |    60.586 ns |    2024 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,153.23 ns |     7.491 ns |     7.007 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   5,902.34 ns |    18.288 ns |    16.212 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,798.92 ns |     5.093 ns |     4.764 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  12,553.19 ns |     1.524 ns |     1.351 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,089.84 ns |    80.900 ns |    67.556 ns |    9184 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,453.09 ns |    64.655 ns |    60.479 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        |  94,219.24 ns |   248.982 ns |   232.898 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,461.29 ns |    43.033 ns |    40.253 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 200,854.82 ns |    27.419 ns |    24.306 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 470,320.69 ns | 1,518.969 ns | 1,420.844 ns |  132092 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
@@ -1,31 +1,37 @@
-﻿| Description                                            | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128B         |     126.5 ns |     0.27 ns |     0.25 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)      | 128B         |     224.4 ns |     1.18 ns |     1.10 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128B         |     391.1 ns |     1.12 ns |     1.05 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128B         |     589.7 ns |     2.86 ns |     2.68 ns |    1120 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 137B         |     231.0 ns |     0.20 ns |     0.18 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)      | 137B         |     445.3 ns |     6.47 ns |     6.05 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 137B         |     775.3 ns |     2.18 ns |     2.04 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 137B         |   1,094.9 ns |     3.29 ns |     2.91 ns |    1136 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1KB          |     868.6 ns |     0.48 ns |     0.45 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)      | 1KB          |   1,763.2 ns |    26.09 ns |    24.41 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1KB          |   3,083.1 ns |    11.65 ns |    10.89 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1KB          |   3,765.2 ns |    11.00 ns |    10.29 ns |    2016 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1025B        |     974.5 ns |     0.86 ns |     0.76 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)      | 1025B        |   1,958.3 ns |    11.02 ns |     9.21 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1025B        |   3,467.7 ns |     8.47 ns |     7.51 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1025B        |   4,278.9 ns |    20.90 ns |    19.55 ns |    2024 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 8KB          |   6,794.7 ns |     3.31 ns |     3.10 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)      | 8KB          |  13,920.8 ns |    99.03 ns |    82.69 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 8KB          |  24,628.2 ns |    75.90 ns |    71.00 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 8KB          |  29,061.8 ns |    87.33 ns |    81.68 ns |    9184 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128KB        | 108,406.0 ns |    47.08 ns |    44.04 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)      | 128KB        | 222,025.7 ns | 1,153.38 ns | 1,078.87 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128KB        | 394,033.8 ns | 1,013.46 ns |   947.99 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128KB        | 470,733.4 ns | 1,239.01 ns | 1,158.97 ns |  132092 B |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |     103.0 ns |     1.16 ns |     0.97 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.8 ns |     0.28 ns |     0.23 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     199.6 ns |     0.86 ns |     0.76 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     392.1 ns |     5.81 ns |     4.85 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     593.0 ns |     3.02 ns |     2.67 ns |    1120 B |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     181.9 ns |     0.40 ns |     0.31 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     235.7 ns |     4.70 ns |     4.83 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     397.6 ns |     0.38 ns |     0.29 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     782.1 ns |     5.77 ns |     4.50 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,109.6 ns |     5.79 ns |     4.84 ns |    1136 B |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     667.5 ns |     6.27 ns |     5.56 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     876.0 ns |     8.01 ns |     7.10 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,588.9 ns |    19.28 ns |    16.10 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   3,163.7 ns |    41.05 ns |    38.40 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,836.7 ns |    25.79 ns |    22.87 ns |    2016 B |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     746.1 ns |     0.53 ns |     0.41 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     981.0 ns |     7.13 ns |     5.57 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,776.3 ns |     4.71 ns |     3.67 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   3,522.7 ns |     9.16 ns |     7.15 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,367.5 ns |    22.16 ns |    17.30 ns |    2024 B |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,180.7 ns |     1.47 ns |     1.23 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,824.1 ns |    22.94 ns |    17.91 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  12,594.0 ns |    40.08 ns |    35.53 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |  24,981.7 ns |    71.58 ns |    59.77 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,598.6 ns |    93.78 ns |    83.14 ns |    9184 B |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,728.5 ns |   143.32 ns |   111.89 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,753.0 ns |   392.36 ns |   306.33 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 201,168.1 ns |   245.54 ns |   217.67 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 399,233.6 ns | 1,129.07 ns |   942.83 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 481,868.6 ns | 2,136.43 ns | 1,784.01 ns |  132092 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev     | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-----------:|----------:|
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      90.90 ns |     0.207 ns |   0.184 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     101.73 ns |     0.541 ns |   0.452 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.74 ns |     0.372 ns |   0.291 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     179.82 ns |     0.212 ns |   0.165 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     591.61 ns |     3.247 ns |   3.037 ns |    1120 B |
-|                                                         |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     168.83 ns |     0.273 ns |   0.255 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     194.41 ns |     0.373 ns |   0.349 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     232.50 ns |     0.315 ns |   0.279 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     367.16 ns |     5.079 ns |   4.751 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,096.63 ns |     5.112 ns |   4.781 ns |    1136 B |
-|                                                         |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     652.19 ns |     0.451 ns |   0.422 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     748.17 ns |     3.101 ns |   2.901 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     870.96 ns |     0.438 ns |   0.365 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,495.02 ns |    28.773 ns |  28.259 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,806.08 ns |    14.258 ns |  11.906 ns |    2016 B |
-|                                                         |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     733.72 ns |     0.350 ns |   0.327 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |     840.34 ns |     1.190 ns |   1.055 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     978.66 ns |     4.261 ns |   3.327 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,646.28 ns |     0.190 ns |   0.168 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,326.51 ns |    25.883 ns |  22.945 ns |    2024 B |
-|                                                         |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,157.42 ns |     2.080 ns |   1.946 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   5,906.62 ns |    10.009 ns |   8.873 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,801.51 ns |     3.021 ns |   2.678 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  11,730.70 ns |     1.449 ns |   1.210 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,176.01 ns |    82.221 ns |  76.910 ns |    9184 B |
-|                                                         |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,468.86 ns |    43.385 ns |  40.582 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        |  94,453.34 ns |   186.377 ns | 174.337 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,483.67 ns |    35.816 ns |  31.750 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 187,789.85 ns |    19.117 ns |  15.963 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 472,230.04 ns | 1,100.842 ns | 975.867 ns |  132092 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      90.96 ns |     0.143 ns |     0.127 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     100.12 ns |     0.206 ns |     0.183 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     126.66 ns |     0.199 ns |     0.166 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128B         |     179.52 ns |     0.150 ns |     0.133 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     588.01 ns |     2.687 ns |     2.382 ns |    1120 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     169.56 ns |     0.185 ns |     0.164 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     189.56 ns |     0.536 ns |     0.447 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     232.34 ns |     0.183 ns |     0.162 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 137B         |     363.24 ns |     0.357 ns |     0.316 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |   1,093.35 ns |     4.095 ns |     3.831 ns |    1136 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     658.28 ns |     9.849 ns |     8.731 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     734.46 ns |     2.547 ns |     2.258 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     871.98 ns |     0.738 ns |     0.616 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1KB          |   1,463.59 ns |     0.947 ns |     0.840 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,808.96 ns |    25.041 ns |    22.198 ns |    2016 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     735.37 ns |     2.306 ns |     2.044 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |     833.66 ns |     1.851 ns |     1.545 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     976.85 ns |     0.923 ns |     0.770 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 1025B        |   1,649.24 ns |     2.762 ns |     2.156 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   4,319.33 ns |    37.199 ns |    31.063 ns |    2024 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,156.92 ns |     3.900 ns |     3.458 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   5,904.21 ns |    33.923 ns |    30.072 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   6,816.14 ns |    18.407 ns |    14.371 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 8KB          |  11,755.03 ns |    42.104 ns |    32.872 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  29,391.40 ns |    81.526 ns |    76.259 ns |    9184 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  82,852.38 ns | 1,010.721 ns |   843.998 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        |  93,993.86 ns |   192.576 ns |   170.713 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        | 108,499.08 ns |    63.177 ns |    52.756 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Neon)       | 128KB        | 187,858.44 ns |   111.401 ns |    93.025 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 474,934.19 ns | 1,809.229 ns | 1,412.527 ns |  132092 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
@@ -1,37 +1,31 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      91.48 ns |     0.191 ns |     0.179 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     101.82 ns |     0.076 ns |     0.067 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     129.09 ns |     0.150 ns |     0.133 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     179.22 ns |     0.123 ns |     0.115 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     616.22 ns |     2.484 ns |     2.324 ns |    1216 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     170.21 ns |     0.062 ns |     0.058 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     191.51 ns |     0.169 ns |     0.158 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     234.41 ns |     0.281 ns |     0.263 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     362.86 ns |     0.116 ns |     0.103 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,123.08 ns |     4.087 ns |     3.823 ns |    1232 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     654.40 ns |     2.305 ns |     1.925 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     742.13 ns |     1.204 ns |     1.068 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     891.03 ns |    17.315 ns |    21.264 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,462.84 ns |     0.409 ns |     0.341 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,853.15 ns |    24.987 ns |    23.373 ns |    2112 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     735.78 ns |     2.180 ns |     1.933 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |     838.34 ns |     2.775 ns |     2.596 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     978.95 ns |     2.290 ns |     1.788 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,652.49 ns |     6.967 ns |     6.517 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,366.24 ns |    36.792 ns |    34.416 ns |    2120 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,174.06 ns |    24.743 ns |    21.934 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   5,897.99 ns |    16.958 ns |    14.161 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,816.16 ns |    26.455 ns |    23.452 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  11,775.91 ns |    51.955 ns |    48.599 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  29,512.23 ns |   137.092 ns |   121.528 ns |    9280 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,640.41 ns |   296.972 ns |   263.258 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        |  94,529.65 ns |   368.296 ns |   344.504 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,886.45 ns |   522.295 ns |   488.555 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 188,210.73 ns |   578.133 ns |   540.786 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 477,473.47 ns | 1,482.936 ns | 1,238.319 ns |  132188 B |
+﻿| Description                                             | TestDataSize | Mean          | Error      | StdDev     | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-----------:|-----------:|----------:|
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      92.11 ns |   0.136 ns |   0.127 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     102.01 ns |   0.104 ns |   0.092 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     129.33 ns |   0.406 ns |   0.359 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     629.28 ns |   1.149 ns |   1.075 ns |    1216 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     171.80 ns |   0.199 ns |   0.186 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     192.53 ns |   0.172 ns |   0.161 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     235.89 ns |   0.302 ns |   0.267 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,146.74 ns |   1.403 ns |   1.312 ns |    1232 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     657.05 ns |   0.782 ns |   0.693 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     748.99 ns |   0.587 ns |   0.490 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     879.71 ns |   1.132 ns |   1.003 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,908.72 ns |  13.158 ns |  12.308 ns |    2112 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     739.53 ns |   1.339 ns |   1.187 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |     842.70 ns |   1.299 ns |   1.014 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     984.21 ns |   0.916 ns |   0.812 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,451.15 ns |   9.199 ns |   8.604 ns |    2120 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,197.21 ns |   3.975 ns |   3.718 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   5,948.49 ns |   6.674 ns |   5.917 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,848.70 ns |   4.591 ns |   4.070 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  30,223.19 ns |  40.514 ns |  37.897 ns |    9280 B |
+|                                                         |              |               |            |            |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  83,054.29 ns |  90.841 ns |  75.856 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        |  95,150.61 ns |  83.629 ns |  74.135 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 109,025.38 ns | 414.316 ns | 323.471 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 487,768.87 ns | 868.891 ns | 770.249 ns |  132188 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
@@ -1,37 +1,37 @@
 ﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
 |-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      91.64 ns |     0.135 ns |     0.126 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     103.10 ns |     0.110 ns |     0.103 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     128.97 ns |     0.170 ns |     0.159 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     179.50 ns |     0.042 ns |     0.038 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     612.22 ns |     2.841 ns |     2.657 ns |    1216 B |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      91.48 ns |     0.191 ns |     0.179 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     101.82 ns |     0.076 ns |     0.067 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     129.09 ns |     0.150 ns |     0.133 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     179.22 ns |     0.123 ns |     0.115 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     616.22 ns |     2.484 ns |     2.324 ns |    1216 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     170.14 ns |     0.046 ns |     0.043 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     196.01 ns |     0.199 ns |     0.186 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     234.62 ns |     0.173 ns |     0.162 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     363.20 ns |     0.054 ns |     0.045 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,128.63 ns |     5.540 ns |     5.182 ns |    1232 B |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     170.21 ns |     0.062 ns |     0.058 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     191.51 ns |     0.169 ns |     0.158 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     234.41 ns |     0.281 ns |     0.263 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     362.86 ns |     0.116 ns |     0.103 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,123.08 ns |     4.087 ns |     3.823 ns |    1232 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     653.70 ns |     0.208 ns |     0.173 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     749.44 ns |     0.983 ns |     0.920 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     873.07 ns |     0.710 ns |     0.664 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,462.97 ns |     0.647 ns |     0.505 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,807.56 ns |    13.368 ns |    12.504 ns |    2112 B |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     654.40 ns |     2.305 ns |     1.925 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     742.13 ns |     1.204 ns |     1.068 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     891.03 ns |    17.315 ns |    21.264 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,462.84 ns |     0.409 ns |     0.341 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,853.15 ns |    24.987 ns |    23.373 ns |    2112 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     734.98 ns |     0.256 ns |     0.240 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |     844.15 ns |     1.155 ns |     1.081 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     978.13 ns |     0.693 ns |     0.648 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,646.19 ns |     0.185 ns |     0.164 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,324.14 ns |    16.944 ns |    15.850 ns |    2120 B |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     735.78 ns |     2.180 ns |     1.933 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |     838.34 ns |     2.775 ns |     2.596 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     978.95 ns |     2.290 ns |     1.788 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,652.49 ns |     6.967 ns |     6.517 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,366.24 ns |    36.792 ns |    34.416 ns |    2120 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,160.05 ns |     3.151 ns |     2.947 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   5,931.60 ns |     8.931 ns |     8.354 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,801.45 ns |     4.541 ns |     4.248 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  11,729.50 ns |     3.135 ns |     2.779 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  29,336.98 ns |    93.761 ns |    87.704 ns |    9280 B |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,174.06 ns |    24.743 ns |    21.934 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   5,897.99 ns |    16.958 ns |    14.161 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,816.16 ns |    26.455 ns |    23.452 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  11,775.91 ns |    51.955 ns |    48.599 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  29,512.23 ns |   137.092 ns |   121.528 ns |    9280 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,504.05 ns |    37.307 ns |    33.072 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        |  94,806.29 ns |   175.744 ns |   164.391 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,483.94 ns |    36.782 ns |    32.606 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 187,807.33 ns |    37.139 ns |    34.740 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 475,842.57 ns | 1,711.904 ns | 1,601.316 ns |  132188 B |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,640.41 ns |   296.972 ns |   263.258 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        |  94,529.65 ns |   368.296 ns |   344.504 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,886.45 ns |   522.295 ns |   488.555 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 188,210.73 ns |   578.133 ns |   540.786 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 477,473.47 ns | 1,482.936 ns | 1,238.319 ns |  132188 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      91.39 ns |     0.807 ns |     0.673 ns |      91.32 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     103.79 ns |     0.108 ns |     0.101 ns |     103.77 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     128.79 ns |     0.192 ns |     0.179 ns |     128.82 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     199.11 ns |     0.143 ns |     0.112 ns |     199.12 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     596.19 ns |    11.900 ns |    15.473 ns |     587.26 ns |    1216 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     169.75 ns |     0.107 ns |     0.100 ns |     169.78 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     194.25 ns |     0.333 ns |     0.311 ns |     194.21 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     234.67 ns |     0.185 ns |     0.173 ns |     234.69 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     398.34 ns |     0.470 ns |     0.439 ns |     398.43 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,111.40 ns |     4.998 ns |     4.675 ns |   1,109.85 ns |    1232 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     651.56 ns |     0.517 ns |     0.432 ns |     651.43 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     745.01 ns |     1.927 ns |     1.802 ns |     745.41 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     873.33 ns |     0.886 ns |     0.740 ns |     873.33 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,573.53 ns |     0.292 ns |     0.244 ns |   1,573.47 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,735.41 ns |    20.995 ns |    18.611 ns |   3,739.19 ns |    2112 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     725.45 ns |     2.672 ns |     2.500 ns |     725.66 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |     843.65 ns |     1.082 ns |     0.960 ns |     843.78 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     971.52 ns |     2.347 ns |     2.195 ns |     971.86 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,768.82 ns |     0.617 ns |     0.482 ns |   1,768.85 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,182.54 ns |    24.432 ns |    22.853 ns |   4,174.79 ns |    2120 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,088.94 ns |    21.311 ns |    19.935 ns |   5,076.06 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   5,864.66 ns |    22.063 ns |    20.637 ns |   5,863.92 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,762.94 ns |    50.009 ns |    39.044 ns |   6,755.56 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  12,549.57 ns |     3.096 ns |     2.585 ns |  12,548.71 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  28,313.70 ns |   159.599 ns |   149.289 ns |  28,315.94 ns |    9280 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,507.80 ns |    26.085 ns |    24.400 ns |  82,506.76 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        |  94,272.00 ns |   290.534 ns |   271.766 ns |  94,179.96 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,466.66 ns |    39.249 ns |    34.793 ns | 108,472.74 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 200,786.27 ns |    23.246 ns |    21.745 ns | 200,784.32 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 479,466.05 ns | 1,505.527 ns | 1,408.271 ns | 479,636.07 ns |  132188 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      91.64 ns |     0.135 ns |     0.126 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     103.10 ns |     0.110 ns |     0.103 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     128.97 ns |     0.170 ns |     0.159 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     179.50 ns |     0.042 ns |     0.038 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     612.22 ns |     2.841 ns |     2.657 ns |    1216 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     170.14 ns |     0.046 ns |     0.043 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     196.01 ns |     0.199 ns |     0.186 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     234.62 ns |     0.173 ns |     0.162 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     363.20 ns |     0.054 ns |     0.045 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,128.63 ns |     5.540 ns |     5.182 ns |    1232 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     653.70 ns |     0.208 ns |     0.173 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     749.44 ns |     0.983 ns |     0.920 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     873.07 ns |     0.710 ns |     0.664 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,462.97 ns |     0.647 ns |     0.505 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,807.56 ns |    13.368 ns |    12.504 ns |    2112 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     734.98 ns |     0.256 ns |     0.240 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |     844.15 ns |     1.155 ns |     1.081 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     978.13 ns |     0.693 ns |     0.648 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,646.19 ns |     0.185 ns |     0.164 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,324.14 ns |    16.944 ns |    15.850 ns |    2120 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,160.05 ns |     3.151 ns |     2.947 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   5,931.60 ns |     8.931 ns |     8.354 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,801.45 ns |     4.541 ns |     4.248 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  11,729.50 ns |     3.135 ns |     2.779 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  29,336.98 ns |    93.761 ns |    87.704 ns |    9280 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,504.05 ns |    37.307 ns |    33.072 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        |  94,806.29 ns |   175.744 ns |   164.391 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,483.94 ns |    36.782 ns |    32.606 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 187,807.33 ns |    37.139 ns |    34.740 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 475,842.57 ns | 1,711.904 ns | 1,601.316 ns |  132188 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev    | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|------------:|----------:|----------:|
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |     103.3 ns |     0.19 ns |   0.16 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     129.1 ns |     0.15 ns |   0.14 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     201.0 ns |     0.92 ns |   0.86 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     398.8 ns |     0.79 ns |   0.74 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     621.9 ns |     1.66 ns |   1.55 ns |    1216 B |
-|                                                         |              |              |             |           |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     181.9 ns |     0.83 ns |   0.65 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     237.6 ns |     4.12 ns |   3.86 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     401.2 ns |     3.62 ns |   3.39 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     792.3 ns |     6.65 ns |   5.90 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,143.1 ns |     8.99 ns |   7.51 ns |    1232 B |
-|                                                         |              |              |             |           |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     664.9 ns |     0.35 ns |   0.28 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     876.5 ns |     3.29 ns |   2.74 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,581.1 ns |     3.42 ns |   2.67 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   3,139.1 ns |     5.74 ns |   5.09 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,887.7 ns |    36.47 ns |  34.11 ns |    2112 B |
-|                                                         |              |              |             |           |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     747.4 ns |     0.35 ns |   0.29 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     979.1 ns |     1.39 ns |   1.16 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,780.9 ns |     5.52 ns |   4.89 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   3,535.2 ns |     6.27 ns |   5.24 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,397.5 ns |    25.85 ns |  21.58 ns |    2120 B |
-|                                                         |              |              |             |           |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,190.8 ns |     5.38 ns |   4.20 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,814.9 ns |     2.41 ns |   2.01 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  12,689.2 ns |    45.73 ns |  40.54 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |  25,154.3 ns |   150.92 ns | 133.79 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  29,905.9 ns |   187.56 ns | 166.27 ns |    9280 B |
-|                                                         |              |              |             |           |           |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,685.1 ns |    98.54 ns |  76.94 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,638.9 ns |    45.51 ns |  38.00 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 202,336.3 ns | 1,066.66 ns | 997.76 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 401,503.6 ns |   700.29 ns | 584.77 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 483,081.5 ns |   868.35 ns | 769.77 ns |  132188 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      91.39 ns |     0.807 ns |     0.673 ns |      91.32 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     103.79 ns |     0.108 ns |     0.101 ns |     103.77 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     128.79 ns |     0.192 ns |     0.179 ns |     128.82 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     199.11 ns |     0.143 ns |     0.112 ns |     199.12 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     596.19 ns |    11.900 ns |    15.473 ns |     587.26 ns |    1216 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     169.75 ns |     0.107 ns |     0.100 ns |     169.78 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     194.25 ns |     0.333 ns |     0.311 ns |     194.21 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     234.67 ns |     0.185 ns |     0.173 ns |     234.69 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     398.34 ns |     0.470 ns |     0.439 ns |     398.43 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,111.40 ns |     4.998 ns |     4.675 ns |   1,109.85 ns |    1232 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     651.56 ns |     0.517 ns |     0.432 ns |     651.43 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     745.01 ns |     1.927 ns |     1.802 ns |     745.41 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     873.33 ns |     0.886 ns |     0.740 ns |     873.33 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,573.53 ns |     0.292 ns |     0.244 ns |   1,573.47 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,735.41 ns |    20.995 ns |    18.611 ns |   3,739.19 ns |    2112 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     725.45 ns |     2.672 ns |     2.500 ns |     725.66 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |     843.65 ns |     1.082 ns |     0.960 ns |     843.78 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     971.52 ns |     2.347 ns |     2.195 ns |     971.86 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,768.82 ns |     0.617 ns |     0.482 ns |   1,768.85 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,182.54 ns |    24.432 ns |    22.853 ns |   4,174.79 ns |    2120 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,088.94 ns |    21.311 ns |    19.935 ns |   5,076.06 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   5,864.66 ns |    22.063 ns |    20.637 ns |   5,863.92 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,762.94 ns |    50.009 ns |    39.044 ns |   6,755.56 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  12,549.57 ns |     3.096 ns |     2.585 ns |  12,548.71 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  28,313.70 ns |   159.599 ns |   149.289 ns |  28,315.94 ns |    9280 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,507.80 ns |    26.085 ns |    24.400 ns |  82,506.76 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        |  94,272.00 ns |   290.534 ns |   271.766 ns |  94,179.96 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,466.66 ns |    39.249 ns |    34.793 ns | 108,472.74 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 200,786.27 ns |    23.246 ns |    21.745 ns | 200,784.32 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 479,466.05 ns | 1,505.527 ns | 1,408.271 ns | 479,636.07 ns |  132188 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
@@ -1,31 +1,37 @@
-﻿| Description                                            | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128B         |     129.0 ns |     0.12 ns |     0.11 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)      | 128B         |     232.6 ns |     0.60 ns |     0.56 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128B         |     394.1 ns |     1.24 ns |     1.16 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128B         |     610.2 ns |     2.28 ns |     2.14 ns |    1216 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 137B         |     233.8 ns |     0.14 ns |     0.13 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)      | 137B         |     445.4 ns |     5.57 ns |     5.21 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 137B         |     779.0 ns |     2.10 ns |     1.97 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 137B         |   1,118.5 ns |     4.42 ns |     4.14 ns |    1232 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1KB          |     872.4 ns |     0.54 ns |     0.50 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)      | 1KB          |   1,744.5 ns |     4.81 ns |     4.50 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1KB          |   3,087.7 ns |    10.91 ns |    10.20 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1KB          |   3,790.6 ns |    19.74 ns |    18.47 ns |    2112 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1025B        |     977.5 ns |     1.47 ns |     1.38 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)      | 1025B        |   2,009.4 ns |    39.35 ns |    43.73 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1025B        |   3,477.3 ns |     8.41 ns |     7.87 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1025B        |   4,313.9 ns |    24.88 ns |    23.27 ns |    2120 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 8KB          |   6,801.7 ns |     3.51 ns |     3.28 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)      | 8KB          |  13,895.6 ns |    67.48 ns |    63.12 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 8KB          |  24,667.8 ns |    72.71 ns |    68.02 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 8KB          |  29,061.3 ns |    78.42 ns |    73.35 ns |    9280 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128KB        | 108,415.7 ns |    69.42 ns |    64.94 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)      | 128KB        | 222,170.2 ns | 1,126.74 ns | 1,053.96 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128KB        | 394,592.4 ns | 1,469.54 ns | 1,374.60 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128KB        | 470,910.8 ns | 1,174.52 ns | 1,098.65 ns |  132188 B |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev    | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|----------:|----------:|
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |     103.3 ns |     0.19 ns |   0.16 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     129.1 ns |     0.15 ns |   0.14 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128B         |     201.0 ns |     0.92 ns |   0.86 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     398.8 ns |     0.79 ns |   0.74 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     621.9 ns |     1.66 ns |   1.55 ns |    1216 B |
+|                                                         |              |              |             |           |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     181.9 ns |     0.83 ns |   0.65 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     237.6 ns |     4.12 ns |   3.86 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 137B         |     401.2 ns |     3.62 ns |   3.39 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     792.3 ns |     6.65 ns |   5.90 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |   1,143.1 ns |     8.99 ns |   7.51 ns |    1232 B |
+|                                                         |              |              |             |           |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     664.9 ns |     0.35 ns |   0.28 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     876.5 ns |     3.29 ns |   2.74 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1KB          |   1,581.1 ns |     3.42 ns |   2.67 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   3,139.1 ns |     5.74 ns |   5.09 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,887.7 ns |    36.47 ns |  34.11 ns |    2112 B |
+|                                                         |              |              |             |           |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     747.4 ns |     0.35 ns |   0.29 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     979.1 ns |     1.39 ns |   1.16 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 1025B        |   1,780.9 ns |     5.52 ns |   4.89 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   3,535.2 ns |     6.27 ns |   5.24 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   4,397.5 ns |    25.85 ns |  21.58 ns |    2120 B |
+|                                                         |              |              |             |           |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,190.8 ns |     5.38 ns |   4.20 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   6,814.9 ns |     2.41 ns |   2.01 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 8KB          |  12,689.2 ns |    45.73 ns |  40.54 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |  25,154.3 ns |   150.92 ns | 133.79 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  29,905.9 ns |   187.56 ns | 166.27 ns |    9280 B |
+|                                                         |              |              |             |           |           |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  82,685.1 ns |    98.54 ns |  76.94 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        | 108,638.9 ns |    45.51 ns |  38.00 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Neon)       | 128KB        | 202,336.3 ns | 1,066.66 ns | 997.76 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 401,503.6 ns |   700.29 ns | 584.77 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 483,081.5 ns |   868.35 ns | 769.77 ns |  132188 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s128.md
@@ -1,25 +1,31 @@
-﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128B         |     196.3 ns |     0.11 ns |     0.10 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon) | 128B         |     351.6 ns |     0.06 ns |     0.05 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed            | 128B         |     638.4 ns |     2.20 ns |     2.06 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 137B         |     284.9 ns |     0.41 ns |     0.38 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon) | 137B         |     529.2 ns |     0.65 ns |     0.61 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed            | 137B         |     954.6 ns |     5.61 ns |     5.24 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1KB          |   1,450.7 ns |     1.67 ns |     1.56 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon) | 1KB          |   2,782.0 ns |     0.46 ns |     0.41 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed            | 1KB          |   5,046.4 ns |    17.74 ns |    16.59 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1025B        |   1,542.9 ns |     2.03 ns |     1.90 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon) | 1025B        |   2,955.0 ns |     0.56 ns |     0.50 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed            | 1025B        |   5,370.2 ns |    12.82 ns |    11.99 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 8KB          |  11,482.9 ns |    11.26 ns |    10.53 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon) | 8KB          |  22,202.1 ns |     5.10 ns |     4.26 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed            | 8KB          |  40,334.1 ns |   128.89 ns |   120.56 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128KB        | 183,323.1 ns |   183.99 ns |   172.11 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon) | 128KB        | 355,162.0 ns |    44.43 ns |    39.38 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed            | 128KB        | 645,318.7 ns | 3,331.70 ns | 3,116.48 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     148.1 ns |     1.80 ns |     1.59 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     196.6 ns |     1.00 ns |     0.78 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 128B         |     357.7 ns |     7.19 ns |     5.61 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     640.0 ns |     2.87 ns |     2.40 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     217.6 ns |     1.28 ns |     1.07 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     286.2 ns |     2.49 ns |     2.08 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 137B         |     529.9 ns |     0.87 ns |     0.68 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     961.7 ns |     3.47 ns |     3.24 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,096.1 ns |     0.70 ns |     0.55 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,462.9 ns |    17.84 ns |    15.82 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 1KB          |   2,790.9 ns |    15.10 ns |    12.61 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   5,126.1 ns |    26.15 ns |    21.84 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,167.6 ns |     6.43 ns |     5.37 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,542.7 ns |     3.25 ns |     2.54 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 1025B        |   2,976.0 ns |    11.28 ns |     9.42 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,474.6 ns |    20.61 ns |    17.21 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   8,672.9 ns |     4.98 ns |     4.16 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |  11,626.8 ns |   191.07 ns |   178.73 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 8KB          |  22,351.0 ns |   146.99 ns |   130.30 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  41,197.8 ns |   182.92 ns |   162.15 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 138,613.3 ns |   194.97 ns |   162.81 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 184,681.9 ns | 1,769.64 ns | 1,477.73 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 128KB        | 357,501.4 ns | 2,267.99 ns | 2,010.52 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 662,037.7 ns | 6,215.90 ns | 5,510.24 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s128.md
@@ -1,31 +1,25 @@
-﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     148.1 ns |     1.80 ns |     1.59 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     196.6 ns |     1.00 ns |     0.78 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 128B         |     357.7 ns |     7.19 ns |     5.61 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     640.0 ns |     2.87 ns |     2.40 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     217.6 ns |     1.28 ns |     1.07 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     286.2 ns |     2.49 ns |     2.08 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 137B         |     529.9 ns |     0.87 ns |     0.68 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     961.7 ns |     3.47 ns |     3.24 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,096.1 ns |     0.70 ns |     0.55 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,462.9 ns |    17.84 ns |    15.82 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 1KB          |   2,790.9 ns |    15.10 ns |    12.61 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   5,126.1 ns |    26.15 ns |    21.84 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,167.6 ns |     6.43 ns |     5.37 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,542.7 ns |     3.25 ns |     2.54 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 1025B        |   2,976.0 ns |    11.28 ns |     9.42 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,474.6 ns |    20.61 ns |    17.21 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   8,672.9 ns |     4.98 ns |     4.16 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |  11,626.8 ns |   191.07 ns |   178.73 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 8KB          |  22,351.0 ns |   146.99 ns |   130.30 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  41,197.8 ns |   182.92 ns |   162.15 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 138,613.3 ns |   194.97 ns |   162.81 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 184,681.9 ns | 1,769.64 ns | 1,477.73 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Neon)       | 128KB        | 357,501.4 ns | 2,267.99 ns | 2,010.52 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 662,037.7 ns | 6,215.90 ns | 5,510.24 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     141.6 ns |   0.10 ns |   0.10 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     163.0 ns |   0.18 ns |   0.16 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     197.2 ns |   0.17 ns |   0.15 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     211.0 ns |   0.15 ns |   0.14 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     240.8 ns |   0.19 ns |   0.18 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     286.9 ns |   0.35 ns |   0.33 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,099.1 ns |   0.93 ns |   0.87 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   1,260.3 ns |   1.36 ns |   1.27 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,466.1 ns |   7.51 ns |   6.65 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,167.9 ns |   2.52 ns |   2.10 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   1,337.3 ns |   3.42 ns |   3.20 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,555.2 ns |   9.55 ns |   7.98 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   8,752.9 ns |  32.72 ns |  25.55 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  10,038.7 ns |  13.31 ns |  12.45 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |  11,606.8 ns |  57.33 ns |  50.82 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 139,323.4 ns | 137.47 ns | 114.80 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 160,579.6 ns | 388.04 ns | 324.03 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 184,633.6 ns | 747.44 ns | 624.15 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s256.md
@@ -1,25 +1,31 @@
-﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128B         |     197.7 ns |     0.22 ns |     0.21 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon) | 128B         |     351.7 ns |     0.04 ns |     0.04 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed            | 128B         |     637.7 ns |     2.19 ns |     2.05 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 137B         |     286.7 ns |     0.56 ns |     0.52 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon) | 137B         |     529.3 ns |     0.75 ns |     0.70 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed            | 137B         |     953.3 ns |     4.40 ns |     3.90 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1KB          |   1,455.2 ns |     1.50 ns |     1.41 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon) | 1KB          |   2,783.5 ns |     0.48 ns |     0.45 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed            | 1KB          |   5,048.3 ns |    14.27 ns |    13.35 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1025B        |   1,543.3 ns |     2.55 ns |     2.39 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon) | 1025B        |   2,955.0 ns |     0.86 ns |     0.81 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed            | 1025B        |   5,367.0 ns |    14.22 ns |    13.30 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 8KB          |  11,483.0 ns |    10.49 ns |     9.81 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon) | 8KB          |  22,201.2 ns |     4.84 ns |     4.53 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed            | 8KB          |  40,327.0 ns |   171.24 ns |   160.18 ns |         - |
-|                                                   |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128KB        | 183,284.4 ns |   253.23 ns |   236.87 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon) | 128KB        | 355,158.4 ns |    71.44 ns |    63.33 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed            | 128KB        | 645,148.0 ns | 2,217.39 ns | 2,074.15 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     150.6 ns |     2.61 ns |     2.44 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     198.7 ns |     1.61 ns |     1.35 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 128B         |     356.2 ns |     2.90 ns |     2.43 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     656.7 ns |     5.51 ns |     4.88 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     219.0 ns |     3.01 ns |     2.81 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     293.7 ns |     5.30 ns |     4.96 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 137B         |     537.7 ns |     4.36 ns |     3.64 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     984.0 ns |    14.47 ns |    13.53 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,102.1 ns |    12.04 ns |    10.06 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,460.1 ns |     8.25 ns |     6.44 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 1KB          |   2,832.8 ns |    27.87 ns |    23.27 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   5,210.9 ns |    19.78 ns |    15.44 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,170.4 ns |    12.37 ns |    10.97 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,551.0 ns |    17.03 ns |    15.10 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 1025B        |   2,975.8 ns |    12.84 ns |    11.38 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   5,507.0 ns |    13.90 ns |    10.85 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   8,724.2 ns |    79.14 ns |    70.16 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |  11,581.6 ns |   128.31 ns |   120.02 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 8KB          |  22,450.9 ns |   106.74 ns |    99.84 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  41,586.7 ns |   363.94 ns |   322.62 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 139,020.1 ns | 1,211.47 ns | 1,011.63 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 183,546.6 ns |   870.67 ns |   727.05 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 128KB        | 359,547.7 ns | 3,576.85 ns | 3,170.79 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 662,539.2 ns | 1,192.36 ns |   995.68 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s256.md
@@ -1,31 +1,25 @@
-﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     150.6 ns |     2.61 ns |     2.44 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     198.7 ns |     1.61 ns |     1.35 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 128B         |     356.2 ns |     2.90 ns |     2.43 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     656.7 ns |     5.51 ns |     4.88 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     219.0 ns |     3.01 ns |     2.81 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     293.7 ns |     5.30 ns |     4.96 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 137B         |     537.7 ns |     4.36 ns |     3.64 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     984.0 ns |    14.47 ns |    13.53 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,102.1 ns |    12.04 ns |    10.06 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,460.1 ns |     8.25 ns |     6.44 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 1KB          |   2,832.8 ns |    27.87 ns |    23.27 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   5,210.9 ns |    19.78 ns |    15.44 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,170.4 ns |    12.37 ns |    10.97 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,551.0 ns |    17.03 ns |    15.10 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 1025B        |   2,975.8 ns |    12.84 ns |    11.38 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   5,507.0 ns |    13.90 ns |    10.85 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   8,724.2 ns |    79.14 ns |    70.16 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |  11,581.6 ns |   128.31 ns |   120.02 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 8KB          |  22,450.9 ns |   106.74 ns |    99.84 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  41,586.7 ns |   363.94 ns |   322.62 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 139,020.1 ns | 1,211.47 ns | 1,011.63 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 183,546.6 ns |   870.67 ns |   727.05 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Neon)       | 128KB        | 359,547.7 ns | 3,576.85 ns | 3,170.79 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 662,539.2 ns | 1,192.36 ns |   995.68 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     142.3 ns |   0.34 ns |   0.29 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     163.2 ns |   0.45 ns |   0.35 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     198.9 ns |   0.31 ns |   0.29 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     212.0 ns |   0.12 ns |   0.10 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     240.8 ns |   0.85 ns |   0.80 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     287.6 ns |   0.38 ns |   0.32 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,098.6 ns |   3.72 ns |   3.48 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   1,260.6 ns |   1.24 ns |   1.16 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,464.2 ns |   2.52 ns |   2.23 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,168.9 ns |   0.84 ns |   0.78 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   1,339.3 ns |   0.86 ns |   0.81 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,551.3 ns |   1.52 ns |   1.35 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   8,732.3 ns |   4.78 ns |   4.24 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  10,045.6 ns |   6.70 ns |   6.27 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |  11,545.8 ns |  21.33 ns |  19.96 ns |         - |
+|                                                         |              |              |           |           |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 139,297.8 ns | 105.44 ns |  98.63 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 160,418.7 ns |  97.95 ns |  91.62 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 184,308.0 ns | 255.01 ns | 238.53 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,31 +1,37 @@
-﻿| Description                                            | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
-|------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 128B         |      87.46 ns |     1.262 ns |     1.119 ns |      87.09 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128B         |     101.47 ns |     1.384 ns |     1.295 ns |     101.59 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128B         |     390.90 ns |     7.593 ns |     8.124 ns |     390.41 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128B         |     518.53 ns |     9.914 ns |    10.608 ns |     514.20 ns |    1120 B |
-|                                                        |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 137B         |     168.34 ns |     1.321 ns |     1.171 ns |     168.38 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 137B         |     183.87 ns |     0.983 ns |     0.871 ns |     183.89 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 137B         |     771.89 ns |    15.171 ns |    19.726 ns |     769.23 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 137B         |     969.92 ns |    16.784 ns |    14.879 ns |     969.04 ns |    1136 B |
-|                                                        |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 1KB          |     658.91 ns |    13.167 ns |    28.623 ns |     647.23 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1KB          |     744.06 ns |    14.710 ns |    28.691 ns |     727.25 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1KB          |   2,989.50 ns |    25.533 ns |    19.935 ns |   2,995.47 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1KB          |   3,218.94 ns |    41.143 ns |    38.485 ns |   3,220.80 ns |    2016 B |
-|                                                        |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 1025B        |     735.98 ns |    14.704 ns |    20.127 ns |     731.65 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1025B        |     808.81 ns |     3.774 ns |     3.151 ns |     808.43 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1025B        |   3,462.12 ns |    53.123 ns |    47.092 ns |   3,465.86 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1025B        |   3,663.63 ns |    40.901 ns |    38.259 ns |   3,666.72 ns |    2024 B |
-|                                                        |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 8KB          |   5,206.45 ns |   103.178 ns |   188.668 ns |   5,155.94 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 8KB          |   5,816.64 ns |   111.292 ns |   191.974 ns |   5,739.12 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 8KB          |  24,316.28 ns |   465.013 ns |   497.559 ns |  24,328.00 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 8KB          |  26,017.09 ns |   200.485 ns |   177.725 ns |  26,045.93 ns |    9184 B |
-|                                                        |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 128KB        |  79,965.65 ns |   567.167 ns |   530.529 ns |  80,096.53 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128KB        |  90,041.91 ns |   363.578 ns |   322.302 ns |  89,969.27 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128KB        | 381,892.70 ns | 3,512.969 ns | 3,286.033 ns | 382,991.89 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128KB        | 415,017.35 ns | 3,743.185 ns | 3,501.378 ns | 415,813.72 ns |  132078 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      88.18 ns |     1.416 ns |     1.324 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     101.99 ns |     0.942 ns |     0.881 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |     104.51 ns |     1.412 ns |     1.321 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     384.08 ns |     7.521 ns |     7.035 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     512.15 ns |    10.040 ns |    16.496 ns |    1120 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     167.25 ns |     1.181 ns |     1.047 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     187.53 ns |     1.546 ns |     1.371 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     188.58 ns |     1.292 ns |     1.208 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     757.64 ns |    11.759 ns |    10.424 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     945.74 ns |    15.894 ns |    14.868 ns |    1136 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     629.62 ns |     4.436 ns |     4.149 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     663.24 ns |     4.686 ns |     4.383 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     716.56 ns |     2.368 ns |     1.978 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   2,994.58 ns |    51.377 ns |    45.544 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,159.35 ns |    52.996 ns |    49.572 ns |    2016 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     713.13 ns |     3.487 ns |     3.262 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     744.82 ns |     3.327 ns |     3.112 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     802.09 ns |     2.651 ns |     2.350 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   3,349.39 ns |    46.711 ns |    43.694 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,579.16 ns |    39.210 ns |    34.759 ns |    2024 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   5,005.39 ns |    37.476 ns |    35.055 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,117.18 ns |    35.576 ns |    31.537 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,592.75 ns |    33.215 ns |    31.069 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |  23,767.84 ns |   436.453 ns |   408.259 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  24,247.81 ns |   124.810 ns |   110.641 ns |    9184 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  79,760.62 ns |   383.722 ns |   340.159 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  81,338.34 ns |   488.100 ns |   432.687 ns |     248 B |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  89,258.04 ns |   260.648 ns |   231.058 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 379,956.29 ns | 6,970.219 ns | 6,519.947 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 415,607.24 ns | 8,302.629 ns | 8,154.292 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,31 +1,31 @@
-﻿| Description                                            | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 128B         |      87.94 ns |     1.610 ns |     1.506 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128B         |     100.98 ns |     0.911 ns |     0.852 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128B         |     387.22 ns |     5.643 ns |     5.002 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128B         |     521.38 ns |    10.411 ns |    21.268 ns |    1120 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 137B         |     169.98 ns |     3.340 ns |     3.430 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 137B         |     195.94 ns |     2.320 ns |     2.170 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 137B         |     773.51 ns |    15.122 ns |    18.002 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 137B         |     974.25 ns |    19.510 ns |    33.654 ns |    1136 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 1KB          |     627.71 ns |     3.940 ns |     3.685 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1KB          |     727.01 ns |     6.611 ns |     5.860 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1KB          |   3,007.04 ns |    57.602 ns |    70.740 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1KB          |   3,171.70 ns |    26.056 ns |    21.758 ns |    2016 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 1025B        |     732.88 ns |    13.855 ns |    15.400 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1025B        |     808.27 ns |     6.412 ns |     5.998 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1025B        |   3,356.09 ns |    66.615 ns |    74.043 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1025B        |   3,602.54 ns |    65.236 ns |    61.022 ns |    2024 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 8KB          |   4,995.74 ns |    19.582 ns |    15.289 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 8KB          |   5,617.03 ns |    22.779 ns |    19.021 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 8KB          |  23,914.64 ns |   471.445 ns |   561.221 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 8KB          |  24,480.59 ns |   381.554 ns |   356.906 ns |    9184 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 128KB        |  84,448.81 ns | 1,647.164 ns | 2,752.042 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128KB        |  88,982.88 ns |   671.300 ns |   627.934 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128KB        | 378,912.54 ns | 5,052.417 ns | 4,218.997 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128KB        | 414,485.68 ns | 7,916.450 ns | 8,129.611 ns |  132078 B |
+﻿| Description                                            | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
+|------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 128B         |      87.46 ns |     1.262 ns |     1.119 ns |      87.09 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128B         |     101.47 ns |     1.384 ns |     1.295 ns |     101.59 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 128B         |     390.90 ns |     7.593 ns |     8.124 ns |     390.41 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128B         |     518.53 ns |     9.914 ns |    10.608 ns |     514.20 ns |    1120 B |
+|                                                        |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 137B         |     168.34 ns |     1.321 ns |     1.171 ns |     168.38 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 137B         |     183.87 ns |     0.983 ns |     0.871 ns |     183.89 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 137B         |     771.89 ns |    15.171 ns |    19.726 ns |     769.23 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 137B         |     969.92 ns |    16.784 ns |    14.879 ns |     969.04 ns |    1136 B |
+|                                                        |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 1KB          |     658.91 ns |    13.167 ns |    28.623 ns |     647.23 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1KB          |     744.06 ns |    14.710 ns |    28.691 ns |     727.25 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 1KB          |   2,989.50 ns |    25.533 ns |    19.935 ns |   2,995.47 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1KB          |   3,218.94 ns |    41.143 ns |    38.485 ns |   3,220.80 ns |    2016 B |
+|                                                        |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 1025B        |     735.98 ns |    14.704 ns |    20.127 ns |     731.65 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1025B        |     808.81 ns |     3.774 ns |     3.151 ns |     808.43 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 1025B        |   3,462.12 ns |    53.123 ns |    47.092 ns |   3,465.86 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1025B        |   3,663.63 ns |    40.901 ns |    38.259 ns |   3,666.72 ns |    2024 B |
+|                                                        |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 8KB          |   5,206.45 ns |   103.178 ns |   188.668 ns |   5,155.94 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 8KB          |   5,816.64 ns |   111.292 ns |   191.974 ns |   5,739.12 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 8KB          |  24,316.28 ns |   465.013 ns |   497.559 ns |  24,328.00 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 8KB          |  26,017.09 ns |   200.485 ns |   177.725 ns |  26,045.93 ns |    9184 B |
+|                                                        |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 128KB        |  79,965.65 ns |   567.167 ns |   530.529 ns |  80,096.53 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128KB        |  90,041.91 ns |   363.578 ns |   322.302 ns |  89,969.27 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 128KB        | 381,892.70 ns | 3,512.969 ns | 3,286.033 ns | 382,991.89 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128KB        | 415,017.35 ns | 3,743.185 ns | 3,501.378 ns | 415,813.72 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      86.57 ns |     1.198 ns |     1.062 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      95.71 ns |     0.237 ns |     0.198 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     100.22 ns |     0.982 ns |     0.918 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     175.40 ns |     1.784 ns |     1.669 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     504.20 ns |     7.624 ns |     7.131 ns |    1120 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     165.97 ns |     0.371 ns |     0.290 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     181.51 ns |     3.557 ns |     3.806 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     182.75 ns |     2.685 ns |     2.511 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     337.60 ns |     0.889 ns |     0.743 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     930.42 ns |     3.748 ns |     3.129 ns |    1136 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     631.49 ns |     2.072 ns |     1.730 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     652.82 ns |     1.631 ns |     1.362 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     731.13 ns |    11.829 ns |    10.486 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   1,332.75 ns |    12.260 ns |    11.468 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,162.75 ns |    18.167 ns |    16.105 ns |    2016 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     715.41 ns |     2.291 ns |     2.031 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     735.36 ns |     2.251 ns |     1.996 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     810.15 ns |     2.231 ns |     1.863 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   1,478.00 ns |     3.626 ns |     3.028 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,574.53 ns |     4.863 ns |     4.061 ns |    2024 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   5,111.23 ns |   100.642 ns |    98.844 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,230.70 ns |    48.862 ns |    45.706 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,696.75 ns |    29.243 ns |    24.419 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |  10,475.66 ns |    41.591 ns |    38.905 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  24,381.79 ns |   291.123 ns |   243.100 ns |    9184 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  81,593.08 ns |   360.243 ns |   319.346 ns |         - |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  83,230.07 ns | 1,457.537 ns | 1,559.548 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  92,111.67 ns |   379.216 ns |   316.663 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 167,350.18 ns |   743.924 ns |   621.211 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 417,658.58 ns | 2,338.404 ns | 2,072.934 ns |  132078 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      85.47 ns |     1.538 ns |     2.053 ns |      85.20 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      96.29 ns |     0.906 ns |     0.847 ns |      96.14 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     101.04 ns |     1.403 ns |     1.172 ns |     101.22 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     139.85 ns |     2.753 ns |     4.523 ns |     138.36 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     509.27 ns |     9.791 ns |    25.098 ns |     499.30 ns |    1120 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     165.65 ns |     1.030 ns |     0.913 ns |     165.73 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     178.43 ns |     1.034 ns |     0.967 ns |     178.70 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     186.74 ns |     1.506 ns |     1.409 ns |     187.15 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     260.76 ns |     5.091 ns |     6.969 ns |     257.22 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     944.07 ns |    18.274 ns |    22.442 ns |     948.13 ns |    1136 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     626.23 ns |     3.210 ns |     2.846 ns |     626.17 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     652.27 ns |     7.340 ns |     8.453 ns |     649.58 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     715.20 ns |     2.431 ns |     2.030 ns |     714.83 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     987.90 ns |    18.899 ns |    19.408 ns |     987.76 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,111.33 ns |    60.015 ns |    56.138 ns |   3,094.60 ns |    2016 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     713.70 ns |     4.604 ns |     4.081 ns |     711.78 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     731.50 ns |     2.329 ns |     1.945 ns |     731.32 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     804.56 ns |     4.233 ns |     3.753 ns |     805.39 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   1,089.92 ns |    13.565 ns |    11.328 ns |   1,086.66 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,545.57 ns |    55.962 ns |    52.347 ns |   3,533.60 ns |    2024 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   4,979.46 ns |    24.289 ns |    21.532 ns |   4,985.18 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,082.36 ns |    30.454 ns |    28.486 ns |   5,075.46 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,607.91 ns |    28.908 ns |    27.041 ns |   5,595.83 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   7,684.93 ns |   136.607 ns |   127.782 ns |   7,636.75 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  24,054.70 ns |   463.464 ns |   475.943 ns |  23,945.83 ns |    9184 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  79,613.89 ns |   630.019 ns |   589.320 ns |  79,359.76 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  80,960.21 ns |   482.480 ns |   451.312 ns |  80,977.53 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  89,005.77 ns |   487.532 ns |   432.184 ns |  88,819.73 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 122,883.31 ns | 2,280.342 ns | 2,133.033 ns | 121,899.84 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 411,394.62 ns | 7,990.059 ns | 9,511.597 ns | 408,785.89 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      85.47 ns |     1.538 ns |     2.053 ns |      85.20 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      96.29 ns |     0.906 ns |     0.847 ns |      96.14 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     101.04 ns |     1.403 ns |     1.172 ns |     101.22 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     139.85 ns |     2.753 ns |     4.523 ns |     138.36 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     509.27 ns |     9.791 ns |    25.098 ns |     499.30 ns |    1120 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     165.65 ns |     1.030 ns |     0.913 ns |     165.73 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     178.43 ns |     1.034 ns |     0.967 ns |     178.70 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     186.74 ns |     1.506 ns |     1.409 ns |     187.15 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     260.76 ns |     5.091 ns |     6.969 ns |     257.22 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     944.07 ns |    18.274 ns |    22.442 ns |     948.13 ns |    1136 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     626.23 ns |     3.210 ns |     2.846 ns |     626.17 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     652.27 ns |     7.340 ns |     8.453 ns |     649.58 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     715.20 ns |     2.431 ns |     2.030 ns |     714.83 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     987.90 ns |    18.899 ns |    19.408 ns |     987.76 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,111.33 ns |    60.015 ns |    56.138 ns |   3,094.60 ns |    2016 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     713.70 ns |     4.604 ns |     4.081 ns |     711.78 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     731.50 ns |     2.329 ns |     1.945 ns |     731.32 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     804.56 ns |     4.233 ns |     3.753 ns |     805.39 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   1,089.92 ns |    13.565 ns |    11.328 ns |   1,086.66 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,545.57 ns |    55.962 ns |    52.347 ns |   3,533.60 ns |    2024 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   4,979.46 ns |    24.289 ns |    21.532 ns |   4,985.18 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,082.36 ns |    30.454 ns |    28.486 ns |   5,075.46 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,607.91 ns |    28.908 ns |    27.041 ns |   5,595.83 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   7,684.93 ns |   136.607 ns |   127.782 ns |   7,636.75 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  24,054.70 ns |   463.464 ns |   475.943 ns |  23,945.83 ns |    9184 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  79,613.89 ns |   630.019 ns |   589.320 ns |  79,359.76 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  80,960.21 ns |   482.480 ns |   451.312 ns |  80,977.53 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  89,005.77 ns |   487.532 ns |   432.184 ns |  88,819.73 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 122,883.31 ns | 2,280.342 ns | 2,133.033 ns | 121,899.84 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 411,394.62 ns | 7,990.059 ns | 9,511.597 ns | 408,785.89 ns |  132078 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      87.62 ns |     1.764 ns |     1.733 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      96.09 ns |     0.978 ns |     0.915 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     100.05 ns |     0.978 ns |     0.914 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     139.03 ns |     2.707 ns |     3.325 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     496.29 ns |     9.784 ns |    14.032 ns |    1120 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     166.17 ns |     1.516 ns |     1.344 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     177.54 ns |     1.342 ns |     1.190 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     186.97 ns |     1.546 ns |     1.447 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     259.22 ns |     5.042 ns |     4.952 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     947.04 ns |    17.987 ns |    17.666 ns |    1136 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     630.13 ns |     4.220 ns |     3.947 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     653.33 ns |     2.750 ns |     2.572 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     716.37 ns |     3.574 ns |     2.984 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |     987.51 ns |    19.435 ns |    18.180 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,145.06 ns |    62.759 ns |    77.074 ns |    2016 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     711.48 ns |     4.542 ns |     4.249 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     730.82 ns |     5.407 ns |     5.057 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     803.72 ns |     6.398 ns |     5.342 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   1,100.77 ns |    15.878 ns |    14.075 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,565.09 ns |    71.265 ns |    84.836 ns |    2024 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   4,974.12 ns |    31.228 ns |    29.211 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,093.12 ns |    29.185 ns |    27.300 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,591.12 ns |    28.034 ns |    23.409 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   7,738.33 ns |   142.733 ns |   126.529 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  24,103.01 ns |   461.986 ns |   432.142 ns |    9184 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  79,534.90 ns |   413.658 ns |   386.936 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  80,742.72 ns |   316.183 ns |   264.027 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  89,437.68 ns |   513.170 ns |   480.020 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 124,605.86 ns | 2,484.490 ns | 3,400.799 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 407,812.83 ns | 8,064.829 ns | 7,920.740 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,37 +1,37 @@
 ﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
 |-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      87.20 ns |     1.686 ns |     1.656 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      96.59 ns |     0.593 ns |     0.555 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     100.45 ns |     0.820 ns |     0.727 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     160.72 ns |     3.160 ns |     3.761 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     500.53 ns |     8.138 ns |     7.612 ns |    1120 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      86.57 ns |     1.198 ns |     1.062 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      95.71 ns |     0.237 ns |     0.198 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     100.22 ns |     0.982 ns |     0.918 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     175.40 ns |     1.784 ns |     1.669 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     504.20 ns |     7.624 ns |     7.131 ns |    1120 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     167.80 ns |     1.247 ns |     1.167 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     177.36 ns |     0.883 ns |     0.782 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     189.66 ns |     1.723 ns |     1.612 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     297.50 ns |     4.458 ns |     4.170 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     927.75 ns |    12.324 ns |    11.528 ns |    1136 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     165.97 ns |     0.371 ns |     0.290 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     181.51 ns |     3.557 ns |     3.806 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     182.75 ns |     2.685 ns |     2.511 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     337.60 ns |     0.889 ns |     0.743 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     930.42 ns |     3.748 ns |     3.129 ns |    1136 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     626.59 ns |     3.167 ns |     2.962 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     649.17 ns |     4.519 ns |     4.227 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     717.32 ns |     4.035 ns |     3.577 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   1,141.90 ns |    16.555 ns |    15.485 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,119.64 ns |    54.199 ns |    50.697 ns |    2016 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     631.49 ns |     2.072 ns |     1.730 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     652.82 ns |     1.631 ns |     1.362 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     731.13 ns |    11.829 ns |    10.486 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   1,332.75 ns |    12.260 ns |    11.468 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,162.75 ns |    18.167 ns |    16.105 ns |    2016 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     710.67 ns |     3.351 ns |     3.134 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     732.08 ns |     4.183 ns |     3.913 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     802.51 ns |     4.684 ns |     3.912 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   1,287.53 ns |    13.290 ns |    11.781 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,651.03 ns |    71.800 ns |   102.974 ns |    2024 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     715.41 ns |     2.291 ns |     2.031 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     735.36 ns |     2.251 ns |     1.996 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     810.15 ns |     2.231 ns |     1.863 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   1,478.00 ns |     3.626 ns |     3.028 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,574.53 ns |     4.863 ns |     4.061 ns |    2024 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   4,988.28 ns |    40.053 ns |    35.506 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,079.36 ns |    28.386 ns |    26.553 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,605.08 ns |    29.542 ns |    27.634 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   9,026.31 ns |    68.175 ns |    56.929 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  23,968.64 ns |   469.455 ns |   439.128 ns |    9184 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   5,111.23 ns |   100.642 ns |    98.844 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,230.70 ns |    48.862 ns |    45.706 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,696.75 ns |    29.243 ns |    24.419 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |  10,475.66 ns |    41.591 ns |    38.905 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  24,381.79 ns |   291.123 ns |   243.100 ns |    9184 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  79,468.77 ns |   336.729 ns |   298.502 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  81,122.90 ns |   572.712 ns |   535.715 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  89,063.90 ns |   394.766 ns |   329.648 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 144,746.77 ns | 1,873.272 ns | 1,660.607 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 407,703.38 ns | 6,372.705 ns | 5,961.032 ns |  132078 B |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  81,593.08 ns |   360.243 ns |   319.346 ns |         - |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  83,230.07 ns | 1,457.537 ns | 1,559.548 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  92,111.67 ns |   379.216 ns |   316.663 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 167,350.18 ns |   743.924 ns |   621.211 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 417,658.58 ns | 2,338.404 ns | 2,072.934 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,37 +1,37 @@
 ﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
 |-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      88.18 ns |     1.416 ns |     1.324 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     101.99 ns |     0.942 ns |     0.881 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |     104.51 ns |     1.412 ns |     1.321 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     384.08 ns |     7.521 ns |     7.035 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     512.15 ns |    10.040 ns |    16.496 ns |    1120 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128B         |      87.20 ns |     1.686 ns |     1.656 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128B         |      96.59 ns |     0.593 ns |     0.555 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128B         |     100.45 ns |     0.820 ns |     0.727 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128B         |     160.72 ns |     3.160 ns |     3.761 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128B         |     500.53 ns |     8.138 ns |     7.612 ns |    1120 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     167.25 ns |     1.181 ns |     1.047 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     187.53 ns |     1.546 ns |     1.371 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     188.58 ns |     1.292 ns |     1.208 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     757.64 ns |    11.759 ns |    10.424 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     945.74 ns |    15.894 ns |    14.868 ns |    1136 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 137B         |     167.80 ns |     1.247 ns |     1.167 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 137B         |     177.36 ns |     0.883 ns |     0.782 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 137B         |     189.66 ns |     1.723 ns |     1.612 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 137B         |     297.50 ns |     4.458 ns |     4.170 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 137B         |     927.75 ns |    12.324 ns |    11.528 ns |    1136 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     629.62 ns |     4.436 ns |     4.149 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     663.24 ns |     4.686 ns |     4.383 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     716.56 ns |     2.368 ns |     1.978 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   2,994.58 ns |    51.377 ns |    45.544 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,159.35 ns |    52.996 ns |    49.572 ns |    2016 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1KB          |     626.59 ns |     3.167 ns |     2.962 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1KB          |     649.17 ns |     4.519 ns |     4.227 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1KB          |     717.32 ns |     4.035 ns |     3.577 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1KB          |   1,141.90 ns |    16.555 ns |    15.485 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1KB          |   3,119.64 ns |    54.199 ns |    50.697 ns |    2016 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     713.13 ns |     3.487 ns |     3.262 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     744.82 ns |     3.327 ns |     3.112 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     802.09 ns |     2.651 ns |     2.350 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   3,349.39 ns |    46.711 ns |    43.694 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,579.16 ns |    39.210 ns |    34.759 ns |    2024 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 1025B        |     710.67 ns |     3.351 ns |     3.134 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 1025B        |     732.08 ns |     4.183 ns |     3.913 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 1025B        |     802.51 ns |     4.684 ns |     3.912 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 1025B        |   1,287.53 ns |    13.290 ns |    11.781 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 1025B        |   3,651.03 ns |    71.800 ns |   102.974 ns |    2024 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   5,005.39 ns |    37.476 ns |    35.055 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,117.18 ns |    35.576 ns |    31.537 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,592.75 ns |    33.215 ns |    31.069 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |  23,767.84 ns |   436.453 ns |   408.259 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  24,247.81 ns |   124.810 ns |   110.641 ns |    9184 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 8KB          |   4,988.28 ns |    40.053 ns |    35.506 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 8KB          |   5,079.36 ns |    28.386 ns |    26.553 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 8KB          |   5,605.08 ns |    29.542 ns |    27.634 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 8KB          |   9,026.31 ns |    68.175 ns |    56.929 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 8KB          |  23,968.64 ns |   469.455 ns |   439.128 ns |    9184 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  79,760.62 ns |   383.722 ns |   340.159 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  81,338.34 ns |   488.100 ns |   432.687 ns |     248 B |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  89,258.04 ns |   260.648 ns |   231.058 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 379,956.29 ns | 6,970.219 ns | 6,519.947 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 415,607.24 ns | 8,302.629 ns | 8,154.292 ns |  132078 B |
+| TryComputeHash · BLAKE2b-256 · AVX2                     | 128KB        |  79,468.77 ns |   336.729 ns |   298.502 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Blake2Fast) | 128KB        |  81,122.90 ns |   572.712 ns |   535.715 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle             | 128KB        |  89,063.90 ns |   394.766 ns |   329.648 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                  | 128KB        | 144,746.77 ns | 1,873.272 ns | 1,660.607 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious)  | 128KB        | 407,703.38 ns | 6,372.705 ns | 5,961.032 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,31 +1,31 @@
-﻿| Description                                            | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128B         |     105.5 ns |     0.32 ns |     0.28 ns |         - |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 128B         |     107.6 ns |     0.36 ns |     0.34 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128B         |     369.3 ns |     2.07 ns |     1.84 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128B         |     501.0 ns |     3.82 ns |     3.19 ns |    1120 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 137B         |     187.1 ns |     0.62 ns |     0.58 ns |         - |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 137B         |     205.0 ns |     0.58 ns |     0.55 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 137B         |     724.2 ns |     4.25 ns |     3.32 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 137B         |     902.7 ns |     7.81 ns |     7.31 ns |    1136 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1KB          |     714.1 ns |     1.33 ns |     1.24 ns |         - |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 1KB          |     804.2 ns |    13.10 ns |    12.25 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1KB          |   2,846.8 ns |    14.99 ns |    13.29 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1KB          |   3,028.1 ns |    22.88 ns |    19.10 ns |    2016 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1025B        |     798.6 ns |     2.46 ns |     2.30 ns |         - |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 1025B        |     915.1 ns |    12.96 ns |    12.13 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 1025B        |   3,201.9 ns |    10.81 ns |    10.11 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1025B        |   3,445.0 ns |    19.81 ns |    17.56 ns |    2024 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 8KB          |   5,605.2 ns |    21.74 ns |    16.97 ns |         - |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 8KB          |   6,555.0 ns |    20.55 ns |    18.22 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 8KB          |  22,771.2 ns |   115.50 ns |   102.38 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 8KB          |  23,310.3 ns |   191.81 ns |   170.03 ns |    9184 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128KB        |  88,571.6 ns |   257.57 ns |   228.33 ns |         - |
-| TryComputeHash · BLAKE2b-256 · AVX2                    | 128KB        | 104,882.1 ns |   364.67 ns |   341.11 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Managed                 | 128KB        | 363,922.3 ns | 2,669.46 ns | 2,497.02 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128KB        | 395,481.9 ns | 1,828.77 ns | 1,621.16 ns |  132078 B |
+﻿| Description                                            | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 128B         |      87.94 ns |     1.610 ns |     1.506 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128B         |     100.98 ns |     0.911 ns |     0.852 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 128B         |     387.22 ns |     5.643 ns |     5.002 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128B         |     521.38 ns |    10.411 ns |    21.268 ns |    1120 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 137B         |     169.98 ns |     3.340 ns |     3.430 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 137B         |     195.94 ns |     2.320 ns |     2.170 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 137B         |     773.51 ns |    15.122 ns |    18.002 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 137B         |     974.25 ns |    19.510 ns |    33.654 ns |    1136 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 1KB          |     627.71 ns |     3.940 ns |     3.685 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1KB          |     727.01 ns |     6.611 ns |     5.860 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 1KB          |   3,007.04 ns |    57.602 ns |    70.740 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1KB          |   3,171.70 ns |    26.056 ns |    21.758 ns |    2016 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 1025B        |     732.88 ns |    13.855 ns |    15.400 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 1025B        |     808.27 ns |     6.412 ns |     5.998 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 1025B        |   3,356.09 ns |    66.615 ns |    74.043 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 1025B        |   3,602.54 ns |    65.236 ns |    61.022 ns |    2024 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 8KB          |   4,995.74 ns |    19.582 ns |    15.289 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 8KB          |   5,617.03 ns |    22.779 ns |    19.021 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 8KB          |  23,914.64 ns |   471.445 ns |   561.221 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 8KB          |  24,480.59 ns |   381.554 ns |   356.906 ns |    9184 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · AVX2                    | 128KB        |  84,448.81 ns | 1,647.164 ns | 2,752.042 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle            | 128KB        |  88,982.88 ns |   671.300 ns |   627.934 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Managed                 | 128KB        | 378,912.54 ns | 5,052.417 ns | 4,218.997 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BLAKE2b-256 (Konscious) | 128KB        | 414,485.68 ns | 7,916.450 ns | 8,129.611 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,31 +1,31 @@
-﻿| Description                                            | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128B         |     101.9 ns |     0.27 ns |     0.22 ns |         - |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 128B         |     110.3 ns |     0.29 ns |     0.26 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128B         |     371.5 ns |     2.23 ns |     1.97 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128B         |     506.8 ns |     4.75 ns |     4.44 ns |    1216 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 137B         |     190.3 ns |     0.78 ns |     0.73 ns |         - |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 137B         |     208.2 ns |     0.64 ns |     0.54 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 137B         |     723.6 ns |     4.20 ns |     3.73 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 137B         |     921.1 ns |     4.90 ns |     4.58 ns |    1232 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1KB          |     721.7 ns |     2.18 ns |     1.93 ns |         - |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 1KB          |     806.2 ns |    13.37 ns |    12.51 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1KB          |   2,849.7 ns |    10.94 ns |     9.14 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1KB          |   3,066.8 ns |    22.87 ns |    21.40 ns |    2112 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1025B        |     799.6 ns |     1.33 ns |     1.25 ns |         - |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 1025B        |     905.9 ns |    13.40 ns |    12.53 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1025B        |   3,228.4 ns |    62.55 ns |    52.23 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1025B        |   3,451.1 ns |    12.10 ns |    10.72 ns |    2120 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 8KB          |   5,614.0 ns |     9.76 ns |     9.13 ns |         - |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 8KB          |   6,559.6 ns |    14.95 ns |    13.98 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 8KB          |  22,714.0 ns |   181.67 ns |   169.93 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 8KB          |  23,311.8 ns |   164.21 ns |   153.61 ns |    9280 B |
-|                                                        |              |              |             |             |           |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128KB        |  88,791.3 ns |   375.62 ns |   332.97 ns |         - |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 128KB        | 104,956.3 ns |   303.52 ns |   283.91 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128KB        | 364,996.7 ns | 3,320.46 ns | 2,943.50 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128KB        | 396,224.7 ns | 2,294.31 ns | 2,033.84 ns |  132174 B |
+﻿| Description                                            | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 128B         |      87.74 ns |     0.489 ns |     0.457 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128B         |     104.92 ns |     0.978 ns |     0.817 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 128B         |     384.08 ns |     7.299 ns |     7.495 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128B         |     531.44 ns |    10.630 ns |    15.245 ns |    1216 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 137B         |     168.07 ns |     0.845 ns |     0.749 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 137B         |     186.91 ns |     3.166 ns |     2.961 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 137B         |     755.03 ns |    14.912 ns |    14.646 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 137B         |     969.46 ns |    16.571 ns |    15.500 ns |    1232 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 1KB          |     632.14 ns |     3.317 ns |     3.102 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1KB          |     723.32 ns |     5.715 ns |     5.346 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 1KB          |   2,984.66 ns |    57.453 ns |    53.741 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1KB          |   3,187.52 ns |    35.358 ns |    31.344 ns |    2112 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 1025B        |     715.55 ns |     4.179 ns |     3.909 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1025B        |     807.60 ns |     6.285 ns |     5.879 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 1025B        |   3,367.87 ns |    66.353 ns |    65.167 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1025B        |   3,630.80 ns |    65.039 ns |    57.656 ns |    2120 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 8KB          |   5,014.34 ns |    38.857 ns |    34.446 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 8KB          |   5,644.53 ns |    29.162 ns |    27.279 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 8KB          |  23,834.69 ns |   311.551 ns |   276.182 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 8KB          |  24,378.11 ns |   187.710 ns |   175.585 ns |    9280 B |
+|                                                        |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 128KB        |  80,025.78 ns |   358.905 ns |   335.720 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128KB        |  90,141.16 ns |   445.854 ns |   417.052 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 128KB        | 380,325.03 ns | 4,191.431 ns | 3,920.667 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128KB        | 417,042.78 ns | 4,849.698 ns | 4,536.410 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,37 +1,37 @@
 ﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
 |-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      87.04 ns |     0.637 ns |     0.565 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      98.92 ns |     0.927 ns |     0.821 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     104.30 ns |     0.759 ns |     0.710 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     156.79 ns |     2.495 ns |     2.334 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     521.20 ns |    10.200 ns |    15.576 ns |    1216 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      86.03 ns |     0.600 ns |     0.532 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |     100.90 ns |     1.932 ns |     1.897 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     104.13 ns |     0.253 ns |     0.225 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     178.16 ns |     1.034 ns |     0.916 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     543.03 ns |     9.037 ns |     8.453 ns |    1216 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     166.87 ns |     2.393 ns |     1.998 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     179.68 ns |     1.804 ns |     1.599 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     186.47 ns |     3.657 ns |     3.421 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     297.73 ns |     4.681 ns |     4.149 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     946.30 ns |    18.544 ns |    17.346 ns |    1232 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     167.61 ns |     0.971 ns |     0.908 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     177.70 ns |     0.538 ns |     0.450 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     186.26 ns |     3.723 ns |     3.824 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     339.67 ns |     2.471 ns |     2.311 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     930.45 ns |     7.830 ns |     7.324 ns |    1232 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     627.75 ns |     7.770 ns |     6.488 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     650.01 ns |     4.287 ns |     4.011 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     721.91 ns |     5.964 ns |     5.287 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   1,147.31 ns |    15.356 ns |    14.364 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,130.45 ns |    50.272 ns |    44.565 ns |    2112 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     625.91 ns |     2.600 ns |     2.304 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     650.03 ns |     4.762 ns |     4.454 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     717.67 ns |     2.016 ns |     1.886 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   1,287.70 ns |     4.170 ns |     3.901 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,089.76 ns |    19.595 ns |    18.329 ns |    2112 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     709.66 ns |     4.914 ns |     4.597 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     733.75 ns |     4.033 ns |     3.773 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     805.49 ns |     4.113 ns |     3.847 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   1,289.22 ns |    16.529 ns |    15.461 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,559.94 ns |    67.175 ns |    65.975 ns |    2120 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     711.66 ns |     6.036 ns |     5.646 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     732.17 ns |     4.650 ns |     4.350 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     806.89 ns |     5.274 ns |     4.404 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   1,465.99 ns |     8.604 ns |     8.049 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,509.01 ns |    23.648 ns |    22.120 ns |    2120 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,975.39 ns |    37.276 ns |    33.045 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,056.92 ns |     9.194 ns |     8.600 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,597.36 ns |    20.041 ns |    18.746 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   9,015.87 ns |    65.088 ns |    54.352 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  23,791.04 ns |   250.971 ns |   234.759 ns |    9280 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,971.42 ns |    20.580 ns |    18.243 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,071.71 ns |    28.543 ns |    26.699 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,590.79 ns |    19.342 ns |    17.146 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |  10,246.39 ns |    65.031 ns |    60.830 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  23,703.41 ns |   156.571 ns |   146.457 ns |    9280 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,381.02 ns |   510.445 ns |   452.496 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  81,268.23 ns |   245.821 ns |   229.941 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,067.50 ns |   202.408 ns |   189.332 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 146,038.19 ns | 2,057.717 ns | 1,924.790 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 404,870.66 ns | 7,102.644 ns | 6,643.818 ns |  132174 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,512.24 ns |   424.724 ns |   376.507 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  80,862.06 ns |   371.825 ns |   329.613 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,202.02 ns |   382.540 ns |   357.829 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 164,326.98 ns |   461.566 ns |   409.167 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 399,631.54 ns | 2,314.776 ns | 2,051.989 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,31 +1,37 @@
-﻿| Description                                            | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 128B         |      93.30 ns |     0.591 ns |     0.524 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128B         |     103.63 ns |     0.862 ns |     0.806 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128B         |     391.19 ns |     6.748 ns |     5.982 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128B         |     546.46 ns |    10.293 ns |    10.109 ns |    1216 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 137B         |     168.64 ns |     2.053 ns |     1.820 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 137B         |     184.92 ns |     1.468 ns |     1.373 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 137B         |     758.14 ns |     7.946 ns |     7.044 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 137B         |     981.01 ns |    10.051 ns |     8.393 ns |    1232 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 1KB          |     631.26 ns |     5.331 ns |     4.451 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1KB          |     737.01 ns |    14.751 ns |    15.784 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1KB          |   3,002.58 ns |    30.921 ns |    28.924 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1KB          |   3,227.18 ns |    63.402 ns |    77.863 ns |    2112 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 1025B        |     717.65 ns |     9.831 ns |     8.210 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1025B        |     817.71 ns |    12.836 ns |    12.007 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1025B        |   3,360.37 ns |    64.421 ns |    63.270 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1025B        |   3,636.10 ns |    46.117 ns |    43.138 ns |    2120 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 8KB          |   5,092.52 ns |    69.561 ns |    58.086 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 8KB          |   5,624.61 ns |    26.204 ns |    21.882 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 8KB          |  24,000.15 ns |   360.452 ns |   319.531 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 8KB          |  24,450.98 ns |   219.652 ns |   205.463 ns |    9280 B |
-|                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 128KB        |  79,929.28 ns |   525.261 ns |   465.630 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128KB        |  90,545.56 ns |   382.308 ns |   319.244 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128KB        | 378,555.34 ns | 3,928.400 ns | 3,482.424 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128KB        | 415,197.55 ns | 2,259.150 ns | 1,886.493 ns |  132174 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      87.59 ns |     0.703 ns |     0.658 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |     104.93 ns |     1.116 ns |     1.044 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     106.18 ns |     0.940 ns |     0.834 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     383.49 ns |     3.689 ns |     3.451 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     540.80 ns |    10.546 ns |    12.952 ns |    1216 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     168.10 ns |     1.742 ns |     1.629 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     186.48 ns |     1.380 ns |     1.223 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     186.66 ns |     2.993 ns |     2.800 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     756.01 ns |    15.124 ns |    14.854 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     965.53 ns |    14.504 ns |    13.567 ns |    1232 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     631.13 ns |     3.250 ns |     2.881 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     664.95 ns |     6.370 ns |     5.958 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     718.99 ns |     3.042 ns |     2.540 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   2,963.21 ns |    58.295 ns |    57.253 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,215.27 ns |    55.874 ns |    52.265 ns |    2112 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     712.50 ns |     3.052 ns |     2.855 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     744.04 ns |     2.464 ns |     2.184 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     805.80 ns |     4.341 ns |     3.848 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   3,341.11 ns |    50.841 ns |    47.557 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,606.81 ns |    46.034 ns |    43.060 ns |    2120 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,997.54 ns |    36.832 ns |    34.453 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,105.87 ns |    35.919 ns |    33.598 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,598.33 ns |    30.760 ns |    27.268 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |  23,686.20 ns |   455.429 ns |   447.293 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  24,609.50 ns |   457.961 ns |   405.970 ns |    9280 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,540.96 ns |   387.160 ns |   362.150 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  80,872.45 ns |   299.737 ns |   280.374 ns |     248 B |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,423.54 ns |   477.313 ns |   446.479 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 379,934.15 ns | 6,357.846 ns | 5,947.133 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 407,176.06 ns | 5,173.561 ns | 4,586.227 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,37 +1,37 @@
 ﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
 |-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      87.59 ns |     0.703 ns |     0.658 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |     104.93 ns |     1.116 ns |     1.044 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     106.18 ns |     0.940 ns |     0.834 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     383.49 ns |     3.689 ns |     3.451 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     540.80 ns |    10.546 ns |    12.952 ns |    1216 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      87.04 ns |     0.637 ns |     0.565 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      98.92 ns |     0.927 ns |     0.821 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     104.30 ns |     0.759 ns |     0.710 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     156.79 ns |     2.495 ns |     2.334 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     521.20 ns |    10.200 ns |    15.576 ns |    1216 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     168.10 ns |     1.742 ns |     1.629 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     186.48 ns |     1.380 ns |     1.223 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     186.66 ns |     2.993 ns |     2.800 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     756.01 ns |    15.124 ns |    14.854 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     965.53 ns |    14.504 ns |    13.567 ns |    1232 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     166.87 ns |     2.393 ns |     1.998 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     179.68 ns |     1.804 ns |     1.599 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     186.47 ns |     3.657 ns |     3.421 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     297.73 ns |     4.681 ns |     4.149 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     946.30 ns |    18.544 ns |    17.346 ns |    1232 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     631.13 ns |     3.250 ns |     2.881 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     664.95 ns |     6.370 ns |     5.958 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     718.99 ns |     3.042 ns |     2.540 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   2,963.21 ns |    58.295 ns |    57.253 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,215.27 ns |    55.874 ns |    52.265 ns |    2112 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     627.75 ns |     7.770 ns |     6.488 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     650.01 ns |     4.287 ns |     4.011 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     721.91 ns |     5.964 ns |     5.287 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   1,147.31 ns |    15.356 ns |    14.364 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,130.45 ns |    50.272 ns |    44.565 ns |    2112 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     712.50 ns |     3.052 ns |     2.855 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     744.04 ns |     2.464 ns |     2.184 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     805.80 ns |     4.341 ns |     3.848 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   3,341.11 ns |    50.841 ns |    47.557 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,606.81 ns |    46.034 ns |    43.060 ns |    2120 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     709.66 ns |     4.914 ns |     4.597 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     733.75 ns |     4.033 ns |     3.773 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     805.49 ns |     4.113 ns |     3.847 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   1,289.22 ns |    16.529 ns |    15.461 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,559.94 ns |    67.175 ns |    65.975 ns |    2120 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,997.54 ns |    36.832 ns |    34.453 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,105.87 ns |    35.919 ns |    33.598 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,598.33 ns |    30.760 ns |    27.268 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |  23,686.20 ns |   455.429 ns |   447.293 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  24,609.50 ns |   457.961 ns |   405.970 ns |    9280 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,975.39 ns |    37.276 ns |    33.045 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,056.92 ns |     9.194 ns |     8.600 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,597.36 ns |    20.041 ns |    18.746 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   9,015.87 ns |    65.088 ns |    54.352 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  23,791.04 ns |   250.971 ns |   234.759 ns |    9280 B |
 |                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,540.96 ns |   387.160 ns |   362.150 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  80,872.45 ns |   299.737 ns |   280.374 ns |     248 B |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,423.54 ns |   477.313 ns |   446.479 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 379,934.15 ns | 6,357.846 ns | 5,947.133 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 407,176.06 ns | 5,173.561 ns | 4,586.227 ns |  132174 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,381.02 ns |   510.445 ns |   452.496 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  81,268.23 ns |   245.821 ns |   229.941 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,067.50 ns |   202.408 ns |   189.332 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 146,038.19 ns | 2,057.717 ns | 1,924.790 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 404,870.66 ns | 7,102.644 ns | 6,643.818 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      86.00 ns |     1.038 ns |     0.971 ns |      85.95 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      99.35 ns |     1.108 ns |     1.037 ns |      99.00 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     103.29 ns |     1.245 ns |     1.164 ns |     102.97 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     136.60 ns |     1.905 ns |     1.591 ns |     136.58 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     525.00 ns |    10.487 ns |    19.953 ns |     515.60 ns |    1216 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     167.92 ns |     1.070 ns |     1.001 ns |     167.83 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     179.02 ns |     1.151 ns |     1.077 ns |     178.90 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     185.39 ns |     3.057 ns |     2.859 ns |     186.06 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     259.12 ns |     5.017 ns |     6.523 ns |     256.78 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     952.02 ns |    19.005 ns |    21.887 ns |     951.86 ns |    1232 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     630.22 ns |     3.850 ns |     3.601 ns |     628.79 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     649.39 ns |     2.919 ns |     2.279 ns |     649.16 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     728.13 ns |     3.260 ns |     3.049 ns |     727.81 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     976.88 ns |    19.193 ns |    20.537 ns |     968.45 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,152.70 ns |    57.946 ns |    51.367 ns |   3,145.98 ns |    2112 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     711.36 ns |     3.915 ns |     3.662 ns |     709.83 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     735.19 ns |     4.353 ns |     4.072 ns |     733.75 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     809.10 ns |     4.297 ns |     4.019 ns |     808.54 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   1,108.03 ns |    22.140 ns |    21.744 ns |   1,099.31 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,619.11 ns |    71.746 ns |    67.111 ns |   3,597.04 ns |    2120 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,977.64 ns |    29.231 ns |    27.343 ns |   4,979.30 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,094.11 ns |    37.533 ns |    35.108 ns |   5,083.28 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,594.71 ns |    23.816 ns |    22.278 ns |   5,590.93 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   7,714.45 ns |   138.236 ns |   122.542 ns |   7,743.02 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  24,028.93 ns |   479.074 ns |   491.974 ns |  23,932.05 ns |    9280 B |
-|                                                         |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,356.52 ns |   351.857 ns |   293.816 ns |  79,325.20 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  81,126.81 ns |   477.077 ns |   446.258 ns |  80,947.47 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,266.18 ns |   523.788 ns |   437.387 ns |  89,211.81 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 122,427.12 ns | 1,784.676 ns | 1,669.387 ns | 121,847.58 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 407,919.43 ns | 7,878.411 ns | 8,756.833 ns | 406,472.80 ns |  132174 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      85.97 ns |     1.157 ns |     1.082 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      99.44 ns |     1.300 ns |     1.216 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     102.35 ns |     1.085 ns |     1.015 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     138.25 ns |     2.679 ns |     2.631 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     529.55 ns |    10.617 ns |    20.201 ns |    1216 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     167.77 ns |     0.918 ns |     0.767 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     179.70 ns |     1.812 ns |     1.607 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     184.38 ns |     2.647 ns |     2.476 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     259.29 ns |     4.676 ns |     4.146 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     963.20 ns |    14.382 ns |    13.453 ns |    1232 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     628.78 ns |     2.889 ns |     2.702 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     650.68 ns |     3.782 ns |     3.538 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     720.43 ns |     5.740 ns |     5.369 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     990.22 ns |    19.766 ns |    28.973 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,164.30 ns |    60.460 ns |    64.691 ns |    2112 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     712.47 ns |     4.229 ns |     3.956 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     732.46 ns |     2.398 ns |     2.002 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     803.96 ns |     4.172 ns |     3.484 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   1,106.75 ns |    21.722 ns |    25.858 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,557.07 ns |    49.337 ns |    43.736 ns |    2120 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,958.14 ns |    15.924 ns |    14.116 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,075.71 ns |    24.351 ns |    21.587 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,600.21 ns |    12.466 ns |    11.051 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   7,743.88 ns |   145.249 ns |   142.654 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  24,015.72 ns |   480.204 ns |   449.183 ns |    9280 B |
+|                                                         |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,262.04 ns |   240.617 ns |   213.301 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  80,661.74 ns |   166.099 ns |   129.679 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,005.69 ns |   210.637 ns |   186.725 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 122,989.17 ns |   694.614 ns |   649.742 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 407,704.50 ns | 7,375.880 ns | 6,899.402 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,31 +1,31 @@
 ﻿| Description                                            | TestDataSize | Mean          | Error        | StdDev       | Allocated |
 |------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 128B         |      87.74 ns |     0.489 ns |     0.457 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128B         |     104.92 ns |     0.978 ns |     0.817 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128B         |     384.08 ns |     7.299 ns |     7.495 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128B         |     531.44 ns |    10.630 ns |    15.245 ns |    1216 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 128B         |      93.30 ns |     0.591 ns |     0.524 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128B         |     103.63 ns |     0.862 ns |     0.806 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 128B         |     391.19 ns |     6.748 ns |     5.982 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128B         |     546.46 ns |    10.293 ns |    10.109 ns |    1216 B |
 |                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 137B         |     168.07 ns |     0.845 ns |     0.749 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 137B         |     186.91 ns |     3.166 ns |     2.961 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 137B         |     755.03 ns |    14.912 ns |    14.646 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 137B         |     969.46 ns |    16.571 ns |    15.500 ns |    1232 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 137B         |     168.64 ns |     2.053 ns |     1.820 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 137B         |     184.92 ns |     1.468 ns |     1.373 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 137B         |     758.14 ns |     7.946 ns |     7.044 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 137B         |     981.01 ns |    10.051 ns |     8.393 ns |    1232 B |
 |                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 1KB          |     632.14 ns |     3.317 ns |     3.102 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1KB          |     723.32 ns |     5.715 ns |     5.346 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1KB          |   2,984.66 ns |    57.453 ns |    53.741 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1KB          |   3,187.52 ns |    35.358 ns |    31.344 ns |    2112 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 1KB          |     631.26 ns |     5.331 ns |     4.451 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1KB          |     737.01 ns |    14.751 ns |    15.784 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 1KB          |   3,002.58 ns |    30.921 ns |    28.924 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1KB          |   3,227.18 ns |    63.402 ns |    77.863 ns |    2112 B |
 |                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 1025B        |     715.55 ns |     4.179 ns |     3.909 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1025B        |     807.60 ns |     6.285 ns |     5.879 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 1025B        |   3,367.87 ns |    66.353 ns |    65.167 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1025B        |   3,630.80 ns |    65.039 ns |    57.656 ns |    2120 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 1025B        |     717.65 ns |     9.831 ns |     8.210 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 1025B        |     817.71 ns |    12.836 ns |    12.007 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 1025B        |   3,360.37 ns |    64.421 ns |    63.270 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 1025B        |   3,636.10 ns |    46.117 ns |    43.138 ns |    2120 B |
 |                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 8KB          |   5,014.34 ns |    38.857 ns |    34.446 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 8KB          |   5,644.53 ns |    29.162 ns |    27.279 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 8KB          |  23,834.69 ns |   311.551 ns |   276.182 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 8KB          |  24,378.11 ns |   187.710 ns |   175.585 ns |    9280 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 8KB          |   5,092.52 ns |    69.561 ns |    58.086 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 8KB          |   5,624.61 ns |    26.204 ns |    21.882 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 8KB          |  24,000.15 ns |   360.452 ns |   319.531 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 8KB          |  24,450.98 ns |   219.652 ns |   205.463 ns |    9280 B |
 |                                                        |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                    | 128KB        |  80,025.78 ns |   358.905 ns |   335.720 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128KB        |  90,141.16 ns |   445.854 ns |   417.052 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                 | 128KB        | 380,325.03 ns | 4,191.431 ns | 3,920.667 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128KB        | 417,042.78 ns | 4,849.698 ns | 4,536.410 ns |  132174 B |
+| TryComputeHash · BLAKE2b-512 · AVX2                    | 128KB        |  79,929.28 ns |   525.261 ns |   465.630 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle            | 128KB        |  90,545.56 ns |   382.308 ns |   319.244 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                 | 128KB        | 378,555.34 ns | 3,928.400 ns | 3,482.424 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious) | 128KB        | 415,197.55 ns | 2,259.150 ns | 1,886.493 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,37 +1,37 @@
-﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      86.03 ns |     0.600 ns |     0.532 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |     100.90 ns |     1.932 ns |     1.897 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     104.13 ns |     0.253 ns |     0.225 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     178.16 ns |     1.034 ns |     0.916 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     543.03 ns |     9.037 ns |     8.453 ns |    1216 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     167.61 ns |     0.971 ns |     0.908 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     177.70 ns |     0.538 ns |     0.450 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     186.26 ns |     3.723 ns |     3.824 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     339.67 ns |     2.471 ns |     2.311 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     930.45 ns |     7.830 ns |     7.324 ns |    1232 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     625.91 ns |     2.600 ns |     2.304 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     650.03 ns |     4.762 ns |     4.454 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     717.67 ns |     2.016 ns |     1.886 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |   1,287.70 ns |     4.170 ns |     3.901 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,089.76 ns |    19.595 ns |    18.329 ns |    2112 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     711.66 ns |     6.036 ns |     5.646 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     732.17 ns |     4.650 ns |     4.350 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     806.89 ns |     5.274 ns |     4.404 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   1,465.99 ns |     8.604 ns |     8.049 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,509.01 ns |    23.648 ns |    22.120 ns |    2120 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,971.42 ns |    20.580 ns |    18.243 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,071.71 ns |    28.543 ns |    26.699 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,590.79 ns |    19.342 ns |    17.146 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |  10,246.39 ns |    65.031 ns |    60.830 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  23,703.41 ns |   156.571 ns |   146.457 ns |    9280 B |
-|                                                         |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,512.24 ns |   424.724 ns |   376.507 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  80,862.06 ns |   371.825 ns |   329.613 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,202.02 ns |   382.540 ns |   357.829 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 164,326.98 ns |   461.566 ns |   409.167 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 399,631.54 ns | 2,314.776 ns | 2,051.989 ns |  132174 B |
+﻿| Description                                             | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
+|-------------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128B         |      86.00 ns |     1.038 ns |     0.971 ns |      85.95 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128B         |      99.35 ns |     1.108 ns |     1.037 ns |      99.00 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128B         |     103.29 ns |     1.245 ns |     1.164 ns |     102.97 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128B         |     136.60 ns |     1.905 ns |     1.591 ns |     136.58 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128B         |     525.00 ns |    10.487 ns |    19.953 ns |     515.60 ns |    1216 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 137B         |     167.92 ns |     1.070 ns |     1.001 ns |     167.83 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 137B         |     179.02 ns |     1.151 ns |     1.077 ns |     178.90 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 137B         |     185.39 ns |     3.057 ns |     2.859 ns |     186.06 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 137B         |     259.12 ns |     5.017 ns |     6.523 ns |     256.78 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 137B         |     952.02 ns |    19.005 ns |    21.887 ns |     951.86 ns |    1232 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1KB          |     630.22 ns |     3.850 ns |     3.601 ns |     628.79 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1KB          |     649.39 ns |     2.919 ns |     2.279 ns |     649.16 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1KB          |     728.13 ns |     3.260 ns |     3.049 ns |     727.81 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1KB          |     976.88 ns |    19.193 ns |    20.537 ns |     968.45 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1KB          |   3,152.70 ns |    57.946 ns |    51.367 ns |   3,145.98 ns |    2112 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 1025B        |     711.36 ns |     3.915 ns |     3.662 ns |     709.83 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 1025B        |     735.19 ns |     4.353 ns |     4.072 ns |     733.75 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 1025B        |     809.10 ns |     4.297 ns |     4.019 ns |     808.54 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 1025B        |   1,108.03 ns |    22.140 ns |    21.744 ns |   1,099.31 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 1025B        |   3,619.11 ns |    71.746 ns |    67.111 ns |   3,597.04 ns |    2120 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 8KB          |   4,977.64 ns |    29.231 ns |    27.343 ns |   4,979.30 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 8KB          |   5,094.11 ns |    37.533 ns |    35.108 ns |   5,083.28 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 8KB          |   5,594.71 ns |    23.816 ns |    22.278 ns |   5,590.93 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 8KB          |   7,714.45 ns |   138.236 ns |   122.542 ns |   7,743.02 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 8KB          |  24,028.93 ns |   479.074 ns |   491.974 ns |  23,932.05 ns |    9280 B |
+|                                                         |              |               |              |              |               |           |
+| TryComputeHash · BLAKE2b-512 · AVX2                     | 128KB        |  79,356.52 ns |   351.857 ns |   293.816 ns |  79,325.20 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Blake2Fast) | 128KB        |  81,126.81 ns |   477.077 ns |   446.258 ns |  80,947.47 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle             | 128KB        |  89,266.18 ns |   523.788 ns |   437.387 ns |  89,211.81 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Managed                  | 128KB        | 122,427.12 ns | 1,784.676 ns | 1,669.387 ns | 121,847.58 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BLAKE2b-512 (Konscious)  | 128KB        | 407,919.43 ns | 7,878.411 ns | 8,756.833 ns | 406,472.80 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
@@ -1,43 +1,31 @@
 ﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     156.7 ns |     1.16 ns |     1.03 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     157.4 ns |     1.08 ns |     1.01 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     159.2 ns |     0.92 ns |     0.86 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     159.5 ns |     1.62 ns |     1.51 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     159.6 ns |     1.29 ns |     1.20 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     162.5 ns |     2.97 ns |     2.78 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     156.4 ns |     1.12 ns |     1.05 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     157.4 ns |     2.13 ns |     1.99 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     159.8 ns |     1.09 ns |     1.02 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     161.9 ns |     2.91 ns |     2.72 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     229.0 ns |     1.01 ns |     0.89 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     236.4 ns |     1.25 ns |     1.17 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     237.9 ns |     2.56 ns |     2.40 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     239.8 ns |     1.71 ns |     1.60 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     240.7 ns |     1.03 ns |     0.92 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     243.8 ns |     2.11 ns |     1.97 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     227.3 ns |     0.83 ns |     0.77 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     235.5 ns |     1.22 ns |     1.02 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     237.4 ns |     3.30 ns |     2.75 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     240.2 ns |     2.49 ns |     2.08 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,138.0 ns |     5.07 ns |     4.23 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   1,216.1 ns |    22.90 ns |    23.52 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,219.0 ns |     5.37 ns |     5.02 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,220.2 ns |     4.58 ns |     4.06 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,230.3 ns |     4.23 ns |     3.75 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,243.1 ns |     9.69 ns |     9.06 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,142.0 ns |     7.61 ns |     7.12 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   1,211.9 ns |    14.78 ns |    13.82 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,215.4 ns |     5.48 ns |     5.12 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,232.5 ns |    10.24 ns |     9.58 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,212.1 ns |     5.59 ns |     5.23 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   1,293.3 ns |    23.63 ns |    25.29 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,294.4 ns |     7.20 ns |     6.74 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,302.1 ns |     8.93 ns |     7.92 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,307.7 ns |     6.62 ns |     6.19 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,325.9 ns |     7.34 ns |     6.87 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,222.9 ns |    10.26 ns |     9.09 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   1,289.4 ns |    10.02 ns |     9.37 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,299.1 ns |     8.31 ns |     7.37 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,307.0 ns |     7.58 ns |     6.72 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,003.1 ns |    26.71 ns |    22.31 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |   9,680.6 ns |   190.03 ns |   203.33 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,715.3 ns |    71.32 ns |    63.22 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,738.5 ns |    57.04 ns |    53.35 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,740.8 ns |    48.03 ns |    44.93 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,884.5 ns |    51.24 ns |    47.93 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,029.6 ns |    54.63 ns |    48.43 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |   9,575.4 ns |    87.52 ns |    81.87 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,663.9 ns |    38.08 ns |    33.75 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,783.9 ns |   124.71 ns |   116.66 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 143,827.0 ns |   553.69 ns |   462.36 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 153,394.7 ns | 2,383.20 ns | 2,229.25 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 154,605.9 ns | 1,004.92 ns |   890.84 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,611.6 ns |   383.71 ns |   320.42 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 156,049.9 ns |   981.13 ns |   917.75 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,754.2 ns | 1,311.94 ns | 1,227.19 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 145,986.2 ns | 2,369.96 ns | 2,216.86 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 153,683.3 ns | 1,147.98 ns | 1,017.65 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 154,482.8 ns |   803.94 ns |   752.01 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 155,453.0 ns |   890.28 ns |   832.77 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
@@ -1,43 +1,43 @@
 ﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     155.6 ns |     1.08 ns |     1.01 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     157.0 ns |     0.50 ns |     0.47 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     158.0 ns |     1.17 ns |     1.10 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     160.4 ns |     1.08 ns |     1.01 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     160.9 ns |     1.09 ns |     1.02 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     599.6 ns |     3.98 ns |     3.73 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     156.7 ns |     1.16 ns |     1.03 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     157.4 ns |     1.08 ns |     1.01 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     159.2 ns |     0.92 ns |     0.86 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     159.5 ns |     1.62 ns |     1.51 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     159.6 ns |     1.29 ns |     1.20 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     162.5 ns |     2.97 ns |     2.78 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     228.1 ns |     1.24 ns |     1.16 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     238.7 ns |     1.72 ns |     1.52 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     240.2 ns |     1.56 ns |     1.46 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     242.5 ns |     1.87 ns |     1.66 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     244.7 ns |     1.51 ns |     1.41 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     894.8 ns |     4.04 ns |     3.78 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     229.0 ns |     1.01 ns |     0.89 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     236.4 ns |     1.25 ns |     1.17 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     237.9 ns |     2.56 ns |     2.40 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     239.8 ns |     1.71 ns |     1.60 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     240.7 ns |     1.03 ns |     0.92 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     243.8 ns |     2.11 ns |     1.97 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,142.2 ns |     6.26 ns |     5.86 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,217.0 ns |     7.36 ns |     6.89 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,218.6 ns |     3.89 ns |     3.24 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,230.2 ns |     7.86 ns |     7.36 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,248.7 ns |     7.32 ns |     6.85 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   4,705.2 ns |    37.84 ns |    35.39 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,138.0 ns |     5.07 ns |     4.23 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   1,216.1 ns |    22.90 ns |    23.52 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,219.0 ns |     5.37 ns |     5.02 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,220.2 ns |     4.58 ns |     4.06 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,230.3 ns |     4.23 ns |     3.75 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,243.1 ns |     9.69 ns |     9.06 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,215.2 ns |     8.54 ns |     7.99 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,296.0 ns |     1.06 ns |     0.89 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,299.8 ns |    10.74 ns |    10.04 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,308.7 ns |     8.76 ns |     8.20 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,328.5 ns |     3.33 ns |     3.12 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,004.1 ns |    35.23 ns |    32.95 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,212.1 ns |     5.59 ns |     5.23 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   1,293.3 ns |    23.63 ns |    25.29 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,294.4 ns |     7.20 ns |     6.74 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,302.1 ns |     8.93 ns |     7.92 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,307.7 ns |     6.62 ns |     6.19 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,325.9 ns |     7.34 ns |     6.87 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,005.2 ns |    26.33 ns |    24.63 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,638.4 ns |    32.33 ns |    30.24 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,670.7 ns |    48.42 ns |    40.43 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,699.4 ns |    10.90 ns |    10.19 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,905.0 ns |    13.65 ns |    12.77 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  37,405.3 ns |   148.42 ns |   131.57 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,003.1 ns |    26.71 ns |    22.31 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |   9,680.6 ns |   190.03 ns |   203.33 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,715.3 ns |    71.32 ns |    63.22 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,738.5 ns |    57.04 ns |    53.35 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,740.8 ns |    48.03 ns |    44.93 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,884.5 ns |    51.24 ns |    47.93 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 143,956.7 ns |   418.43 ns |   391.40 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 153,895.8 ns |   490.64 ns |   458.94 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 154,549.4 ns |   657.81 ns |   615.32 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,890.4 ns |   223.80 ns |   209.34 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,461.0 ns |   241.72 ns |   226.11 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 597,035.8 ns | 2,047.81 ns | 1,710.01 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 143,827.0 ns |   553.69 ns |   462.36 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 153,394.7 ns | 2,383.20 ns | 2,229.25 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 154,605.9 ns | 1,004.92 ns |   890.84 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,611.6 ns |   383.71 ns |   320.42 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 156,049.9 ns |   981.13 ns |   917.75 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,754.2 ns | 1,311.94 ns | 1,227.19 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
@@ -1,37 +1,43 @@
-﻿| Description                                 | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-128 · Ssse3        | 128B         |     157.3 ns |     0.50 ns |     0.47 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2         | 128B         |     158.6 ns |     0.98 ns |     0.92 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2         | 128B         |     160.2 ns |     0.31 ns |     0.29 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle | 128B         |     162.0 ns |     1.27 ns |     1.13 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed      | 128B         |     595.9 ns |     4.89 ns |     4.57 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · AVX2         | 137B         |     236.6 ns |     1.07 ns |     1.00 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3        | 137B         |     239.4 ns |     0.48 ns |     0.42 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle | 137B         |     243.2 ns |     0.81 ns |     0.76 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2         | 137B         |     244.1 ns |     0.46 ns |     0.43 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed      | 137B         |     890.6 ns |     4.42 ns |     4.14 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · AVX2         | 1KB          |   1,212.7 ns |     5.83 ns |     5.45 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3        | 1KB          |   1,215.7 ns |     1.42 ns |     1.33 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle | 1KB          |   1,234.2 ns |     1.27 ns |     1.06 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2         | 1KB          |   1,241.6 ns |     1.77 ns |     1.66 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed      | 1KB          |   4,673.5 ns |    30.65 ns |    27.17 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · AVX2         | 1025B        |   1,291.4 ns |     4.96 ns |     4.39 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3        | 1025B        |   1,296.8 ns |     1.52 ns |     1.42 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle | 1025B        |   1,308.6 ns |     2.27 ns |     2.13 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2         | 1025B        |   1,324.6 ns |     0.94 ns |     0.83 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed      | 1025B        |   4,986.0 ns |    49.93 ns |    44.26 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · AVX2         | 8KB          |   9,644.9 ns |    28.39 ns |    25.17 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle | 8KB          |   9,652.7 ns |    26.29 ns |    23.30 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3        | 8KB          |   9,683.0 ns |    13.84 ns |    12.27 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2         | 8KB          |   9,886.9 ns |     9.56 ns |     8.47 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed      | 8KB          |  37,531.4 ns |   528.04 ns |   440.94 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle | 128KB        | 154,333.8 ns |   682.76 ns |   570.13 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2         | 128KB        | 154,389.9 ns |   876.43 ns |   776.94 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3        | 128KB        | 154,900.2 ns |   171.03 ns |   159.98 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2         | 128KB        | 158,113.3 ns |   238.41 ns |   211.34 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed      | 128KB        | 596,021.5 ns | 3,885.56 ns | 3,634.56 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     158.0 ns |     0.76 ns |     0.71 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     158.7 ns |     0.55 ns |     0.49 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     158.9 ns |     1.20 ns |     0.94 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     160.1 ns |     0.78 ns |     0.73 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     161.0 ns |     0.63 ns |     0.59 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     607.9 ns |    10.28 ns |     9.62 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     231.9 ns |     0.55 ns |     0.51 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     238.4 ns |     2.00 ns |     1.78 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     240.2 ns |     0.56 ns |     0.52 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     244.6 ns |     1.43 ns |     1.34 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     244.6 ns |     0.60 ns |     0.56 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     908.7 ns |    11.46 ns |    10.72 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,144.7 ns |     3.63 ns |     3.39 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,219.3 ns |     5.90 ns |     5.23 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,219.4 ns |     1.98 ns |     1.76 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,227.2 ns |     3.01 ns |     2.81 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,245.0 ns |     1.55 ns |     1.37 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   4,815.4 ns |    94.95 ns |   123.47 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,216.6 ns |     4.91 ns |     4.60 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,297.2 ns |     6.32 ns |     5.60 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,299.2 ns |     1.35 ns |     1.20 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,303.3 ns |     4.98 ns |     4.66 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,328.7 ns |     1.90 ns |     1.69 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,065.4 ns |    97.72 ns |   104.56 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,034.4 ns |    42.30 ns |    39.57 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,657.2 ns |    26.66 ns |    23.63 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,717.9 ns |    70.87 ns |    66.29 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,720.7 ns |    20.73 ns |    18.37 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,908.9 ns |    22.64 ns |    20.07 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  37,886.7 ns |   750.02 ns |   664.87 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 144,031.9 ns |   536.53 ns |   501.87 ns |     136 B |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 153,741.5 ns |   318.87 ns |   282.67 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,956.5 ns |   218.84 ns |   204.70 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 155,415.0 ns | 1,088.94 ns | 1,018.60 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,493.9 ns |   314.22 ns |   293.92 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 605,164.8 ns | 7,953.89 ns | 7,050.92 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
@@ -1,43 +1,43 @@
-﻿| Description                                             | TestDataSize | Mean         | Error        | StdDev       | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     155.7 ns |      0.58 ns |      0.51 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     157.9 ns |      1.20 ns |      1.12 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     158.6 ns |      0.62 ns |      0.58 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     158.7 ns |      1.00 ns |      0.89 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     161.1 ns |      1.20 ns |      1.12 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     607.1 ns |     10.52 ns |      9.84 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     227.3 ns |      0.32 ns |      0.30 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     237.7 ns |      1.16 ns |      1.03 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     239.8 ns |      0.45 ns |      0.42 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     242.7 ns |      0.78 ns |      0.73 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     244.1 ns |      0.34 ns |      0.29 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     908.7 ns |     14.29 ns |     13.37 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,140.1 ns |      4.10 ns |      3.83 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,212.5 ns |      4.71 ns |      4.18 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,218.3 ns |      1.30 ns |      1.21 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,231.5 ns |      6.43 ns |      6.01 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,246.1 ns |      1.65 ns |      1.55 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   4,752.6 ns |     91.89 ns |     85.96 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,209.1 ns |      3.59 ns |      3.00 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,293.7 ns |      2.69 ns |      2.39 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,298.8 ns |      1.96 ns |      1.74 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,305.6 ns |      4.09 ns |      3.62 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,327.8 ns |      2.20 ns |      1.95 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,027.1 ns |     73.74 ns |     68.97 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,009.1 ns |     37.17 ns |     34.77 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,633.7 ns |     27.19 ns |     25.43 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,675.5 ns |     33.05 ns |     30.92 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,700.8 ns |      9.82 ns |      8.71 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,890.5 ns |     17.38 ns |     16.26 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  37,797.2 ns |    588.44 ns |    550.43 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 144,012.4 ns |    467.75 ns |    414.65 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 153,897.9 ns |    398.12 ns |    352.92 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 154,663.5 ns |  1,151.18 ns |    961.29 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,861.5 ns |    143.94 ns |    127.60 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,433.0 ns |    218.83 ns |    204.70 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 606,575.6 ns | 11,435.06 ns | 11,230.76 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     155.6 ns |     1.08 ns |     1.01 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     157.0 ns |     0.50 ns |     0.47 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     158.0 ns |     1.17 ns |     1.10 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     160.4 ns |     1.08 ns |     1.01 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     160.9 ns |     1.09 ns |     1.02 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     599.6 ns |     3.98 ns |     3.73 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     228.1 ns |     1.24 ns |     1.16 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     238.7 ns |     1.72 ns |     1.52 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     240.2 ns |     1.56 ns |     1.46 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     242.5 ns |     1.87 ns |     1.66 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     244.7 ns |     1.51 ns |     1.41 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     894.8 ns |     4.04 ns |     3.78 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,142.2 ns |     6.26 ns |     5.86 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,217.0 ns |     7.36 ns |     6.89 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,218.6 ns |     3.89 ns |     3.24 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,230.2 ns |     7.86 ns |     7.36 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,248.7 ns |     7.32 ns |     6.85 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   4,705.2 ns |    37.84 ns |    35.39 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,215.2 ns |     8.54 ns |     7.99 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,296.0 ns |     1.06 ns |     0.89 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,299.8 ns |    10.74 ns |    10.04 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,308.7 ns |     8.76 ns |     8.20 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,328.5 ns |     3.33 ns |     3.12 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,004.1 ns |    35.23 ns |    32.95 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,005.2 ns |    26.33 ns |    24.63 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,638.4 ns |    32.33 ns |    30.24 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,670.7 ns |    48.42 ns |    40.43 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,699.4 ns |    10.90 ns |    10.19 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,905.0 ns |    13.65 ns |    12.77 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  37,405.3 ns |   148.42 ns |   131.57 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 143,956.7 ns |   418.43 ns |   391.40 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 153,895.8 ns |   490.64 ns |   458.94 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 154,549.4 ns |   657.81 ns |   615.32 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,890.4 ns |   223.80 ns |   209.34 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,461.0 ns |   241.72 ns |   226.11 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 597,035.8 ns | 2,047.81 ns | 1,710.01 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
@@ -1,43 +1,43 @@
-﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     158.0 ns |     0.76 ns |     0.71 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     158.7 ns |     0.55 ns |     0.49 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     158.9 ns |     1.20 ns |     0.94 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     160.1 ns |     0.78 ns |     0.73 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     161.0 ns |     0.63 ns |     0.59 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     607.9 ns |    10.28 ns |     9.62 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     231.9 ns |     0.55 ns |     0.51 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     238.4 ns |     2.00 ns |     1.78 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     240.2 ns |     0.56 ns |     0.52 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     244.6 ns |     1.43 ns |     1.34 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     244.6 ns |     0.60 ns |     0.56 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     908.7 ns |    11.46 ns |    10.72 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,144.7 ns |     3.63 ns |     3.39 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,219.3 ns |     5.90 ns |     5.23 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,219.4 ns |     1.98 ns |     1.76 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,227.2 ns |     3.01 ns |     2.81 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,245.0 ns |     1.55 ns |     1.37 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   4,815.4 ns |    94.95 ns |   123.47 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,216.6 ns |     4.91 ns |     4.60 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,297.2 ns |     6.32 ns |     5.60 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,299.2 ns |     1.35 ns |     1.20 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,303.3 ns |     4.98 ns |     4.66 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,328.7 ns |     1.90 ns |     1.69 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,065.4 ns |    97.72 ns |   104.56 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,034.4 ns |    42.30 ns |    39.57 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,657.2 ns |    26.66 ns |    23.63 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,717.9 ns |    70.87 ns |    66.29 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,720.7 ns |    20.73 ns |    18.37 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,908.9 ns |    22.64 ns |    20.07 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  37,886.7 ns |   750.02 ns |   664.87 ns |         - |
-|                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 144,031.9 ns |   536.53 ns |   501.87 ns |     136 B |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 153,741.5 ns |   318.87 ns |   282.67 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,956.5 ns |   218.84 ns |   204.70 ns |         - |
-| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 155,415.0 ns | 1,088.94 ns | 1,018.60 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,493.9 ns |   314.22 ns |   293.92 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 605,164.8 ns | 7,953.89 ns | 7,050.92 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128B         |     155.7 ns |      0.58 ns |      0.51 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128B         |     157.9 ns |      1.20 ns |      1.12 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128B         |     158.6 ns |      0.62 ns |      0.58 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128B         |     158.7 ns |      1.00 ns |      0.89 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128B         |     161.1 ns |      1.20 ns |      1.12 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128B         |     607.1 ns |     10.52 ns |      9.84 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 137B         |     227.3 ns |      0.32 ns |      0.30 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 137B         |     237.7 ns |      1.16 ns |      1.03 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 137B         |     239.8 ns |      0.45 ns |      0.42 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 137B         |     242.7 ns |      0.78 ns |      0.73 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 137B         |     244.1 ns |      0.34 ns |      0.29 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 137B         |     908.7 ns |     14.29 ns |     13.37 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1KB          |   1,140.1 ns |      4.10 ns |      3.83 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1KB          |   1,212.5 ns |      4.71 ns |      4.18 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1KB          |   1,218.3 ns |      1.30 ns |      1.21 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1KB          |   1,231.5 ns |      6.43 ns |      6.01 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1KB          |   1,246.1 ns |      1.65 ns |      1.55 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1KB          |   4,752.6 ns |     91.89 ns |     85.96 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 1025B        |   1,209.1 ns |      3.59 ns |      3.00 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 1025B        |   1,293.7 ns |      2.69 ns |      2.39 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 1025B        |   1,298.8 ns |      1.96 ns |      1.74 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 1025B        |   1,305.6 ns |      4.09 ns |      3.62 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 1025B        |   1,327.8 ns |      2.20 ns |      1.95 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 1025B        |   5,027.1 ns |     73.74 ns |     68.97 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 8KB          |   9,009.1 ns |     37.17 ns |     34.77 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 8KB          |   9,633.7 ns |     27.19 ns |     25.43 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 8KB          |   9,675.5 ns |     33.05 ns |     30.92 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 8KB          |   9,700.8 ns |      9.82 ns |      8.71 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 8KB          |   9,890.5 ns |     17.38 ns |     16.26 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 8KB          |  37,797.2 ns |    588.44 ns |    550.43 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-128 · BLAKE2s-128 (Blake2Fast) | 128KB        | 144,012.4 ns |    467.75 ns |    414.65 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle             | 128KB        | 153,897.9 ns |    398.12 ns |    352.92 ns |         - |
+| TryComputeHash · BLAKE2s-128 · AVX2                     | 128KB        | 154,663.5 ns |  1,151.18 ns |    961.29 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Ssse3                    | 128KB        | 154,861.5 ns |    143.94 ns |    127.60 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Sse2                     | 128KB        | 158,433.0 ns |    218.83 ns |    204.70 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Managed                  | 128KB        | 606,575.6 ns | 11,435.06 ns | 11,230.76 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
@@ -1,43 +1,43 @@
-﻿| Description                                             | TestDataSize | Mean         | Error        | StdDev       | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     158.8 ns |      1.00 ns |      0.94 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     159.6 ns |      1.93 ns |      1.71 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     161.4 ns |      1.43 ns |      1.33 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     162.1 ns |      1.07 ns |      0.89 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     163.1 ns |      0.88 ns |      0.82 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     621.7 ns |      6.78 ns |      6.01 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     231.3 ns |      1.05 ns |      0.93 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     241.3 ns |      1.80 ns |      1.60 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     241.8 ns |      2.44 ns |      2.28 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     244.6 ns |      2.52 ns |      2.35 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     246.8 ns |      1.54 ns |      1.44 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     921.1 ns |     13.51 ns |     11.97 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,143.7 ns |      4.06 ns |      3.17 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,225.4 ns |      7.05 ns |      6.60 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,237.7 ns |     18.57 ns |     17.37 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,248.2 ns |     18.62 ns |     16.50 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,250.7 ns |      8.35 ns |      7.81 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   4,826.7 ns |     84.65 ns |     75.04 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,219.8 ns |      6.91 ns |      6.12 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,307.0 ns |      7.12 ns |      6.66 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,311.9 ns |     10.46 ns |      9.78 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,315.7 ns |     18.13 ns |     16.07 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,331.3 ns |      5.77 ns |      5.39 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   5,169.3 ns |     99.74 ns |    122.49 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,045.1 ns |     57.81 ns |     51.25 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,644.7 ns |     63.13 ns |     59.05 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,763.7 ns |     56.90 ns |     53.23 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,862.9 ns |    117.12 ns |    109.55 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,901.2 ns |     20.29 ns |     16.94 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  38,853.8 ns |    743.26 ns |    695.25 ns |         - |
-|                                                         |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 143,943.4 ns |    831.40 ns |    777.69 ns |     136 B |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 153,208.5 ns |    651.61 ns |    544.13 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 156,384.4 ns |  1,116.15 ns |  1,044.05 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 158,555.7 ns |    659.61 ns |    584.72 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 158,780.4 ns |  1,952.04 ns |  1,825.94 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 624,052.7 ns | 11,940.72 ns | 13,272.07 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error        | StdDev       | Median       | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|-------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     156.6 ns |      0.37 ns |      0.33 ns |     156.7 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     158.5 ns |      1.66 ns |      1.47 ns |     158.2 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     158.6 ns |      1.01 ns |      0.95 ns |     158.2 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     161.7 ns |      0.79 ns |      0.74 ns |     161.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     164.4 ns |      0.99 ns |      0.92 ns |     164.1 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     608.4 ns |     11.91 ns |     11.14 ns |     605.7 ns |         - |
+|                                                         |              |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     236.3 ns |      1.04 ns |      0.93 ns |     236.1 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     236.5 ns |      0.78 ns |      0.65 ns |     236.6 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     240.2 ns |      0.74 ns |      0.66 ns |     240.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     245.1 ns |      0.47 ns |      0.42 ns |     245.1 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     245.8 ns |      0.78 ns |      0.73 ns |     245.9 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     902.9 ns |     10.98 ns |     10.27 ns |     899.4 ns |         - |
+|                                                         |              |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,139.6 ns |      3.53 ns |      3.31 ns |   1,139.0 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,214.1 ns |      6.27 ns |      5.56 ns |   1,213.0 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,218.0 ns |      2.86 ns |      2.67 ns |   1,217.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,236.3 ns |      3.44 ns |      3.22 ns |   1,236.7 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,241.1 ns |      1.82 ns |      1.61 ns |   1,240.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   4,708.6 ns |     41.92 ns |     35.01 ns |   4,701.8 ns |         - |
+|                                                         |              |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,211.6 ns |      4.59 ns |      4.29 ns |   1,211.6 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,288.9 ns |      3.36 ns |      3.14 ns |   1,289.4 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,299.5 ns |      1.97 ns |      1.84 ns |   1,299.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,308.3 ns |      3.27 ns |      3.06 ns |   1,308.4 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,324.3 ns |      2.47 ns |      2.19 ns |   1,323.8 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   5,049.8 ns |     98.97 ns |    125.16 ns |   4,966.7 ns |         - |
+|                                                         |              |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,003.7 ns |     36.97 ns |     34.59 ns |   9,009.8 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,635.8 ns |     12.36 ns |     11.56 ns |   9,635.9 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,649.5 ns |     54.84 ns |     48.61 ns |   9,647.6 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,699.1 ns |     20.17 ns |     18.87 ns |   9,699.9 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,887.2 ns |     25.60 ns |     23.95 ns |   9,879.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  37,626.0 ns |    591.61 ns |    581.04 ns |  37,295.5 ns |         - |
+|                                                         |              |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 144,182.1 ns |    618.48 ns |    548.27 ns | 144,159.6 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 154,148.3 ns |    457.19 ns |    405.29 ns | 154,151.9 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 154,326.0 ns |    694.05 ns |    615.26 ns | 154,305.7 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 154,996.0 ns |    252.75 ns |    236.42 ns | 154,988.1 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 158,004.1 ns |    300.37 ns |    280.96 ns | 157,999.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 603,951.1 ns | 11,842.83 ns | 11,077.79 ns | 598,307.6 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
@@ -1,43 +1,43 @@
-﻿| Description                                             | TestDataSize | Mean         | Error        | StdDev       | Median       | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|-------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     156.6 ns |      0.37 ns |      0.33 ns |     156.7 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     158.5 ns |      1.66 ns |      1.47 ns |     158.2 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     158.6 ns |      1.01 ns |      0.95 ns |     158.2 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     161.7 ns |      0.79 ns |      0.74 ns |     161.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     164.4 ns |      0.99 ns |      0.92 ns |     164.1 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     608.4 ns |     11.91 ns |     11.14 ns |     605.7 ns |         - |
-|                                                         |              |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     236.3 ns |      1.04 ns |      0.93 ns |     236.1 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     236.5 ns |      0.78 ns |      0.65 ns |     236.6 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     240.2 ns |      0.74 ns |      0.66 ns |     240.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     245.1 ns |      0.47 ns |      0.42 ns |     245.1 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     245.8 ns |      0.78 ns |      0.73 ns |     245.9 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     902.9 ns |     10.98 ns |     10.27 ns |     899.4 ns |         - |
-|                                                         |              |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,139.6 ns |      3.53 ns |      3.31 ns |   1,139.0 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,214.1 ns |      6.27 ns |      5.56 ns |   1,213.0 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,218.0 ns |      2.86 ns |      2.67 ns |   1,217.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,236.3 ns |      3.44 ns |      3.22 ns |   1,236.7 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,241.1 ns |      1.82 ns |      1.61 ns |   1,240.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   4,708.6 ns |     41.92 ns |     35.01 ns |   4,701.8 ns |         - |
-|                                                         |              |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,211.6 ns |      4.59 ns |      4.29 ns |   1,211.6 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,288.9 ns |      3.36 ns |      3.14 ns |   1,289.4 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,299.5 ns |      1.97 ns |      1.84 ns |   1,299.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,308.3 ns |      3.27 ns |      3.06 ns |   1,308.4 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,324.3 ns |      2.47 ns |      2.19 ns |   1,323.8 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   5,049.8 ns |     98.97 ns |    125.16 ns |   4,966.7 ns |         - |
-|                                                         |              |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,003.7 ns |     36.97 ns |     34.59 ns |   9,009.8 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,635.8 ns |     12.36 ns |     11.56 ns |   9,635.9 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,649.5 ns |     54.84 ns |     48.61 ns |   9,647.6 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,699.1 ns |     20.17 ns |     18.87 ns |   9,699.9 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,887.2 ns |     25.60 ns |     23.95 ns |   9,879.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  37,626.0 ns |    591.61 ns |    581.04 ns |  37,295.5 ns |         - |
-|                                                         |              |              |              |              |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 144,182.1 ns |    618.48 ns |    548.27 ns | 144,159.6 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 154,148.3 ns |    457.19 ns |    405.29 ns | 154,151.9 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 154,326.0 ns |    694.05 ns |    615.26 ns | 154,305.7 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 154,996.0 ns |    252.75 ns |    236.42 ns | 154,988.1 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 158,004.1 ns |    300.37 ns |    280.96 ns | 157,999.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 603,951.1 ns | 11,842.83 ns | 11,077.79 ns | 598,307.6 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Median       | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     156.3 ns |     0.36 ns |     0.34 ns |     156.2 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     157.6 ns |     0.15 ns |     0.13 ns |     157.6 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     158.0 ns |     0.90 ns |     0.80 ns |     157.7 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     161.2 ns |     0.26 ns |     0.24 ns |     161.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     161.3 ns |     0.23 ns |     0.20 ns |     161.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     597.3 ns |     2.65 ns |     2.21 ns |     597.5 ns |         - |
+|                                                         |              |              |             |             |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     233.0 ns |     0.87 ns |     0.77 ns |     233.0 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     237.0 ns |     0.60 ns |     0.53 ns |     237.1 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     239.6 ns |     0.41 ns |     0.38 ns |     239.4 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     244.6 ns |     0.45 ns |     0.42 ns |     244.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     245.5 ns |     1.40 ns |     1.31 ns |     245.8 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     887.0 ns |     2.87 ns |     2.54 ns |     886.7 ns |         - |
+|                                                         |              |              |             |             |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,175.9 ns |    21.79 ns |    58.53 ns |   1,147.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,210.1 ns |     6.55 ns |     6.12 ns |   1,209.8 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,216.0 ns |     1.25 ns |     1.17 ns |   1,216.0 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,241.4 ns |     1.68 ns |     1.57 ns |   1,241.4 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,435.0 ns |    11.38 ns |    10.64 ns |   1,435.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   4,762.4 ns |    41.47 ns |    38.79 ns |   4,748.0 ns |         - |
+|                                                         |              |              |             |             |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,216.1 ns |     9.51 ns |     7.94 ns |   1,214.9 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,289.3 ns |     8.65 ns |     8.09 ns |   1,286.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,301.8 ns |     7.64 ns |     7.14 ns |   1,297.8 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,312.2 ns |     7.56 ns |     6.32 ns |   1,310.9 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,332.1 ns |     8.01 ns |     7.49 ns |   1,331.0 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   4,983.6 ns |    45.03 ns |    42.12 ns |   4,980.9 ns |         - |
+|                                                         |              |              |             |             |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,019.3 ns |    35.78 ns |    29.88 ns |   9,019.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,664.1 ns |    27.99 ns |    24.81 ns |   9,664.2 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,696.9 ns |    73.17 ns |    68.45 ns |   9,685.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,760.7 ns |    15.90 ns |    13.28 ns |   9,754.0 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,980.3 ns |    21.00 ns |    17.53 ns |   9,982.5 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  38,621.4 ns |   751.84 ns |   738.41 ns |  38,277.2 ns |         - |
+|                                                         |              |              |             |             |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 146,018.0 ns | 2,749.36 ns | 2,571.75 ns | 145,178.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 154,859.0 ns | 1,517.70 ns | 1,267.34 ns | 154,601.3 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 156,376.3 ns |   181.89 ns |   161.24 ns | 156,391.6 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 156,721.3 ns |   581.59 ns |   485.65 ns | 156,729.6 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 159,418.3 ns |   294.20 ns |   275.19 ns | 159,416.8 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 607,289.3 ns | 6,288.24 ns | 5,574.36 ns | 606,842.5 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
@@ -1,43 +1,43 @@
-﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Median       | Allocated |
-|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     156.3 ns |     0.36 ns |     0.34 ns |     156.2 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     157.6 ns |     0.15 ns |     0.13 ns |     157.6 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     158.0 ns |     0.90 ns |     0.80 ns |     157.7 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     161.2 ns |     0.26 ns |     0.24 ns |     161.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     161.3 ns |     0.23 ns |     0.20 ns |     161.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     597.3 ns |     2.65 ns |     2.21 ns |     597.5 ns |         - |
-|                                                         |              |              |             |             |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     233.0 ns |     0.87 ns |     0.77 ns |     233.0 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     237.0 ns |     0.60 ns |     0.53 ns |     237.1 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     239.6 ns |     0.41 ns |     0.38 ns |     239.4 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     244.6 ns |     0.45 ns |     0.42 ns |     244.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     245.5 ns |     1.40 ns |     1.31 ns |     245.8 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     887.0 ns |     2.87 ns |     2.54 ns |     886.7 ns |         - |
-|                                                         |              |              |             |             |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,175.9 ns |    21.79 ns |    58.53 ns |   1,147.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,210.1 ns |     6.55 ns |     6.12 ns |   1,209.8 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,216.0 ns |     1.25 ns |     1.17 ns |   1,216.0 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,241.4 ns |     1.68 ns |     1.57 ns |   1,241.4 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,435.0 ns |    11.38 ns |    10.64 ns |   1,435.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   4,762.4 ns |    41.47 ns |    38.79 ns |   4,748.0 ns |         - |
-|                                                         |              |              |             |             |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,216.1 ns |     9.51 ns |     7.94 ns |   1,214.9 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,289.3 ns |     8.65 ns |     8.09 ns |   1,286.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,301.8 ns |     7.64 ns |     7.14 ns |   1,297.8 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,312.2 ns |     7.56 ns |     6.32 ns |   1,310.9 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,332.1 ns |     8.01 ns |     7.49 ns |   1,331.0 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   4,983.6 ns |    45.03 ns |    42.12 ns |   4,980.9 ns |         - |
-|                                                         |              |              |             |             |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,019.3 ns |    35.78 ns |    29.88 ns |   9,019.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,664.1 ns |    27.99 ns |    24.81 ns |   9,664.2 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,696.9 ns |    73.17 ns |    68.45 ns |   9,685.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,760.7 ns |    15.90 ns |    13.28 ns |   9,754.0 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,980.3 ns |    21.00 ns |    17.53 ns |   9,982.5 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  38,621.4 ns |   751.84 ns |   738.41 ns |  38,277.2 ns |         - |
-|                                                         |              |              |             |             |              |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 146,018.0 ns | 2,749.36 ns | 2,571.75 ns | 145,178.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 154,859.0 ns | 1,517.70 ns | 1,267.34 ns | 154,601.3 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 156,376.3 ns |   181.89 ns |   161.24 ns | 156,391.6 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 156,721.3 ns |   581.59 ns |   485.65 ns | 156,729.6 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 159,418.3 ns |   294.20 ns |   275.19 ns | 159,416.8 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 607,289.3 ns | 6,288.24 ns | 5,574.36 ns | 606,842.5 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     157.0 ns |     0.85 ns |     0.79 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     158.0 ns |     1.53 ns |     1.43 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     159.8 ns |     1.32 ns |     1.24 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     160.2 ns |     0.74 ns |     0.69 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     162.5 ns |     0.99 ns |     0.93 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     163.8 ns |     2.77 ns |     2.59 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     233.8 ns |     0.85 ns |     0.79 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     236.4 ns |     1.50 ns |     1.41 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     238.6 ns |     1.76 ns |     1.56 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     239.4 ns |     4.80 ns |     5.90 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     241.5 ns |     1.47 ns |     1.38 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     243.8 ns |     3.80 ns |     3.55 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,141.8 ns |     4.57 ns |     4.05 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,213.6 ns |     6.10 ns |     5.70 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,216.6 ns |     8.65 ns |     7.67 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   1,218.0 ns |    21.59 ns |    20.19 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,236.2 ns |     7.72 ns |     7.22 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,243.1 ns |    10.28 ns |     9.11 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,212.5 ns |     5.21 ns |     4.87 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   1,293.0 ns |    24.29 ns |    23.86 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,293.1 ns |     4.02 ns |     3.76 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,299.1 ns |     8.59 ns |     8.04 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,309.9 ns |     2.87 ns |     2.39 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,321.1 ns |    11.18 ns |    10.46 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,035.6 ns |    72.49 ns |    67.81 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,661.3 ns |    65.41 ns |    61.18 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |   9,670.0 ns |   156.54 ns |   138.77 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,689.1 ns |    53.23 ns |    49.79 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,737.8 ns |    90.75 ns |    84.89 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,883.6 ns |    70.53 ns |    62.52 ns |         - |
+|                                                         |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 143,924.9 ns |   579.04 ns |   541.64 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 153,604.6 ns | 1,720.20 ns | 1,524.91 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 154,070.9 ns |   640.69 ns |   599.31 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 154,800.2 ns | 1,174.45 ns | 1,098.58 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 155,750.5 ns |   925.71 ns |   865.91 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 157,817.8 ns | 1,178.39 ns | 1,044.62 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
@@ -1,43 +1,31 @@
 ﻿| Description                                             | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     157.0 ns |     0.85 ns |     0.79 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     158.0 ns |     1.53 ns |     1.43 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     159.8 ns |     1.32 ns |     1.24 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     160.2 ns |     0.74 ns |     0.69 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     162.5 ns |     0.99 ns |     0.93 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     163.8 ns |     2.77 ns |     2.59 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     156.3 ns |     0.94 ns |     0.88 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     157.7 ns |     0.79 ns |     0.73 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     161.2 ns |     0.89 ns |     0.75 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     161.6 ns |     0.70 ns |     0.65 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     233.8 ns |     0.85 ns |     0.79 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     236.4 ns |     1.50 ns |     1.41 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     238.6 ns |     1.76 ns |     1.56 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     239.4 ns |     4.80 ns |     5.90 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     241.5 ns |     1.47 ns |     1.38 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     243.8 ns |     3.80 ns |     3.55 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     228.5 ns |     1.02 ns |     0.90 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     236.9 ns |     1.57 ns |     1.46 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     237.8 ns |     3.38 ns |     3.16 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     238.0 ns |     2.10 ns |     1.97 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,141.8 ns |     4.57 ns |     4.05 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,213.6 ns |     6.10 ns |     5.70 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,216.6 ns |     8.65 ns |     7.67 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   1,218.0 ns |    21.59 ns |    20.19 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,236.2 ns |     7.72 ns |     7.22 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,243.1 ns |    10.28 ns |     9.11 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,143.1 ns |     6.43 ns |     6.01 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   1,206.6 ns |     6.59 ns |     5.84 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,213.6 ns |     3.24 ns |     3.03 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,232.5 ns |     5.46 ns |     4.84 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,212.5 ns |     5.21 ns |     4.87 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   1,293.0 ns |    24.29 ns |    23.86 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,293.1 ns |     4.02 ns |     3.76 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,299.1 ns |     8.59 ns |     8.04 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,309.9 ns |     2.87 ns |     2.39 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,321.1 ns |    11.18 ns |    10.46 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,213.7 ns |     3.84 ns |     3.00 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   1,283.8 ns |     6.71 ns |     5.95 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,292.2 ns |     2.20 ns |     1.95 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,307.4 ns |     5.81 ns |     5.44 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,035.6 ns |    72.49 ns |    67.81 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,661.3 ns |    65.41 ns |    61.18 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |   9,670.0 ns |   156.54 ns |   138.77 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,689.1 ns |    53.23 ns |    49.79 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,737.8 ns |    90.75 ns |    84.89 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,883.6 ns |    70.53 ns |    62.52 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   8,999.5 ns |    35.92 ns |    29.99 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |   9,587.7 ns |    55.81 ns |    52.20 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,684.3 ns |    31.43 ns |    29.40 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,737.0 ns |    53.84 ns |    50.36 ns |         - |
 |                                                         |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 143,924.9 ns |   579.04 ns |   541.64 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 153,604.6 ns | 1,720.20 ns | 1,524.91 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 154,070.9 ns |   640.69 ns |   599.31 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 154,800.2 ns | 1,174.45 ns | 1,098.58 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 155,750.5 ns |   925.71 ns |   865.91 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 157,817.8 ns | 1,178.39 ns | 1,044.62 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 144,121.6 ns |   796.95 ns |   706.48 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 152,999.3 ns | 1,327.48 ns | 1,241.72 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 154,138.9 ns |   605.76 ns |   536.99 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 155,087.4 ns |   777.72 ns |   727.48 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
@@ -1,37 +1,43 @@
-﻿| Description                                 | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE2s-256 · Ssse3        | 128B         |     158.1 ns |     0.35 ns |     0.32 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2         | 128B         |     161.1 ns |     0.25 ns |     0.21 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle | 128B         |     162.0 ns |     0.21 ns |     0.19 ns |         - |
-| TryComputeHash · BLAKE2s-256 · AVX2         | 128B         |     163.2 ns |     0.87 ns |     0.81 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed      | 128B         |     597.9 ns |     6.05 ns |     5.66 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · AVX2         | 137B         |     236.9 ns |     0.95 ns |     0.79 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3        | 137B         |     239.8 ns |     0.37 ns |     0.33 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2         | 137B         |     244.5 ns |     0.21 ns |     0.20 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle | 137B         |     246.5 ns |     1.21 ns |     1.13 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed      | 137B         |     891.8 ns |     6.59 ns |     6.16 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · AVX2         | 1KB          |   1,211.0 ns |     4.50 ns |     4.21 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3        | 1KB          |   1,216.5 ns |     1.84 ns |     1.73 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle | 1KB          |   1,233.9 ns |     2.85 ns |     2.67 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2         | 1KB          |   1,241.9 ns |     1.38 ns |     1.29 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed      | 1KB          |   4,674.4 ns |    24.77 ns |    20.69 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · AVX2         | 1025B        |   1,291.3 ns |     5.57 ns |     5.21 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3        | 1025B        |   1,298.1 ns |     1.82 ns |     1.62 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle | 1025B        |   1,310.4 ns |     3.24 ns |     2.88 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2         | 1025B        |   1,325.6 ns |     1.62 ns |     1.44 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed      | 1025B        |   4,967.9 ns |    32.27 ns |    28.60 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · AVX2         | 8KB          |   9,640.7 ns |    47.98 ns |    44.88 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle | 8KB          |   9,684.5 ns |    18.39 ns |    16.30 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3        | 8KB          |   9,689.1 ns |    10.96 ns |    10.25 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2         | 8KB          |   9,888.7 ns |    11.86 ns |    10.52 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed      | 8KB          |  37,314.9 ns |   345.06 ns |   288.14 ns |         - |
-|                                             |              |              |             |             |           |
-| TryComputeHash · BLAKE2s-256 · AVX2         | 128KB        | 154,081.4 ns |   536.41 ns |   447.92 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle | 128KB        | 154,083.3 ns |   608.03 ns |   568.76 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Ssse3        | 128KB        | 154,924.6 ns |   229.67 ns |   214.83 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Sse2         | 128KB        | 158,210.1 ns |   295.99 ns |   276.87 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Managed      | 128KB        | 598,431.5 ns | 5,193.57 ns | 4,603.96 ns |         - |
+﻿| Description                                             | TestDataSize | Mean         | Error        | StdDev       | Allocated |
+|-------------------------------------------------------- |------------- |-------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128B         |     158.8 ns |      1.00 ns |      0.94 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128B         |     159.6 ns |      1.93 ns |      1.71 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128B         |     161.4 ns |      1.43 ns |      1.33 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128B         |     162.1 ns |      1.07 ns |      0.89 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128B         |     163.1 ns |      0.88 ns |      0.82 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128B         |     621.7 ns |      6.78 ns |      6.01 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 137B         |     231.3 ns |      1.05 ns |      0.93 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 137B         |     241.3 ns |      1.80 ns |      1.60 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 137B         |     241.8 ns |      2.44 ns |      2.28 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 137B         |     244.6 ns |      2.52 ns |      2.35 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 137B         |     246.8 ns |      1.54 ns |      1.44 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 137B         |     921.1 ns |     13.51 ns |     11.97 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1KB          |   1,143.7 ns |      4.06 ns |      3.17 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1KB          |   1,225.4 ns |      7.05 ns |      6.60 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1KB          |   1,237.7 ns |     18.57 ns |     17.37 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1KB          |   1,248.2 ns |     18.62 ns |     16.50 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1KB          |   1,250.7 ns |      8.35 ns |      7.81 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1KB          |   4,826.7 ns |     84.65 ns |     75.04 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 1025B        |   1,219.8 ns |      6.91 ns |      6.12 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 1025B        |   1,307.0 ns |      7.12 ns |      6.66 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 1025B        |   1,311.9 ns |     10.46 ns |      9.78 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 1025B        |   1,315.7 ns |     18.13 ns |     16.07 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 1025B        |   1,331.3 ns |      5.77 ns |      5.39 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 1025B        |   5,169.3 ns |     99.74 ns |    122.49 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 8KB          |   9,045.1 ns |     57.81 ns |     51.25 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 8KB          |   9,644.7 ns |     63.13 ns |     59.05 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 8KB          |   9,763.7 ns |     56.90 ns |     53.23 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 8KB          |   9,862.9 ns |    117.12 ns |    109.55 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 8KB          |   9,901.2 ns |     20.29 ns |     16.94 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 8KB          |  38,853.8 ns |    743.26 ns |    695.25 ns |         - |
+|                                                         |              |              |              |              |           |
+| TryComputeHash · BLAKE2s-256 · BLAKE2s-256 (Blake2Fast) | 128KB        | 143,943.4 ns |    831.40 ns |    777.69 ns |     136 B |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle             | 128KB        | 153,208.5 ns |    651.61 ns |    544.13 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Ssse3                    | 128KB        | 156,384.4 ns |  1,116.15 ns |  1,044.05 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Sse2                     | 128KB        | 158,555.7 ns |    659.61 ns |    584.72 ns |         - |
+| TryComputeHash · BLAKE2s-256 · AVX2                     | 128KB        | 158,780.4 ns |  1,952.04 ns |  1,825.94 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Managed                  | 128KB        | 624,052.7 ns | 11,940.72 ns | 13,272.07 ns |         - |

--- a/src/Security/Cryptography/Cipher/ChaCha/ChaChaCore.cs
+++ b/src/Security/Cryptography/Cipher/ChaCha/ChaChaCore.cs
@@ -121,17 +121,14 @@ internal readonly partial struct ChaChaCore
         if ((_simdSupport & SimdSupport.Avx2) != 0)
         {
             TransformAvx2(key, nonce, counter, input, output);
-            return;
         }
         else if ((_simdSupport & SimdSupport.Ssse3) != 0)
         {
             TransformSsse3(key, nonce, counter, input, output);
-            return;
         }
         else if ((_simdSupport & SimdSupport.Neon) != 0)
         {
             TransformNeon(key, nonce, counter, input, output);
-            return;
         }
         else
 #endif

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.Avx2.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.Avx2.cs
@@ -66,212 +66,206 @@ public sealed partial class Blake2b : HashAlgorithm
 
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private unsafe void CompressAvx2(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private static unsafe void CompressAvx2(byte* msgPtr, ulong* state, ulong bytesCompressed, bool isFinal)
     {
-        _bytesCompressed += (ulong)bytesConsumed;
+        // Load state into vector registers
+        Vector256<ulong> row1 = Avx.LoadVector256(state);
+        Vector256<ulong> row2 = Avx.LoadVector256(state + Vector256<ulong>.Count);
+        Vector256<ulong> row3 = IVLow;
+        Vector256<ulong> row4 = Avx2.Xor(IVHigh, Vector256.Create(bytesCompressed, 0UL, 0UL, 0UL));
 
-        fixed (byte* msgPtr = block)
+        if (isFinal)
         {
-            // Load state into vector registers
-            ulong* state = (ulong*)Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(_state));
-            Vector256<ulong> row1 = Avx.LoadVector256(state);
-            Vector256<ulong> row2 = Avx.LoadVector256(state + Vector256<ulong>.Count);
-            Vector256<ulong> row3 = IVLow;
-            Vector256<ulong> row4 = Avx2.Xor(IVHigh, Vector256.Create(_bytesCompressed, 0UL, 0UL, 0UL));
-
-            if (isFinal)
-            {
-                row4 = Avx2.Xor(row4, FinalMask);
-            }
-
-            // Save original state for finalization
-            Vector256<ulong> orig1 = row1;
-            Vector256<ulong> orig2 = row2;
-
-            // Pre-load all 16 message words as 8 broadcast Vector256<ulong> pairs.
-            // Each m_i = [w_{2i}, w_{2i+1}, w_{2i}, w_{2i+1}] via vbroadcasti128.
-            Vector256<ulong> m0 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr));
-            Vector256<ulong> m1 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 1 * sizeof(Vector128<ulong>)));
-            Vector256<ulong> m2 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 2 * sizeof(Vector128<ulong>)));
-            Vector256<ulong> m3 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 3 * sizeof(Vector128<ulong>)));
-            Vector256<ulong> m4 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 4 * sizeof(Vector128<ulong>)));
-            Vector256<ulong> m5 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 5 * sizeof(Vector128<ulong>)));
-            Vector256<ulong> m6 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 6 * sizeof(Vector128<ulong>)));
-            Vector256<ulong> m7 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 7 * sizeof(Vector128<ulong>)));
-
-            bool step11and12 = false;
-            while (true)
-            {
-                Vector256<ulong> t0, t1, mx1, my1, mx2, my2;
-
-                // ROUND 1/11 — Sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-                t0 = Avx2.UnpackLow(m0, m1);
-                t1 = Avx2.UnpackLow(m2, m3);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m0, m1);
-                t1 = Avx2.UnpackHigh(m2, m3);
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m7, m4);
-                t1 = Avx2.UnpackLow(m5, m6);
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m7, m4);
-                t1 = Avx2.UnpackHigh(m5, m6);
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 2/12 — Sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
-                t0 = Avx2.UnpackLow(m7, m2);
-                t1 = Avx2.UnpackHigh(m4, m6);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m5, m4);
-                t1 = Avx2.AlignRight(m3, m7, 8);
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m2, m0);
-                t1 = Avx2.Blend(m0.AsUInt32(), m5.AsUInt32(), 0xCC).AsUInt64();
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.AlignRight(m6, m1, 8);
-                t1 = Avx2.Blend(m1.AsUInt32(), m3.AsUInt32(), 0xCC).AsUInt64();
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // exit if second round processed step 11 and 12
-                if (step11and12)
-                {
-                    break;
-                }
-
-                // ROUND 3 — Sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
-                t0 = Avx2.AlignRight(m6, m5, 8);
-                t1 = Avx2.UnpackHigh(m2, m7);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m4, m0);
-                t1 = Avx2.Blend(m1.AsUInt32(), m6.AsUInt32(), 0xCC).AsUInt64();
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.AlignRight(m5, m4, 8);
-                t1 = Avx2.UnpackHigh(m1, m3);
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m2, m7);
-                t1 = Avx2.Blend(m3.AsUInt32(), m0.AsUInt32(), 0xCC).AsUInt64();
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 4 — Sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
-                t0 = Avx2.UnpackHigh(m3, m1);
-                t1 = Avx2.UnpackHigh(m6, m5);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m4, m0);
-                t1 = Avx2.UnpackLow(m6, m7);
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.AlignRight(m1, m7, 8);
-                t1 = Avx2.Shuffle(m2.AsUInt32(), 0b_01_00_11_10).AsUInt64();
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m4, m3);
-                t1 = Avx2.UnpackLow(m5, m0);
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 5 — Sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
-                t0 = Avx2.UnpackHigh(m4, m2);
-                t1 = Avx2.UnpackLow(m1, m5);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.Blend(m0.AsUInt32(), m3.AsUInt32(), 0xCC).AsUInt64();
-                t1 = Avx2.Blend(m2.AsUInt32(), m7.AsUInt32(), 0xCC).AsUInt64();
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.AlignRight(m7, m1, 8);
-                t1 = Avx2.AlignRight(m3, m5, 8);
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m6, m0);
-                t1 = Avx2.UnpackLow(m6, m4);
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 6 — Sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
-                t0 = Avx2.UnpackLow(m1, m3);
-                t1 = Avx2.UnpackLow(m0, m4);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m6, m5);
-                t1 = Avx2.UnpackHigh(m5, m1);
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.AlignRight(m2, m0, 8);
-                t1 = Avx2.UnpackHigh(m3, m7);
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m4, m6);
-                t1 = Avx2.AlignRight(m7, m2, 8);
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 7 — Sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
-                t0 = Avx2.Blend(m6.AsUInt32(), m0.AsUInt32(), 0xCC).AsUInt64();
-                t1 = Avx2.UnpackLow(m7, m2);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m2, m7);
-                t1 = Avx2.AlignRight(m5, m6, 8);
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m4, m0);
-                t1 = Avx2.Blend(m3.AsUInt32(), m4.AsUInt32(), 0xCC).AsUInt64();
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m5, m3);
-                t1 = Avx2.Shuffle(m1.AsUInt32(), 0b_01_00_11_10).AsUInt64();
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 8 — Sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
-                t0 = Avx2.UnpackHigh(m6, m3);
-                t1 = Avx2.Blend(m6.AsUInt32(), m1.AsUInt32(), 0xCC).AsUInt64();
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.AlignRight(m7, m5, 8);
-                t1 = Avx2.UnpackHigh(m0, m4);
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.Blend(m1.AsUInt32(), m2.AsUInt32(), 0xCC).AsUInt64();
-                t1 = Avx2.AlignRight(m4, m7, 8);
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m5, m0);
-                t1 = Avx2.UnpackLow(m2, m3);
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 9 — Sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
-                t0 = Avx2.UnpackLow(m3, m7);
-                t1 = Avx2.AlignRight(m0, m5, 8);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m7, m4);
-                t1 = Avx2.AlignRight(m4, m1, 8);
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m5, m6);
-                t1 = Avx2.UnpackHigh(m6, m0);
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.AlignRight(m1, m2, 8);
-                t1 = Avx2.AlignRight(m2, m3, 8);
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                // ROUND 10 — Sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
-                t0 = Avx2.UnpackLow(m5, m4);
-                t1 = Avx2.UnpackHigh(m3, m0);
-                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackLow(m1, m2);
-                t1 = Avx2.Blend(m3.AsUInt32(), m2.AsUInt32(), 0xCC).AsUInt64();
-                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.UnpackHigh(m6, m7);
-                t1 = Avx2.UnpackHigh(m4, m1);
-                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                t0 = Avx2.Blend(m0.AsUInt32(), m5.AsUInt32(), 0xCC).AsUInt64();
-                t1 = Avx2.UnpackLow(m7, m6);
-                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
-                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
-
-                step11and12 = true;
-            }
-
-            // Finalize: state ^= rows ^ IV rows
-            row1 = Avx2.Xor(row1, row3);
-            row2 = Avx2.Xor(row2, row4);
-            row1 = Avx2.Xor(row1, orig1);
-            row2 = Avx2.Xor(row2, orig2);
-
-            Avx.Store(state, row1);
-            Avx.Store(state + Vector256<ulong>.Count, row2);
+            row4 = Avx2.Xor(row4, FinalMask);
         }
+
+        // Save original state for finalization
+        Vector256<ulong> orig1 = row1;
+        Vector256<ulong> orig2 = row2;
+
+        // Pre-load all 16 message words as 8 broadcast Vector256<ulong> pairs.
+        // Each m_i = [w_{2i}, w_{2i+1}, w_{2i}, w_{2i+1}] via vbroadcasti128.
+        Vector256<ulong> m0 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr));
+        Vector256<ulong> m1 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 1 * sizeof(Vector128<ulong>)));
+        Vector256<ulong> m2 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 2 * sizeof(Vector128<ulong>)));
+        Vector256<ulong> m3 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 3 * sizeof(Vector128<ulong>)));
+        Vector256<ulong> m4 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 4 * sizeof(Vector128<ulong>)));
+        Vector256<ulong> m5 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 5 * sizeof(Vector128<ulong>)));
+        Vector256<ulong> m6 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 6 * sizeof(Vector128<ulong>)));
+        Vector256<ulong> m7 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 7 * sizeof(Vector128<ulong>)));
+
+        bool step11and12 = false;
+        while (true)
+        {
+            Vector256<ulong> t0, t1, mx1, my1, mx2, my2;
+
+            // ROUND 1/11 — Sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+            t0 = Avx2.UnpackLow(m0, m1);
+            t1 = Avx2.UnpackLow(m2, m3);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m0, m1);
+            t1 = Avx2.UnpackHigh(m2, m3);
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m7, m4);
+            t1 = Avx2.UnpackLow(m5, m6);
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m7, m4);
+            t1 = Avx2.UnpackHigh(m5, m6);
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 2/12 — Sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+            t0 = Avx2.UnpackLow(m7, m2);
+            t1 = Avx2.UnpackHigh(m4, m6);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m5, m4);
+            t1 = Avx2.AlignRight(m3, m7, 8);
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m2, m0);
+            t1 = Avx2.Blend(m0.AsUInt32(), m5.AsUInt32(), 0xCC).AsUInt64();
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.AlignRight(m6, m1, 8);
+            t1 = Avx2.Blend(m1.AsUInt32(), m3.AsUInt32(), 0xCC).AsUInt64();
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // exit if second round processed step 11 and 12
+            if (step11and12)
+            {
+                break;
+            }
+
+            // ROUND 3 — Sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+            t0 = Avx2.AlignRight(m6, m5, 8);
+            t1 = Avx2.UnpackHigh(m2, m7);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m4, m0);
+            t1 = Avx2.Blend(m1.AsUInt32(), m6.AsUInt32(), 0xCC).AsUInt64();
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.AlignRight(m5, m4, 8);
+            t1 = Avx2.UnpackHigh(m1, m3);
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m2, m7);
+            t1 = Avx2.Blend(m3.AsUInt32(), m0.AsUInt32(), 0xCC).AsUInt64();
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 4 — Sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+            t0 = Avx2.UnpackHigh(m3, m1);
+            t1 = Avx2.UnpackHigh(m6, m5);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m4, m0);
+            t1 = Avx2.UnpackLow(m6, m7);
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.AlignRight(m1, m7, 8);
+            t1 = Avx2.Shuffle(m2.AsUInt32(), 0b_01_00_11_10).AsUInt64();
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m4, m3);
+            t1 = Avx2.UnpackLow(m5, m0);
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 5 — Sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+            t0 = Avx2.UnpackHigh(m4, m2);
+            t1 = Avx2.UnpackLow(m1, m5);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.Blend(m0.AsUInt32(), m3.AsUInt32(), 0xCC).AsUInt64();
+            t1 = Avx2.Blend(m2.AsUInt32(), m7.AsUInt32(), 0xCC).AsUInt64();
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.AlignRight(m7, m1, 8);
+            t1 = Avx2.AlignRight(m3, m5, 8);
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m6, m0);
+            t1 = Avx2.UnpackLow(m6, m4);
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 6 — Sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+            t0 = Avx2.UnpackLow(m1, m3);
+            t1 = Avx2.UnpackLow(m0, m4);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m6, m5);
+            t1 = Avx2.UnpackHigh(m5, m1);
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.AlignRight(m2, m0, 8);
+            t1 = Avx2.UnpackHigh(m3, m7);
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m4, m6);
+            t1 = Avx2.AlignRight(m7, m2, 8);
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 7 — Sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+            t0 = Avx2.Blend(m6.AsUInt32(), m0.AsUInt32(), 0xCC).AsUInt64();
+            t1 = Avx2.UnpackLow(m7, m2);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m2, m7);
+            t1 = Avx2.AlignRight(m5, m6, 8);
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m4, m0);
+            t1 = Avx2.Blend(m3.AsUInt32(), m4.AsUInt32(), 0xCC).AsUInt64();
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m5, m3);
+            t1 = Avx2.Shuffle(m1.AsUInt32(), 0b_01_00_11_10).AsUInt64();
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 8 — Sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+            t0 = Avx2.UnpackHigh(m6, m3);
+            t1 = Avx2.Blend(m6.AsUInt32(), m1.AsUInt32(), 0xCC).AsUInt64();
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.AlignRight(m7, m5, 8);
+            t1 = Avx2.UnpackHigh(m0, m4);
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.Blend(m1.AsUInt32(), m2.AsUInt32(), 0xCC).AsUInt64();
+            t1 = Avx2.AlignRight(m4, m7, 8);
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m5, m0);
+            t1 = Avx2.UnpackLow(m2, m3);
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 9 — Sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+            t0 = Avx2.UnpackLow(m3, m7);
+            t1 = Avx2.AlignRight(m0, m5, 8);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m7, m4);
+            t1 = Avx2.AlignRight(m4, m1, 8);
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m5, m6);
+            t1 = Avx2.UnpackHigh(m6, m0);
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.AlignRight(m1, m2, 8);
+            t1 = Avx2.AlignRight(m2, m3, 8);
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            // ROUND 10 — Sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+            t0 = Avx2.UnpackLow(m5, m4);
+            t1 = Avx2.UnpackHigh(m3, m0);
+            mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackLow(m1, m2);
+            t1 = Avx2.Blend(m3.AsUInt32(), m2.AsUInt32(), 0xCC).AsUInt64();
+            my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.UnpackHigh(m6, m7);
+            t1 = Avx2.UnpackHigh(m4, m1);
+            mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            t0 = Avx2.Blend(m0.AsUInt32(), m5.AsUInt32(), 0xCC).AsUInt64();
+            t1 = Avx2.UnpackLow(m7, m6);
+            my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+            GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+            step11and12 = true;
+        }
+
+        // Finalize: state ^= rows ^ IV rows
+        row1 = Avx2.Xor(row1, row3);
+        row2 = Avx2.Xor(row2, row4);
+        row1 = Avx2.Xor(row1, orig1);
+        row2 = Avx2.Xor(row2, orig2);
+
+        Avx.Store(state, row1);
+        Avx.Store(state + Vector256<ulong>.Count, row2);
     }
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.Avx2.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.Avx2.cs
@@ -8,8 +8,6 @@ namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 #if NET8_0_OR_GREATER
 
 using System;
-using System.Buffers.Binary;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -17,37 +15,16 @@ using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 /// <summary>
-/// Computes the BLAKE2b hash for the input data.
+/// AVX2-accelerated BLAKE2b compression using preloaded message in vectors.
 /// </summary>
 /// <remarks>
-/// <para>
-/// This is a fully managed implementation of BLAKE2b that does not rely on
-/// OS or hardware cryptographic APIs, ensuring deterministic behavior across
-/// all platforms and runtimes.
-/// </para>
-/// <para>
-/// BLAKE2b is optimized for 64-bit platforms and produces digests from 1 to 64 bytes.
-/// The default output size is 64 bytes (512 bits).
-/// </para>
-/// <para>
-/// BLAKE2b supports an optional key for keyed hashing (MAC mode) with keys up to 64 bytes.
-/// </para>
+/// All 16 message words are pre-loaded into 8 <see cref="Vector256{T}"/> registers via
+/// <c>BroadcastVector128ToVector256</c>, then each of the 12 fully-unrolled rounds builds
+/// its four input vectors using 1-cycle <c>UnpackLow/High</c>, <c>Blend</c>,
+/// <c>AlignRight</c>, and <c>Shuffle</c> operations.
 /// </remarks>
 public sealed partial class Blake2b : HashAlgorithm
 {
-    // Pre-computed shuffle masks for byte-aligned rotations (static to avoid recreation)
-    private static readonly Vector256<byte> RotateMask24 = Vector256.Create(
-        (byte)3, 4, 5, 6, 7, 0, 1, 2,
-        11, 12, 13, 14, 15, 8, 9, 10,
-        19, 20, 21, 22, 23, 16, 17, 18,
-        27, 28, 29, 30, 31, 24, 25, 26);
-
-    private static readonly Vector256<byte> RotateMask16 = Vector256.Create(
-        (byte)2, 3, 4, 5, 6, 7, 0, 1,
-        10, 11, 12, 13, 14, 15, 8, 9,
-        18, 19, 20, 21, 22, 23, 16, 17,
-        26, 27, 28, 29, 30, 31, 24, 25);
-
     // Pre-computed IV vectors for AVX2 path
     private static readonly Vector256<ulong> IVLow = Vector256.Create(
         0x6a09e667f3bcc908UL, 0xbb67ae8584caa73bUL,
@@ -60,37 +37,18 @@ public sealed partial class Blake2b : HashAlgorithm
     // Finalization mask for inverting element 2 of row3
     private static readonly Vector256<ulong> FinalMask = Vector256.Create(0UL, 0UL, ~0UL, 0UL);
 
-    // Pre-computed Vector128<int> indices for gather operations (scaled by 8 for ulong stride)
-    private static readonly Vector128<int>[] GatherIndicesX = new Vector128<int>[Rounds * 2];
-    private static readonly Vector128<int>[] GatherIndicesY = new Vector128<int>[Rounds * 2];
+    // Pre-computed shuffle masks for byte-aligned rotations
+    private static readonly Vector256<byte> RotateMask24 = Vector256.Create(
+        (byte)3, 4, 5, 6, 7, 0, 1, 2,
+        11, 12, 13, 14, 15, 8, 9, 10,
+        19, 20, 21, 22, 23, 16, 17, 18,
+        27, 28, 29, 30, 31, 24, 25, 26);
 
-    // Vector state for AVX2 path
-    private Vector256<ulong> _stateVec0;
-    private Vector256<ulong> _stateVec1;
-
-    static Blake2b()
-    {
-        for (int round = 0; round < Rounds; round++)
-        {
-            int offset = round * ScratchSize;
-
-            // Column step indices (multiply by 8 for byte offset of ulong)
-            GatherIndicesX[round * 2] = Vector128.Create(
-                Sigma[offset + 0] * 8, Sigma[offset + 2] * 8,
-                Sigma[offset + 4] * 8, Sigma[offset + 6] * 8);
-            GatherIndicesY[round * 2] = Vector128.Create(
-                Sigma[offset + 1] * 8, Sigma[offset + 3] * 8,
-                Sigma[offset + 5] * 8, Sigma[offset + 7] * 8);
-
-            // Diagonal step indices
-            GatherIndicesX[round * 2 + 1] = Vector128.Create(
-                Sigma[offset + 8] * 8, Sigma[offset + 10] * 8,
-                Sigma[offset + 12] * 8, Sigma[offset + 14] * 8);
-            GatherIndicesY[round * 2 + 1] = Vector128.Create(
-                Sigma[offset + 9] * 8, Sigma[offset + 11] * 8,
-                Sigma[offset + 13] * 8, Sigma[offset + 15] * 8);
-        }
-    }
+    private static readonly Vector256<byte> RotateMask16 = Vector256.Create(
+        (byte)2, 3, 4, 5, 6, 7, 0, 1,
+        10, 11, 12, 13, 14, 15, 8, 9,
+        18, 19, 20, 21, 22, 23, 16, 17,
+        26, 27, 28, 29, 30, 31, 24, 25);
 
     /// <summary>
     /// Gets the SIMD instruction sets supported by this algorithm on the current platform.
@@ -99,96 +57,246 @@ public sealed partial class Blake2b : HashAlgorithm
     {
         get
         {
-            var support = SimdSupport.None;
+            SimdSupport support = SimdSupport.None;
             if (Avx2.IsSupported) support |= SimdSupport.Avx2;
             if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
             return support;
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void InitializeStateAvx2(ulong paramBlock)
-    {
-        _stateVec0 = Avx2.Xor(IVLow, Vector256.Create(paramBlock, 0UL, 0UL, 0UL));
-        _stateVec1 = IVHigh;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ExtractOutputAvx2(Span<byte> destination)
-    {
-        // Store vectors to stack, then copy required bytes
-        Span<ulong> temp = stackalloc ulong[8];
-        _stateVec0.CopyTo(temp[..4]);
-        _stateVec1.CopyTo(temp[4..]);
-
-        int fullWords = _outputBytes / 8;
-        for (int i = 0; i < fullWords; i++)
-        {
-            BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(i * sizeof(UInt64)), temp[i]);
-        }
-
-        int remainingBytes = _outputBytes & 7;
-        if (remainingBytes > 0)
-        {
-            Span<byte> tempBytes = stackalloc byte[sizeof(UInt64)];
-            BinaryPrimitives.WriteUInt64LittleEndian(tempBytes, temp[fullWords]);
-            tempBytes.Slice(0, remainingBytes).CopyTo(destination.Slice(fullWords * sizeof(UInt64)));
-        }
-    }
-
+    [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private unsafe void CompressAvx2(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
     {
         _bytesCompressed += (ulong)bytesConsumed;
 
-        // Pin the message block for gather operations
-        fixed (byte* mPtr = block)
+        fixed (byte* msgPtr = block)
         {
-            // Initialize rows from vector state
-            var row0 = _stateVec0;
-            var row1 = _stateVec1;
-            var row2 = IVLow;
-
-            // row3 = IVHigh with counter/finalization applied
-            var counterVec = Vector256.Create(_bytesCompressed, 0UL, 0UL, 0UL);
-            var row3 = Avx2.Xor(IVHigh, counterVec);
+            // Load state into vector registers
+            ulong* state = (ulong*)Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(_state));
+            Vector256<ulong> row1 = Avx.LoadVector256(state);
+            Vector256<ulong> row2 = Avx.LoadVector256(state + Vector256<ulong>.Count);
+            Vector256<ulong> row3 = IVLow;
+            Vector256<ulong> row4 = Avx2.Xor(IVHigh, Vector256.Create(_bytesCompressed, 0UL, 0UL, 0UL));
 
             if (isFinal)
             {
-                // Invert element 2 (the finalization flag)
-                row3 = Avx2.Xor(row3, FinalMask);
+                row4 = Avx2.Xor(row4, FinalMask);
             }
 
-            // 12 rounds
-            for (int round = 0; round < Rounds; round++)
+            // Save original state for finalization
+            Vector256<ulong> orig1 = row1;
+            Vector256<ulong> orig2 = row2;
+
+            // Pre-load all 16 message words as 8 broadcast Vector256<ulong> pairs.
+            // Each m_i = [w_{2i}, w_{2i+1}, w_{2i}, w_{2i+1}] via vbroadcasti128.
+            Vector256<ulong> m0 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr));
+            Vector256<ulong> m1 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 1 * sizeof(Vector128<ulong>)));
+            Vector256<ulong> m2 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 2 * sizeof(Vector128<ulong>)));
+            Vector256<ulong> m3 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 3 * sizeof(Vector128<ulong>)));
+            Vector256<ulong> m4 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 4 * sizeof(Vector128<ulong>)));
+            Vector256<ulong> m5 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 5 * sizeof(Vector128<ulong>)));
+            Vector256<ulong> m6 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 6 * sizeof(Vector128<ulong>)));
+            Vector256<ulong> m7 = Avx2.BroadcastVector128ToVector256((ulong*)(msgPtr + 7 * sizeof(Vector128<ulong>)));
+
+            bool step11and12 = false;
+            while (true)
             {
-                int gatherIndex = round * 2;
+                Vector256<ulong> t0, t1, mx1, my1, mx2, my2;
 
-                // Column step - use gather for message words
-                var mx = Avx2.GatherVector256((long*)mPtr, GatherIndicesX[gatherIndex], 1).AsUInt64();
-                GRoundX(ref row0, ref row1, ref row2, ref row3, mx);
+                // ROUND 1/11 — Sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+                t0 = Avx2.UnpackLow(m0, m1);
+                t1 = Avx2.UnpackLow(m2, m3);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m0, m1);
+                t1 = Avx2.UnpackHigh(m2, m3);
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m7, m4);
+                t1 = Avx2.UnpackLow(m5, m6);
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m7, m4);
+                t1 = Avx2.UnpackHigh(m5, m6);
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
 
-                var my = Avx2.GatherVector256((long*)mPtr, GatherIndicesY[gatherIndex], 1).AsUInt64();
-                GRoundY(ref row0, ref row1, ref row2, ref row3, my);
+                // ROUND 2/12 — Sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+                t0 = Avx2.UnpackLow(m7, m2);
+                t1 = Avx2.UnpackHigh(m4, m6);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m5, m4);
+                t1 = Avx2.AlignRight(m3, m7, 8);
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m2, m0);
+                t1 = Avx2.Blend(m0.AsUInt32(), m5.AsUInt32(), 0xCC).AsUInt64();
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.AlignRight(m6, m1, 8);
+                t1 = Avx2.Blend(m1.AsUInt32(), m3.AsUInt32(), 0xCC).AsUInt64();
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
 
-                // Diagonal permutations
-                Permute(ref row1, ref row2, ref row3);
+                // exit if second round processed step 11 and 12
+                if (step11and12)
+                {
+                    break;
+                }
 
-                // Diagonal step
-                mx = Avx2.GatherVector256((long*)mPtr, GatherIndicesX[gatherIndex + 1], 1).AsUInt64();
-                GRoundX(ref row0, ref row1, ref row2, ref row3, mx);
+                // ROUND 3 — Sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+                t0 = Avx2.AlignRight(m6, m5, 8);
+                t1 = Avx2.UnpackHigh(m2, m7);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m4, m0);
+                t1 = Avx2.Blend(m1.AsUInt32(), m6.AsUInt32(), 0xCC).AsUInt64();
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.AlignRight(m5, m4, 8);
+                t1 = Avx2.UnpackHigh(m1, m3);
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m2, m7);
+                t1 = Avx2.Blend(m3.AsUInt32(), m0.AsUInt32(), 0xCC).AsUInt64();
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
 
-                my = Avx2.GatherVector256((long*)mPtr, GatherIndicesY[gatherIndex + 1], 1).AsUInt64();
-                GRoundY(ref row0, ref row1, ref row2, ref row3, my);
+                // ROUND 4 — Sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+                t0 = Avx2.UnpackHigh(m3, m1);
+                t1 = Avx2.UnpackHigh(m6, m5);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m4, m0);
+                t1 = Avx2.UnpackLow(m6, m7);
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.AlignRight(m1, m7, 8);
+                t1 = Avx2.Shuffle(m2.AsUInt32(), 0b_01_00_11_10).AsUInt64();
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m4, m3);
+                t1 = Avx2.UnpackLow(m5, m0);
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
 
-                // Un-rotate
-                Permute(ref row3, ref row2, ref row1);
+                // ROUND 5 — Sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+                t0 = Avx2.UnpackHigh(m4, m2);
+                t1 = Avx2.UnpackLow(m1, m5);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.Blend(m0.AsUInt32(), m3.AsUInt32(), 0xCC).AsUInt64();
+                t1 = Avx2.Blend(m2.AsUInt32(), m7.AsUInt32(), 0xCC).AsUInt64();
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.AlignRight(m7, m1, 8);
+                t1 = Avx2.AlignRight(m3, m5, 8);
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m6, m0);
+                t1 = Avx2.UnpackLow(m6, m4);
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+                // ROUND 6 — Sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+                t0 = Avx2.UnpackLow(m1, m3);
+                t1 = Avx2.UnpackLow(m0, m4);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m6, m5);
+                t1 = Avx2.UnpackHigh(m5, m1);
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.AlignRight(m2, m0, 8);
+                t1 = Avx2.UnpackHigh(m3, m7);
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m4, m6);
+                t1 = Avx2.AlignRight(m7, m2, 8);
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+                // ROUND 7 — Sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+                t0 = Avx2.Blend(m6.AsUInt32(), m0.AsUInt32(), 0xCC).AsUInt64();
+                t1 = Avx2.UnpackLow(m7, m2);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m2, m7);
+                t1 = Avx2.AlignRight(m5, m6, 8);
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m4, m0);
+                t1 = Avx2.Blend(m3.AsUInt32(), m4.AsUInt32(), 0xCC).AsUInt64();
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m5, m3);
+                t1 = Avx2.Shuffle(m1.AsUInt32(), 0b_01_00_11_10).AsUInt64();
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+                // ROUND 8 — Sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+                t0 = Avx2.UnpackHigh(m6, m3);
+                t1 = Avx2.Blend(m6.AsUInt32(), m1.AsUInt32(), 0xCC).AsUInt64();
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.AlignRight(m7, m5, 8);
+                t1 = Avx2.UnpackHigh(m0, m4);
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.Blend(m1.AsUInt32(), m2.AsUInt32(), 0xCC).AsUInt64();
+                t1 = Avx2.AlignRight(m4, m7, 8);
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m5, m0);
+                t1 = Avx2.UnpackLow(m2, m3);
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+                // ROUND 9 — Sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+                t0 = Avx2.UnpackLow(m3, m7);
+                t1 = Avx2.AlignRight(m0, m5, 8);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m7, m4);
+                t1 = Avx2.AlignRight(m4, m1, 8);
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m5, m6);
+                t1 = Avx2.UnpackHigh(m6, m0);
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.AlignRight(m1, m2, 8);
+                t1 = Avx2.AlignRight(m2, m3, 8);
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+                // ROUND 10 — Sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+                t0 = Avx2.UnpackLow(m5, m4);
+                t1 = Avx2.UnpackHigh(m3, m0);
+                mx1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackLow(m1, m2);
+                t1 = Avx2.Blend(m3.AsUInt32(), m2.AsUInt32(), 0xCC).AsUInt64();
+                my1 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.UnpackHigh(m6, m7);
+                t1 = Avx2.UnpackHigh(m4, m1);
+                mx2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                t0 = Avx2.Blend(m0.AsUInt32(), m5.AsUInt32(), 0xCC).AsUInt64();
+                t1 = Avx2.UnpackLow(m7, m6);
+                my2 = Avx2.Blend(t0.AsUInt32(), t1.AsUInt32(), 0xF0).AsUInt64();
+                GRound(ref row1, ref row2, ref row3, ref row4, mx1, my1, mx2, my2);
+
+                step11and12 = true;
             }
 
-            // Finalize: state ^= row0 ^ row2, state ^= row1 ^ row3
-            _stateVec0 = Avx2.Xor(_stateVec0, Avx2.Xor(row0, row2));
-            _stateVec1 = Avx2.Xor(_stateVec1, Avx2.Xor(row1, row3));
+            // Finalize: state ^= rows ^ IV rows
+            row1 = Avx2.Xor(row1, row3);
+            row2 = Avx2.Xor(row2, row4);
+            row1 = Avx2.Xor(row1, orig1);
+            row2 = Avx2.Xor(row2, orig2);
+
+            Avx.Store(state, row1);
+            Avx.Store(state + Vector256<ulong>.Count, row2);
         }
+    }
+
+    /// <summary>
+    /// Performs one full BLAKE2b round (column step + diagonal step) using AVX2.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private static void GRound(
+        ref Vector256<ulong> row1, ref Vector256<ulong> row2,
+        ref Vector256<ulong> row3, ref Vector256<ulong> row4,
+        Vector256<ulong> mx1, Vector256<ulong> my1,
+        Vector256<ulong> mx2, Vector256<ulong> my2)
+    {
+        // Column step
+        GRoundX(ref row1, ref row2, ref row3, ref row4, mx1);
+        GRoundY(ref row1, ref row2, ref row3, ref row4, my1);
+
+        // Diagonalize
+        Permute(ref row3, ref row4, ref row1);
+
+        // Diagonal step
+        GRoundX(ref row1, ref row2, ref row3, ref row4, mx2);
+        GRoundY(ref row1, ref row2, ref row3, ref row4, my2);
+
+        // Un-diagonalize — reverse the shifts
+        Permute(ref row1, ref row4, ref row3);
     }
 
     /// <summary>
@@ -203,7 +311,7 @@ public sealed partial class Blake2b : HashAlgorithm
         Vector256<ulong> x)
     {
         // a = a + b + x
-        a = Avx2.Add(a, Avx2.Add(b, x));
+        a = Avx2.Add(b, Avx2.Add(a, x));
         // d = ror(d ^ a, 32)
         d = Avx2.Shuffle(Avx2.Xor(d, a).AsUInt32(), 0b_10_11_00_01).AsUInt64();
 
@@ -225,7 +333,7 @@ public sealed partial class Blake2b : HashAlgorithm
         Vector256<ulong> y)
     {
         // a = a + b + y
-        a = Avx2.Add(a, Avx2.Add(b, y));
+        a = Avx2.Add(b, Avx2.Add(a, y));
         // d = ror(d ^ a, 16)
         d = Avx2.Shuffle(Avx2.Xor(d, a).AsByte(), RotateMask16).AsUInt64();
 

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.Avx2.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.Avx2.cs
@@ -59,7 +59,9 @@ public sealed partial class Blake2b : HashAlgorithm
         {
             SimdSupport support = SimdSupport.None;
             if (Avx2.IsSupported) support |= SimdSupport.Avx2;
+#if EXPERIMENTAL
             if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
+#endif
             return support;
         }
     }

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
@@ -5,7 +5,7 @@
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER && EXPERIMENTAL
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -48,7 +48,7 @@ public sealed partial class Blake2b : HashAlgorithm
         var r2L = Vector128.Create(IV[0], IV[1]);
         var r2H = Vector128.Create(IV[2], IV[3]);
         var r3L = Vector128.Create(IV[4] ^ bytesCompressed, IV[5]);
-        var r3H = Vector128.Create(isFinal ? IV[6] ^ ~0UL : IV[6] , IV[7]);
+        var r3H = Vector128.Create(isFinal ? IV[6] ^ ~0UL : IV[6], IV[7]);
 
         // Save original state for finalization
         var orig0L = r0L;

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
@@ -8,19 +8,21 @@ namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 #if NET8_0_OR_GREATER
 
 using System;
-using System.Buffers.Binary;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 
 /// <summary>
-/// BLAKE2b ARM NEON-accelerated compression using AdvSimd intrinsics.
+/// BLAKE2b ARM NEON-accelerated compression.
 /// </summary>
 /// <remarks>
-/// NEON provides only 128-bit registers, so each logical row is split into a lo half
-/// (elements 0–1) and a hi half (elements 2–3).
+/// <para>
+/// All 16 message words are pre-loaded as 8 <see cref="Vector128{T}"/> pairs via
+/// <c>AdvSimd.LoadVector128</c>, then each of the 12 fully-unrolled rounds builds
+/// its message input vectors using single-cycle <c>ZipLow</c>, <c>ZipHigh</c>,
+/// <c>ExtractVector128</c>, and <c>InsertSelectedScalar</c> operations.
+/// </para>
 /// </remarks>
 public sealed partial class Blake2b : HashAlgorithm
 {
@@ -46,206 +48,217 @@ public sealed partial class Blake2b : HashAlgorithm
     private static readonly Vector128<ulong> s_ivNeon3 = Vector128.Create(   // IVHigh[2..3]
         0x1f83d9abfb41bd6bUL, 0x5be0cd19137e2179UL);
 
-    // Finalization mask: inverts element 0 of s_ivNeon3 (corresponds to v[14] = ~IV[6])
-    private static readonly Vector128<ulong> s_neonFinalMask = Vector128.Create(~0UL, 0UL);
-
-    // NEON vector state: 8 ulong words split as four 128-bit pairs
-    private Vector128<ulong> _neonState0;  // state[0..1]
-    private Vector128<ulong> _neonState1;  // state[2..3]
-    private Vector128<ulong> _neonState2;  // state[4..5]
-    private Vector128<ulong> _neonState3;  // state[6..7]
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void InitializeStateNeon(ulong paramBlock)
-    {
-        _neonState0 = s_ivNeon0 ^ Vector128.Create(paramBlock, 0UL);
-        _neonState1 = s_ivNeon1;
-        _neonState2 = s_ivNeon2;
-        _neonState3 = s_ivNeon3;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ExtractOutputNeon(Span<byte> destination)
-    {
-        // Store NEON vector state to a stack buffer, then copy required bytes.
-        Span<ulong> temp = stackalloc ulong[8];
-        _neonState0.CopyTo(temp[..2]);
-        _neonState1.CopyTo(temp[2..4]);
-        _neonState2.CopyTo(temp[4..6]);
-        _neonState3.CopyTo(temp[6..]);
-
-        int fullWords = _outputBytes / 8;
-        for (int i = 0; i < fullWords; i++)
-        {
-            BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(i * sizeof(UInt64)), temp[i]);
-        }
-
-        int remainingBytes = _outputBytes & 7;
-        if (remainingBytes > 0)
-        {
-            Span<byte> tempBytes = stackalloc byte[sizeof(UInt64)];
-            BinaryPrimitives.WriteUInt64LittleEndian(tempBytes, temp[fullWords]);
-            tempBytes.Slice(0, remainingBytes).CopyTo(destination.Slice(fullWords * sizeof(UInt64)));
-        }
-    }
-
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private void CompressNeon(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private unsafe void CompressNeon(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
     {
         _bytesCompressed += (ulong)bytesConsumed;
 
-        Vector128<ulong> r0L = _neonState0;
-        Vector128<ulong> r0H = _neonState1;
-        Vector128<ulong> r1L = _neonState2;
-        Vector128<ulong> r1H = _neonState3;
-        Vector128<ulong> r2L = s_ivNeon0;
-        Vector128<ulong> r2H = s_ivNeon1;
-        Vector128<ulong> r3L = s_ivNeon2 ^ Vector128.Create(_bytesCompressed, 0UL);
-        Vector128<ulong> r3H = isFinal ? s_ivNeon3 ^ s_neonFinalMask : s_ivNeon3;
+        // Load state from the shared _state[] array (same layout as AVX2 path)
+        ulong* state = (ulong*)Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(_state));
+        var r0L = AdvSimd.LoadVector128(state);
+        var r0H = AdvSimd.LoadVector128(state + 2);
+        var r1L = AdvSimd.LoadVector128(state + 4);
+        var r1H = AdvSimd.LoadVector128(state + 6);
 
-        // Pre-load all 16 message words into locals — eliminates Sigma indirection from inner rounds
-        Span<ulong> msg = stackalloc ulong[ScratchSize];
-        BinarySpans.ReadUInt64LittleEndian(block, msg);
-        ulong w0 = msg[0]; ulong w1 = msg[1]; ulong w2 = msg[2]; ulong w3 = msg[3];
-        ulong w4 = msg[4]; ulong w5 = msg[5]; ulong w6 = msg[6]; ulong w7 = msg[7];
-        ulong w8 = msg[8]; ulong w9 = msg[9]; ulong w10 = msg[10]; ulong w11 = msg[11];
-        ulong w12 = msg[12]; ulong w13 = msg[13]; ulong w14 = msg[14]; ulong w15 = msg[15];
+        var r2L = s_ivNeon0;
+        var r2H = s_ivNeon1;
+        var r3L = AdvSimd.Xor(s_ivNeon2, Vector128.Create(_bytesCompressed, 0UL));
+        var r3H = isFinal ? AdvSimd.Xor(s_ivNeon3, Vector128.Create(~0UL, 0UL)) : s_ivNeon3;
 
-        // ROUND 1 — Sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w0, w2), Vector128.Create(w4, w6),
-            Vector128.Create(w1, w3), Vector128.Create(w5, w7),
-            Vector128.Create(w8, w10), Vector128.Create(w12, w14),
-            Vector128.Create(w9, w11), Vector128.Create(w13, w15));
+        // Save original state for finalization
+        var orig0L = r0L;
+        var orig0H = r0H;
+        var orig1L = r1L;
+        var orig1H = r1H;
 
-        // ROUND 2 — Sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w14, w4), Vector128.Create(w9, w13),
-            Vector128.Create(w10, w8), Vector128.Create(w15, w6),
-            Vector128.Create(w1, w0), Vector128.Create(w11, w5),
-            Vector128.Create(w12, w2), Vector128.Create(w7, w3));
+        // Pre-load all 16 message words as 8 vector pairs via direct 128-bit loads.
+        // m_i = [w_{2i}, w_{2i+1}] — ARM64 .NET is always little-endian.
+        fixed (byte* bp = block)
+        {
+            ulong* mp = (ulong*)bp;
+            var m0 = AdvSimd.LoadVector128(mp);
+            var m1 = AdvSimd.LoadVector128(mp + 2);
+            var m2 = AdvSimd.LoadVector128(mp + 4);
+            var m3 = AdvSimd.LoadVector128(mp + 6);
+            var m4 = AdvSimd.LoadVector128(mp + 8);
+            var m5 = AdvSimd.LoadVector128(mp + 10);
+            var m6 = AdvSimd.LoadVector128(mp + 12);
+            var m7 = AdvSimd.LoadVector128(mp + 14);
 
-        // ROUND 3 — Sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w11, w12), Vector128.Create(w5, w15),
-            Vector128.Create(w8, w0), Vector128.Create(w2, w13),
-            Vector128.Create(w10, w3), Vector128.Create(w7, w9),
-            Vector128.Create(w14, w6), Vector128.Create(w1, w4));
+            // 12 rounds, fully unrolled. Rounds 11/12 reuse rounds 1/2 via loop.
+            // Message scheduling uses single-cycle NEON shuffles:
+            //   ZipLow(a,b)  → [a0, b0]    ZipHigh(a,b)       → [a1, b1]
+            //   Ext(a,b,#8)  → [a1, b0]    Ins(a,1,b,1)       → [a0, b1]
+            bool step11and12 = false;
+            while (true)
+            {
+                // Round 1/11 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m0, m1), AdvSimd.Arm64.ZipLow(m2, m3));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m0, m1), AdvSimd.Arm64.ZipHigh(m2, m3));
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m4, m5), AdvSimd.Arm64.ZipLow(m6, m7));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m4, m5), AdvSimd.Arm64.ZipHigh(m6, m7));
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 4 — Sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w7, w3), Vector128.Create(w13, w11),
-            Vector128.Create(w9, w1), Vector128.Create(w12, w14),
-            Vector128.Create(w2, w5), Vector128.Create(w4, w15),
-            Vector128.Create(w6, w10), Vector128.Create(w0, w8));
+                // Round 2/12 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m7, m2), AdvSimd.Arm64.ZipHigh(m4, m6));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m5, m4),
+                    AdvSimd.ExtractVector128(m7.AsByte(), m3.AsByte(), 8).AsUInt64());
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.ExtractVector128(m0.AsByte(), m0.AsByte(), 8).AsUInt64(),
+                    AdvSimd.Arm64.ZipHigh(m5, m2));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m6, m1), AdvSimd.Arm64.ZipHigh(m3, m1));
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 5 — Sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w9, w5), Vector128.Create(w2, w10),
-            Vector128.Create(w0, w7), Vector128.Create(w4, w15),
-            Vector128.Create(w14, w11), Vector128.Create(w6, w3),
-            Vector128.Create(w1, w12), Vector128.Create(w8, w13));
+                if (step11and12) break;
 
-        // ROUND 6 — Sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w2, w6), Vector128.Create(w0, w8),
-            Vector128.Create(w12, w10), Vector128.Create(w11, w3),
-            Vector128.Create(w4, w7), Vector128.Create(w15, w1),
-            Vector128.Create(w13, w5), Vector128.Create(w14, w9));
+                // Round 3 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.ExtractVector128(m5.AsByte(), m6.AsByte(), 8).AsUInt64(),
+                    AdvSimd.Arm64.ZipHigh(m2, m7));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m4, m0),
+                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m6.AsInt64(), 1).AsUInt64());
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.InsertSelectedScalar(m5.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64(),
+                    AdvSimd.Arm64.ZipHigh(m3, m4));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m7, m3),
+                    AdvSimd.ExtractVector128(m0.AsByte(), m2.AsByte(), 8).AsUInt64());
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 7 — Sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w12, w1), Vector128.Create(w14, w4),
-            Vector128.Create(w5, w15), Vector128.Create(w13, w10),
-            Vector128.Create(w0, w6), Vector128.Create(w9, w8),
-            Vector128.Create(w7, w3), Vector128.Create(w2, w11));
+                // Round 4 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m3, m1), AdvSimd.Arm64.ZipHigh(m6, m5));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m4, m0), AdvSimd.Arm64.ZipLow(m6, m7));
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m2.AsInt64(), 1).AsUInt64(),
+                    AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m7.AsInt64(), 1).AsUInt64());
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m3, m5), AdvSimd.Arm64.ZipLow(m0, m4));
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 8 — Sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w13, w7), Vector128.Create(w12, w3),
-            Vector128.Create(w11, w14), Vector128.Create(w1, w9),
-            Vector128.Create(w5, w15), Vector128.Create(w8, w2),
-            Vector128.Create(w0, w4), Vector128.Create(w6, w10));
+                // Round 5 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m4, m2), AdvSimd.Arm64.ZipLow(m1, m5));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.InsertSelectedScalar(m0.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
+                    AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m7.AsInt64(), 1).AsUInt64());
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.InsertSelectedScalar(m7.AsInt64(), 1, m5.AsInt64(), 1).AsUInt64(),
+                    AdvSimd.Arm64.InsertSelectedScalar(m3.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64());
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.ExtractVector128(m0.AsByte(), m6.AsByte(), 8).AsUInt64(),
+                    AdvSimd.Arm64.InsertSelectedScalar(m4.AsInt64(), 1, m6.AsInt64(), 1).AsUInt64());
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 9 — Sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w6, w14), Vector128.Create(w11, w0),
-            Vector128.Create(w15, w9), Vector128.Create(w3, w8),
-            Vector128.Create(w12, w13), Vector128.Create(w1, w10),
-            Vector128.Create(w2, w7), Vector128.Create(w4, w5));
+                // Round 6 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m1, m3), AdvSimd.Arm64.ZipLow(m0, m4));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m6, m5), AdvSimd.Arm64.ZipHigh(m5, m1));
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
+                    AdvSimd.Arm64.ZipHigh(m7, m0));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m6, m2),
+                    AdvSimd.Arm64.InsertSelectedScalar(m7.AsInt64(), 1, m4.AsInt64(), 1).AsUInt64());
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 10 — Sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w10, w8), Vector128.Create(w7, w1),
-            Vector128.Create(w2, w4), Vector128.Create(w6, w5),
-            Vector128.Create(w15, w9), Vector128.Create(w3, w13),
-            Vector128.Create(w11, w14), Vector128.Create(w12, w0));
+                // Round 7 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.InsertSelectedScalar(m6.AsInt64(), 1, m0.AsInt64(), 1).AsUInt64(),
+                    AdvSimd.Arm64.ZipLow(m7, m2));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m2, m7),
+                    AdvSimd.ExtractVector128(m6.AsByte(), m5.AsByte(), 8).AsUInt64());
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m0, m3),
+                    AdvSimd.ExtractVector128(m4.AsByte(), m4.AsByte(), 8).AsUInt64());
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m3, m1),
+                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m5.AsInt64(), 1).AsUInt64());
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 11 — (same as round 1)
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w0, w2), Vector128.Create(w4, w6),
-            Vector128.Create(w1, w3), Vector128.Create(w5, w7),
-            Vector128.Create(w8, w10), Vector128.Create(w12, w14),
-            Vector128.Create(w9, w11), Vector128.Create(w13, w15));
+                // Round 8 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m6, m3),
+                    AdvSimd.Arm64.InsertSelectedScalar(m6.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64());
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.ExtractVector128(m5.AsByte(), m7.AsByte(), 8).AsUInt64(),
+                    AdvSimd.Arm64.ZipHigh(m0, m4));
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m2, m7), AdvSimd.Arm64.ZipLow(m4, m1));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m0, m2), AdvSimd.Arm64.ZipLow(m3, m5));
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-        // ROUND 12 — (same as round 2)
-        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-            Vector128.Create(w14, w4), Vector128.Create(w9, w13),
-            Vector128.Create(w10, w8), Vector128.Create(w15, w6),
-            Vector128.Create(w1, w0), Vector128.Create(w11, w5),
-            Vector128.Create(w12, w2), Vector128.Create(w7, w3));
+                // Round 9 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m3, m7),
+                    AdvSimd.ExtractVector128(m5.AsByte(), m0.AsByte(), 8).AsUInt64());
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m7, m4),
+                    AdvSimd.ExtractVector128(m1.AsByte(), m4.AsByte(), 8).AsUInt64());
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    m6,
+                    AdvSimd.ExtractVector128(m0.AsByte(), m5.AsByte(), 8).AsUInt64());
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
+                    m2);
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+                // Round 10 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m5, m4), AdvSimd.Arm64.ZipHigh(m3, m0));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipLow(m1, m2),
+                    AdvSimd.Arm64.InsertSelectedScalar(m3.AsInt64(), 1, m2.AsInt64(), 1).AsUInt64());
+                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.Arm64.ZipHigh(m7, m4), AdvSimd.Arm64.ZipHigh(m1, m6));
+                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                    AdvSimd.ExtractVector128(m5.AsByte(), m7.AsByte(), 8).AsUInt64(),
+                    AdvSimd.Arm64.ZipLow(m6, m0));
+                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+                step11and12 = true;
+            }
+        }
 
         // Finalize: state[i] ^= v[i] ^ v[i+8]
-        _neonState0 ^= r0L ^ r2L;
-        _neonState1 ^= r0H ^ r2H;
-        _neonState2 ^= r1L ^ r3L;
-        _neonState3 ^= r1H ^ r3H;
+        r0L = AdvSimd.Xor(AdvSimd.Xor(r0L, r2L), orig0L);
+        r0H = AdvSimd.Xor(AdvSimd.Xor(r0H, r2H), orig0H);
+        r1L = AdvSimd.Xor(AdvSimd.Xor(r1L, r3L), orig1L);
+        r1H = AdvSimd.Xor(AdvSimd.Xor(r1H, r3H), orig1H);
+
+        AdvSimd.Store(state, r0L);
+        AdvSimd.Store(state + 2, r0H);
+        AdvSimd.Store(state + 4, r1L);
+        AdvSimd.Store(state + 6, r1H);
     }
 
     /// <summary>
-    /// Performs one full BLAKE2b round (column step + diagonal step) using NEON.
+    /// Performs one Gx half-round: <c>a += b + x; d = ror(d^a, 32); c += d; b = ror(b^c, 24)</c>.
     /// </summary>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    [SuppressMessage("Performance", "CA1857:A constant is expected for the parameter", Justification = "False negative, false constant provided in .NET 8.0 runtime")]
-    private static void NeonRound(
-        ref Vector128<ulong> r0L, ref Vector128<ulong> r0H,
-        ref Vector128<ulong> r1L, ref Vector128<ulong> r1H,
-        ref Vector128<ulong> r2L, ref Vector128<ulong> r2H,
-        ref Vector128<ulong> r3L, ref Vector128<ulong> r3H,
-        Vector128<ulong> mxL, Vector128<ulong> mxH,
-        Vector128<ulong> myL, Vector128<ulong> myH,
-        Vector128<ulong> dxL, Vector128<ulong> dxH,
-        Vector128<ulong> dyL, Vector128<ulong> dyH)
-    {
-        // Column step
-        GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, mxL, mxH);
-        GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, myL, myH);
-
-        // Diagonalize
-        PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-
-        // Diagonal step
-        GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, dxL, dxH);
-        GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, dyL, dyH);
-
-        // Un-diagonalize
-        PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-    }
-
-    /// <summary>
-    /// Performs one Gx half-round on 4 parallel 64-bit lanes split across 128-bit NEON registers.
-    /// </summary>
-    /// <remarks>
-    /// Each logical 256-bit row is represented as (L, H): two <see cref="Vector128{T}"/> holding
-    /// elements 0–1 and 2–3 respectively.
-    /// <list type="bullet">
-    ///   <item><description><c>a += b + x; d = ror64(d^a, 32)</c></description></item>
-    ///   <item><description><c>c += d; b = ror64(b^c, 24)</c></description></item>
-    /// </list>
-    /// </remarks>
-    [MethodImpl(MethodImplOptionsEx.HotPath)]
-    [SuppressMessage("Performance", "CA1857:A constant is expected for the parameter", Justification = "False negative, false constant provided in .NET 8.0 runtime")]
     private static void GRoundXNeon(
         ref Vector128<ulong> aL, ref Vector128<ulong> aH,
         ref Vector128<ulong> bL, ref Vector128<ulong> bH,
@@ -253,35 +266,22 @@ public sealed partial class Blake2b : HashAlgorithm
         ref Vector128<ulong> dL, ref Vector128<ulong> dH,
         Vector128<ulong> xL, Vector128<ulong> xH)
     {
-        // a += b + x
         aL = AdvSimd.Add(aL, AdvSimd.Add(bL, xL));
         aH = AdvSimd.Add(aH, AdvSimd.Add(bH, xH));
-        // d = ror64(d ^ a, 32) — shift+or (32-bit swap within each 64-bit element)
-        Vector128<ulong> dxL = dL ^ aL;
-        Vector128<ulong> dxH = dH ^ aH;
-        dL = AdvSimd.Or(AdvSimd.ShiftRightLogical(dxL, 32), AdvSimd.ShiftLeftLogical(dxL, 32));
-        dH = AdvSimd.Or(AdvSimd.ShiftRightLogical(dxH, 32), AdvSimd.ShiftLeftLogical(dxH, 32));
-        // c += d
+        // ror64(d ^ a, 32) — single REV64.4S instruction
+        dL = AdvSimd.ReverseElement32((dL ^ aL).AsInt64()).AsUInt64();
+        dH = AdvSimd.ReverseElement32((dH ^ aH).AsInt64()).AsUInt64();
         cL = AdvSimd.Add(cL, dL);
         cH = AdvSimd.Add(cH, dH);
-        // b = ror64(b ^ c, 24) — TBL byte shuffle
-        Vector128<ulong> bxL = bL ^ cL;
-        Vector128<ulong> bxH = bH ^ cH;
-        bL = AdvSimd.Arm64.VectorTableLookup(bxL.AsByte(), s_neonRotMask24).AsUInt64();
-        bH = AdvSimd.Arm64.VectorTableLookup(bxH.AsByte(), s_neonRotMask24).AsUInt64();
+        // ror64(b ^ c, 24) — TBL byte shuffle
+        bL = AdvSimd.Arm64.VectorTableLookup((bL ^ cL).AsByte(), s_neonRotMask24).AsUInt64();
+        bH = AdvSimd.Arm64.VectorTableLookup((bH ^ cH).AsByte(), s_neonRotMask24).AsUInt64();
     }
 
     /// <summary>
-    /// Performs one Gy half-round on 4 parallel 64-bit lanes split across 128-bit NEON registers.
+    /// Performs one Gy half-round: <c>a += b + y; d = ror(d^a, 16); c += d; b = ror(b^c, 63)</c>.
     /// </summary>
-    /// <remarks>
-    /// <list type="bullet">
-    ///   <item><description><c>a += b + y; d = ror64(d^a, 16)</c></description></item>
-    ///   <item><description><c>c += d; b = ror64(b^c, 63)</c></description></item>
-    /// </list>
-    /// </remarks>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    [SuppressMessage("Performance", "CA1857:A constant is expected for the parameter", Justification = "False negative, false constant provided in .NET 8.0 runtime")]
     private static void GRoundYNeon(
         ref Vector128<ulong> aL, ref Vector128<ulong> aH,
         ref Vector128<ulong> bL, ref Vector128<ulong> bH,
@@ -289,20 +289,16 @@ public sealed partial class Blake2b : HashAlgorithm
         ref Vector128<ulong> dL, ref Vector128<ulong> dH,
         Vector128<ulong> yL, Vector128<ulong> yH)
     {
-        // a += b + y
         aL = AdvSimd.Add(aL, AdvSimd.Add(bL, yL));
         aH = AdvSimd.Add(aH, AdvSimd.Add(bH, yH));
-        // d = ror64(d ^ a, 16) — TBL byte shuffle
-        Vector128<ulong> dxL = dL ^ aL;
-        Vector128<ulong> dxH = dH ^ aH;
-        dL = AdvSimd.Arm64.VectorTableLookup(dxL.AsByte(), s_neonRotMask16).AsUInt64();
-        dH = AdvSimd.Arm64.VectorTableLookup(dxH.AsByte(), s_neonRotMask16).AsUInt64();
-        // c += d
+        // ror64(d ^ a, 16) — TBL byte shuffle
+        dL = AdvSimd.Arm64.VectorTableLookup((dL ^ aL).AsByte(), s_neonRotMask16).AsUInt64();
+        dH = AdvSimd.Arm64.VectorTableLookup((dH ^ aH).AsByte(), s_neonRotMask16).AsUInt64();
         cL = AdvSimd.Add(cL, dL);
         cH = AdvSimd.Add(cH, dH);
-        // b = ror64(b ^ c, 63) — shift+or; Add(t,t) == ShiftLeft(t,1)
-        Vector128<ulong> tL = bL ^ cL;
-        Vector128<ulong> tH = bH ^ cH;
+        // ror64(b ^ c, 63) — shift + add (add(t,t) == shl(t,1))
+        var tL = bL ^ cL;
+        var tH = bH ^ cH;
         bL = AdvSimd.Or(AdvSimd.ShiftRightLogical(tL, 63), AdvSimd.Add(tL, tL));
         bH = AdvSimd.Or(AdvSimd.ShiftRightLogical(tH, 63), AdvSimd.Add(tH, tH));
     }
@@ -311,23 +307,12 @@ public sealed partial class Blake2b : HashAlgorithm
     /// Performs the BLAKE2b diagonal permutation on three rows, each split into lo/hi halves.
     /// </summary>
     /// <remarks>
-    /// Equivalent to <c>Avx2.Permute4x64</c> with imm8 values 0b00_11_10_01, 0b01_00_11_10,
-    /// 0b10_01_00_11 on rows <paramref name="aL"/>/<paramref name="aH"/>,
-    /// <paramref name="bL"/>/<paramref name="bH"/>, <paramref name="cL"/>/<paramref name="cH"/>
-    /// respectively.
-    /// <para>
     /// Given a logical row <c>[e0, e1, e2, e3]</c> with lo=<c>[e0,e1]</c> and hi=<c>[e2,e3]</c>:
-    /// </para>
     /// <list type="bullet">
     ///   <item><description>a: rotate left 1 → <c>[e1, e2, e3, e0]</c></description></item>
     ///   <item><description>b: swap halves → <c>[e2, e3, e0, e1]</c></description></item>
     ///   <item><description>c: rotate right 1 → <c>[e3, e0, e1, e2]</c></description></item>
     /// </list>
-    /// <para>
-    /// <c>ExtractVector128(x, y, 8)</c> extracts bytes[8..23] from the 32-byte concatenation [x, y],
-    /// which is the equivalent of picking the second 8-byte element from x followed by the first
-    /// 8-byte element from y.
-    /// </para>
     /// </remarks>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     private static void PermuteNeon(
@@ -335,18 +320,15 @@ public sealed partial class Blake2b : HashAlgorithm
         ref Vector128<ulong> bL, ref Vector128<ulong> bH,
         ref Vector128<ulong> cL, ref Vector128<ulong> cH)
     {
-        // a: rotate left 1 → [a1, a2, a3, a0]
-        Vector128<ulong> newAL = AdvSimd.ExtractVector128(aL.AsByte(), aH.AsByte(), 8).AsUInt64();
-        Vector128<ulong> newAH = AdvSimd.ExtractVector128(aH.AsByte(), aL.AsByte(), 8).AsUInt64();
+        var newAL = AdvSimd.ExtractVector128(aL.AsByte(), aH.AsByte(), 8).AsUInt64();
+        var newAH = AdvSimd.ExtractVector128(aH.AsByte(), aL.AsByte(), 8).AsUInt64();
         aL = newAL;
         aH = newAH;
 
-        // b: swap halves → [b2, b3, b0, b1]
         (bL, bH) = (bH, bL);
 
-        // c: rotate right 1 → [c3, c0, c1, c2]
-        Vector128<ulong> newCL = AdvSimd.ExtractVector128(cH.AsByte(), cL.AsByte(), 8).AsUInt64();
-        Vector128<ulong> newCH = AdvSimd.ExtractVector128(cL.AsByte(), cH.AsByte(), 8).AsUInt64();
+        var newCL = AdvSimd.ExtractVector128(cH.AsByte(), cL.AsByte(), 8).AsUInt64();
+        var newCH = AdvSimd.ExtractVector128(cL.AsByte(), cH.AsByte(), 8).AsUInt64();
         cL = newCL;
         cH = newCH;
     }

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
@@ -8,8 +8,8 @@ namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 #if NET8_0_OR_GREATER
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 
@@ -35,36 +35,20 @@ public sealed partial class Blake2b : HashAlgorithm
     private static readonly Vector128<byte> s_neonRotMask16 = Vector128.Create(
         (byte)2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9);
 
-    // IV split into four 128-bit halves (lo = elements 0–1, hi = elements 2–3 of each 256-bit row)
-    private static readonly Vector128<ulong> s_ivNeon0 = Vector128.Create(   // IVLow[0..1]
-        0x6a09e667f3bcc908UL, 0xbb67ae8584caa73bUL);
-
-    private static readonly Vector128<ulong> s_ivNeon1 = Vector128.Create(   // IVLow[2..3]
-        0x3c6ef372fe94f82bUL, 0xa54ff53a5f1d36f1UL);
-
-    private static readonly Vector128<ulong> s_ivNeon2 = Vector128.Create(   // IVHigh[0..1]
-        0x510e527fade682d1UL, 0x9b05688c2b3e6c1fUL);
-
-    private static readonly Vector128<ulong> s_ivNeon3 = Vector128.Create(   // IVHigh[2..3]
-        0x1f83d9abfb41bd6bUL, 0x5be0cd19137e2179UL);
-
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private unsafe void CompressNeon(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private static unsafe void CompressNeon(byte* bp, ulong* state, ulong bytesCompressed, bool isFinal)
     {
-        _bytesCompressed += (ulong)bytesConsumed;
-
         // Load state from the shared _state[] array (same layout as AVX2 path)
-        ulong* state = (ulong*)Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(_state));
         var r0L = AdvSimd.LoadVector128(state);
         var r0H = AdvSimd.LoadVector128(state + 2);
         var r1L = AdvSimd.LoadVector128(state + 4);
         var r1H = AdvSimd.LoadVector128(state + 6);
 
-        var r2L = s_ivNeon0;
-        var r2H = s_ivNeon1;
-        var r3L = AdvSimd.Xor(s_ivNeon2, Vector128.Create(_bytesCompressed, 0UL));
-        var r3H = isFinal ? AdvSimd.Xor(s_ivNeon3, Vector128.Create(~0UL, 0UL)) : s_ivNeon3;
+        var r2L = Vector128.Create(IV[0], IV[1]);
+        var r2H = Vector128.Create(IV[2], IV[3]);
+        var r3L = Vector128.Create(IV[4] ^ bytesCompressed, IV[5]);
+        var r3H = Vector128.Create(isFinal ? IV[6] ^ ~0UL : IV[6] , IV[7]);
 
         // Save original state for finalization
         var orig0L = r0L;
@@ -74,173 +58,174 @@ public sealed partial class Blake2b : HashAlgorithm
 
         // Pre-load all 16 message words as 8 vector pairs via direct 128-bit loads.
         // m_i = [w_{2i}, w_{2i+1}] — ARM64 .NET is always little-endian.
-        fixed (byte* bp = block)
+        ulong* mp = (ulong*)bp;
+        var m0 = AdvSimd.LoadVector128(mp);
+        var m1 = AdvSimd.LoadVector128(mp + 2);
+        var m2 = AdvSimd.LoadVector128(mp + 4);
+        var m3 = AdvSimd.LoadVector128(mp + 6);
+        var m4 = AdvSimd.LoadVector128(mp + 8);
+        var m5 = AdvSimd.LoadVector128(mp + 10);
+        var m6 = AdvSimd.LoadVector128(mp + 12);
+        var m7 = AdvSimd.LoadVector128(mp + 14);
+
+        // 12 rounds, fully unrolled. Rounds 11/12 reuse rounds 1/2 via loop.
+        // Message scheduling uses single-cycle NEON shuffles:
+        //   ZipLow(a,b)  → [a0, b0]    ZipHigh(a,b)       → [a1, b1]
+        //   Ext(a,b,#8)  → [a1, b0]    Ins(a,1,b,1)       → [a0, b1]
+        bool step11and12 = false;
+        while (true)
         {
-            ulong* mp = (ulong*)bp;
-            var m0 = AdvSimd.LoadVector128(mp);
-            var m1 = AdvSimd.LoadVector128(mp + 2);
-            var m2 = AdvSimd.LoadVector128(mp + 4);
-            var m3 = AdvSimd.LoadVector128(mp + 6);
-            var m4 = AdvSimd.LoadVector128(mp + 8);
-            var m5 = AdvSimd.LoadVector128(mp + 10);
-            var m6 = AdvSimd.LoadVector128(mp + 12);
-            var m7 = AdvSimd.LoadVector128(mp + 14);
+            // Round 1/11 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m0, m1), AdvSimd.Arm64.ZipLow(m2, m3));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m0, m1), AdvSimd.Arm64.ZipHigh(m2, m3));
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m4, m5), AdvSimd.Arm64.ZipLow(m6, m7));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m4, m5), AdvSimd.Arm64.ZipHigh(m6, m7));
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
 
-            // 12 rounds, fully unrolled. Rounds 11/12 reuse rounds 1/2 via loop.
-            // Message scheduling uses single-cycle NEON shuffles:
-            //   ZipLow(a,b)  → [a0, b0]    ZipHigh(a,b)       → [a1, b1]
-            //   Ext(a,b,#8)  → [a1, b0]    Ins(a,1,b,1)       → [a0, b1]
-            bool step11and12 = false;
-            while (true)
+            // Round 2/12 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m7, m2), AdvSimd.Arm64.ZipHigh(m4, m6));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m5, m4),
+                AdvSimd.ExtractVector128(m7.AsByte(), m3.AsByte(), 8).AsUInt64());
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.ExtractVector128(m0.AsByte(), m0.AsByte(), 8).AsUInt64(),
+                AdvSimd.Arm64.ZipHigh(m5, m2));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m6, m1), AdvSimd.Arm64.ZipHigh(m3, m1));
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // exit if second round processed step 11 and 12
+            if (step11and12)
             {
-                // Round 1/11 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m0, m1), AdvSimd.Arm64.ZipLow(m2, m3));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m0, m1), AdvSimd.Arm64.ZipHigh(m2, m3));
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m4, m5), AdvSimd.Arm64.ZipLow(m6, m7));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m4, m5), AdvSimd.Arm64.ZipHigh(m6, m7));
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 2/12 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m7, m2), AdvSimd.Arm64.ZipHigh(m4, m6));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m5, m4),
-                    AdvSimd.ExtractVector128(m7.AsByte(), m3.AsByte(), 8).AsUInt64());
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.ExtractVector128(m0.AsByte(), m0.AsByte(), 8).AsUInt64(),
-                    AdvSimd.Arm64.ZipHigh(m5, m2));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m6, m1), AdvSimd.Arm64.ZipHigh(m3, m1));
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                if (step11and12) break;
-
-                // Round 3 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.ExtractVector128(m5.AsByte(), m6.AsByte(), 8).AsUInt64(),
-                    AdvSimd.Arm64.ZipHigh(m2, m7));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m4, m0),
-                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m6.AsInt64(), 1).AsUInt64());
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.InsertSelectedScalar(m5.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64(),
-                    AdvSimd.Arm64.ZipHigh(m3, m4));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m7, m3),
-                    AdvSimd.ExtractVector128(m0.AsByte(), m2.AsByte(), 8).AsUInt64());
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 4 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m3, m1), AdvSimd.Arm64.ZipHigh(m6, m5));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m4, m0), AdvSimd.Arm64.ZipLow(m6, m7));
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m2.AsInt64(), 1).AsUInt64(),
-                    AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m7.AsInt64(), 1).AsUInt64());
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m3, m5), AdvSimd.Arm64.ZipLow(m0, m4));
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 5 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m4, m2), AdvSimd.Arm64.ZipLow(m1, m5));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.InsertSelectedScalar(m0.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
-                    AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m7.AsInt64(), 1).AsUInt64());
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.InsertSelectedScalar(m7.AsInt64(), 1, m5.AsInt64(), 1).AsUInt64(),
-                    AdvSimd.Arm64.InsertSelectedScalar(m3.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64());
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.ExtractVector128(m0.AsByte(), m6.AsByte(), 8).AsUInt64(),
-                    AdvSimd.Arm64.InsertSelectedScalar(m4.AsInt64(), 1, m6.AsInt64(), 1).AsUInt64());
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 6 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m1, m3), AdvSimd.Arm64.ZipLow(m0, m4));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m6, m5), AdvSimd.Arm64.ZipHigh(m5, m1));
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
-                    AdvSimd.Arm64.ZipHigh(m7, m0));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m6, m2),
-                    AdvSimd.Arm64.InsertSelectedScalar(m7.AsInt64(), 1, m4.AsInt64(), 1).AsUInt64());
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 7 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.InsertSelectedScalar(m6.AsInt64(), 1, m0.AsInt64(), 1).AsUInt64(),
-                    AdvSimd.Arm64.ZipLow(m7, m2));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m2, m7),
-                    AdvSimd.ExtractVector128(m6.AsByte(), m5.AsByte(), 8).AsUInt64());
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m0, m3),
-                    AdvSimd.ExtractVector128(m4.AsByte(), m4.AsByte(), 8).AsUInt64());
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m3, m1),
-                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m5.AsInt64(), 1).AsUInt64());
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 8 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m6, m3),
-                    AdvSimd.Arm64.InsertSelectedScalar(m6.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64());
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.ExtractVector128(m5.AsByte(), m7.AsByte(), 8).AsUInt64(),
-                    AdvSimd.Arm64.ZipHigh(m0, m4));
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m2, m7), AdvSimd.Arm64.ZipLow(m4, m1));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m0, m2), AdvSimd.Arm64.ZipLow(m3, m5));
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 9 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m3, m7),
-                    AdvSimd.ExtractVector128(m5.AsByte(), m0.AsByte(), 8).AsUInt64());
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m7, m4),
-                    AdvSimd.ExtractVector128(m1.AsByte(), m4.AsByte(), 8).AsUInt64());
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    m6,
-                    AdvSimd.ExtractVector128(m0.AsByte(), m5.AsByte(), 8).AsUInt64());
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
-                    m2);
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                // Round 10 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m5, m4), AdvSimd.Arm64.ZipHigh(m3, m0));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipLow(m1, m2),
-                    AdvSimd.Arm64.InsertSelectedScalar(m3.AsInt64(), 1, m2.AsInt64(), 1).AsUInt64());
-                PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
-                GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.Arm64.ZipHigh(m7, m4), AdvSimd.Arm64.ZipHigh(m1, m6));
-                GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
-                    AdvSimd.ExtractVector128(m5.AsByte(), m7.AsByte(), 8).AsUInt64(),
-                    AdvSimd.Arm64.ZipLow(m6, m0));
-                PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-
-                step11and12 = true;
+                break;
             }
+
+            // Round 3 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.ExtractVector128(m5.AsByte(), m6.AsByte(), 8).AsUInt64(),
+                AdvSimd.Arm64.ZipHigh(m2, m7));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m4, m0),
+                AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m6.AsInt64(), 1).AsUInt64());
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.InsertSelectedScalar(m5.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64(),
+                AdvSimd.Arm64.ZipHigh(m3, m4));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m7, m3),
+                AdvSimd.ExtractVector128(m0.AsByte(), m2.AsByte(), 8).AsUInt64());
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // Round 4 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m3, m1), AdvSimd.Arm64.ZipHigh(m6, m5));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m4, m0), AdvSimd.Arm64.ZipLow(m6, m7));
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m2.AsInt64(), 1).AsUInt64(),
+                AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m7.AsInt64(), 1).AsUInt64());
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m3, m5), AdvSimd.Arm64.ZipLow(m0, m4));
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // Round 5 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m4, m2), AdvSimd.Arm64.ZipLow(m1, m5));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.InsertSelectedScalar(m0.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
+                AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m7.AsInt64(), 1).AsUInt64());
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.InsertSelectedScalar(m7.AsInt64(), 1, m5.AsInt64(), 1).AsUInt64(),
+                AdvSimd.Arm64.InsertSelectedScalar(m3.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64());
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.ExtractVector128(m0.AsByte(), m6.AsByte(), 8).AsUInt64(),
+                AdvSimd.Arm64.InsertSelectedScalar(m4.AsInt64(), 1, m6.AsInt64(), 1).AsUInt64());
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // Round 6 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m1, m3), AdvSimd.Arm64.ZipLow(m0, m4));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m6, m5), AdvSimd.Arm64.ZipHigh(m5, m1));
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.InsertSelectedScalar(m2.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
+                AdvSimd.Arm64.ZipHigh(m7, m0));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m6, m2),
+                AdvSimd.Arm64.InsertSelectedScalar(m7.AsInt64(), 1, m4.AsInt64(), 1).AsUInt64());
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // Round 7 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.InsertSelectedScalar(m6.AsInt64(), 1, m0.AsInt64(), 1).AsUInt64(),
+                AdvSimd.Arm64.ZipLow(m7, m2));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m2, m7),
+                AdvSimd.ExtractVector128(m6.AsByte(), m5.AsByte(), 8).AsUInt64());
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m0, m3),
+                AdvSimd.ExtractVector128(m4.AsByte(), m4.AsByte(), 8).AsUInt64());
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m3, m1),
+                AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m5.AsInt64(), 1).AsUInt64());
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // Round 8 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m6, m3),
+                AdvSimd.Arm64.InsertSelectedScalar(m6.AsInt64(), 1, m1.AsInt64(), 1).AsUInt64());
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.ExtractVector128(m5.AsByte(), m7.AsByte(), 8).AsUInt64(),
+                AdvSimd.Arm64.ZipHigh(m0, m4));
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m2, m7), AdvSimd.Arm64.ZipLow(m4, m1));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m0, m2), AdvSimd.Arm64.ZipLow(m3, m5));
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // Round 9 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m3, m7),
+                AdvSimd.ExtractVector128(m5.AsByte(), m0.AsByte(), 8).AsUInt64());
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m7, m4),
+                AdvSimd.ExtractVector128(m1.AsByte(), m4.AsByte(), 8).AsUInt64());
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                m6,
+                AdvSimd.ExtractVector128(m0.AsByte(), m5.AsByte(), 8).AsUInt64());
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.InsertSelectedScalar(m1.AsInt64(), 1, m3.AsInt64(), 1).AsUInt64(),
+                m2);
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            // Round 10 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m5, m4), AdvSimd.Arm64.ZipHigh(m3, m0));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipLow(m1, m2),
+                AdvSimd.Arm64.InsertSelectedScalar(m3.AsInt64(), 1, m2.AsInt64(), 1).AsUInt64());
+            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.Arm64.ZipHigh(m7, m4), AdvSimd.Arm64.ZipHigh(m1, m6));
+            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+                AdvSimd.ExtractVector128(m5.AsByte(), m7.AsByte(), 8).AsUInt64(),
+                AdvSimd.Arm64.ZipLow(m6, m0));
+            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
+
+            step11and12 = true;
         }
 
         // Finalize: state[i] ^= v[i] ^ v[i+8]
@@ -282,6 +267,7 @@ public sealed partial class Blake2b : HashAlgorithm
     /// Performs one Gy half-round: <c>a += b + y; d = ror(d^a, 16); c += d; b = ror(b^c, 63)</c>.
     /// </summary>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
+    [SuppressMessage("Performance", "CA1857:A constant is expected for the parameter", Justification = "False negative due to bug in .NET 8 runtime metadata.")]
     private static void GRoundYNeon(
         ref Vector128<ulong> aL, ref Vector128<ulong> aH,
         ref Vector128<ulong> bL, ref Vector128<ulong> bH,

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.Neon.cs
@@ -95,8 +95,6 @@ public sealed partial class Blake2b : HashAlgorithm
     {
         _bytesCompressed += (ulong)bytesConsumed;
 
-        // Each logical 256-bit row is split into lo (elements 0–1) and hi (elements 2–3).
-        // row0 = v[0..3] = state[0..7], row2 = v[8..11] = IV[0..3], row3 = v[12..15] = IV[4..7] + counter
         Vector128<ulong> r0L = _neonState0;
         Vector128<ulong> r0H = _neonState1;
         Vector128<ulong> r1L = _neonState2;
@@ -106,64 +104,133 @@ public sealed partial class Blake2b : HashAlgorithm
         Vector128<ulong> r3L = s_ivNeon2 ^ Vector128.Create(_bytesCompressed, 0UL);
         Vector128<ulong> r3H = isFinal ? s_ivNeon3 ^ s_neonFinalMask : s_ivNeon3;
 
-        // Parse message block into 16 little-endian 64-bit words
-        Span<ulong> m = stackalloc ulong[ScratchSize];
-        BinarySpans.ReadUInt64LittleEndian(block, m);
+        // Pre-load all 16 message words into locals — eliminates Sigma indirection from inner rounds
+        Span<ulong> msg = stackalloc ulong[ScratchSize];
+        BinarySpans.ReadUInt64LittleEndian(block, msg);
+        ulong w0 = msg[0]; ulong w1 = msg[1]; ulong w2 = msg[2]; ulong w3 = msg[3];
+        ulong w4 = msg[4]; ulong w5 = msg[5]; ulong w6 = msg[6]; ulong w7 = msg[7];
+        ulong w8 = msg[8]; ulong w9 = msg[9]; ulong w10 = msg[10]; ulong w11 = msg[11];
+        ulong w12 = msg[12]; ulong w13 = msg[13]; ulong w14 = msg[14]; ulong w15 = msg[15];
 
-        ref byte sigmaBase = ref MemoryMarshal.GetArrayDataReference(Sigma);
-        ref ulong mBase = ref MemoryMarshal.GetReference(m);
+        // ROUND 1 — Sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w0, w2), Vector128.Create(w4, w6),
+            Vector128.Create(w1, w3), Vector128.Create(w5, w7),
+            Vector128.Create(w8, w10), Vector128.Create(w12, w14),
+            Vector128.Create(w9, w11), Vector128.Create(w13, w15));
 
-        // 12 rounds of mixing
-        for (int sigmaIdx = 0; sigmaIdx < Rounds * ScratchSize; sigmaIdx += ScratchSize)
-        {
-            // Column X step: load m[sigma[0]], m[sigma[2]], m[sigma[4]], m[sigma[6]]
-            var mxL = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 0)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 2)));
-            var mxH = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 4)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 6)));
-            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, mxL, mxH);
+        // ROUND 2 — Sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w14, w4), Vector128.Create(w9, w13),
+            Vector128.Create(w10, w8), Vector128.Create(w15, w6),
+            Vector128.Create(w1, w0), Vector128.Create(w11, w5),
+            Vector128.Create(w12, w2), Vector128.Create(w7, w3));
 
-            // Column Y step: load m[sigma[1]], m[sigma[3]], m[sigma[5]], m[sigma[7]]
-            var myL = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 1)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 3)));
-            var myH = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 5)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 7)));
-            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, myL, myH);
+        // ROUND 3 — Sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w11, w12), Vector128.Create(w5, w15),
+            Vector128.Create(w8, w0), Vector128.Create(w2, w13),
+            Vector128.Create(w10, w3), Vector128.Create(w7, w9),
+            Vector128.Create(w14, w6), Vector128.Create(w1, w4));
 
-            // Diagonal permutation: Permute(row1, row2, row3)
-            PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+        // ROUND 4 — Sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w7, w3), Vector128.Create(w13, w11),
+            Vector128.Create(w9, w1), Vector128.Create(w12, w14),
+            Vector128.Create(w2, w5), Vector128.Create(w4, w15),
+            Vector128.Create(w6, w10), Vector128.Create(w0, w8));
 
-            // Diagonal X step: load m[sigma[8]], m[sigma[10]], m[sigma[12]], m[sigma[14]]
-            mxL = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 8)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 10)));
-            mxH = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 12)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 14)));
-            GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, mxL, mxH);
+        // ROUND 5 — Sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w9, w5), Vector128.Create(w2, w10),
+            Vector128.Create(w0, w7), Vector128.Create(w4, w15),
+            Vector128.Create(w14, w11), Vector128.Create(w6, w3),
+            Vector128.Create(w1, w12), Vector128.Create(w8, w13));
 
-            // Diagonal Y step: load m[sigma[9]], m[sigma[11]], m[sigma[13]], m[sigma[15]]
-            myL = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 9)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 11)));
-            myH = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 13)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 15)));
-            GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, myL, myH);
+        // ROUND 6 — Sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w2, w6), Vector128.Create(w0, w8),
+            Vector128.Create(w12, w10), Vector128.Create(w11, w3),
+            Vector128.Create(w4, w7), Vector128.Create(w15, w1),
+            Vector128.Create(w13, w5), Vector128.Create(w14, w9));
 
-            // Un-permute: Permute(row3, row2, row1)
-            PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
-        }
+        // ROUND 7 — Sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w12, w1), Vector128.Create(w14, w4),
+            Vector128.Create(w5, w15), Vector128.Create(w13, w10),
+            Vector128.Create(w0, w6), Vector128.Create(w9, w8),
+            Vector128.Create(w7, w3), Vector128.Create(w2, w11));
+
+        // ROUND 8 — Sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w13, w7), Vector128.Create(w12, w3),
+            Vector128.Create(w11, w14), Vector128.Create(w1, w9),
+            Vector128.Create(w5, w15), Vector128.Create(w8, w2),
+            Vector128.Create(w0, w4), Vector128.Create(w6, w10));
+
+        // ROUND 9 — Sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w6, w14), Vector128.Create(w11, w0),
+            Vector128.Create(w15, w9), Vector128.Create(w3, w8),
+            Vector128.Create(w12, w13), Vector128.Create(w1, w10),
+            Vector128.Create(w2, w7), Vector128.Create(w4, w5));
+
+        // ROUND 10 — Sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w10, w8), Vector128.Create(w7, w1),
+            Vector128.Create(w2, w4), Vector128.Create(w6, w5),
+            Vector128.Create(w15, w9), Vector128.Create(w3, w13),
+            Vector128.Create(w11, w14), Vector128.Create(w12, w0));
+
+        // ROUND 11 — (same as round 1)
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w0, w2), Vector128.Create(w4, w6),
+            Vector128.Create(w1, w3), Vector128.Create(w5, w7),
+            Vector128.Create(w8, w10), Vector128.Create(w12, w14),
+            Vector128.Create(w9, w11), Vector128.Create(w13, w15));
+
+        // ROUND 12 — (same as round 2)
+        NeonRound(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H,
+            Vector128.Create(w14, w4), Vector128.Create(w9, w13),
+            Vector128.Create(w10, w8), Vector128.Create(w15, w6),
+            Vector128.Create(w1, w0), Vector128.Create(w11, w5),
+            Vector128.Create(w12, w2), Vector128.Create(w7, w3));
 
         // Finalize: state[i] ^= v[i] ^ v[i+8]
         _neonState0 ^= r0L ^ r2L;
         _neonState1 ^= r0H ^ r2H;
         _neonState2 ^= r1L ^ r3L;
         _neonState3 ^= r1H ^ r3H;
+    }
+
+    /// <summary>
+    /// Performs one full BLAKE2b round (column step + diagonal step) using NEON.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    [SuppressMessage("Performance", "CA1857:A constant is expected for the parameter", Justification = "False negative, false constant provided in .NET 8.0 runtime")]
+    private static void NeonRound(
+        ref Vector128<ulong> r0L, ref Vector128<ulong> r0H,
+        ref Vector128<ulong> r1L, ref Vector128<ulong> r1H,
+        ref Vector128<ulong> r2L, ref Vector128<ulong> r2H,
+        ref Vector128<ulong> r3L, ref Vector128<ulong> r3H,
+        Vector128<ulong> mxL, Vector128<ulong> mxH,
+        Vector128<ulong> myL, Vector128<ulong> myH,
+        Vector128<ulong> dxL, Vector128<ulong> dxH,
+        Vector128<ulong> dyL, Vector128<ulong> dyH)
+    {
+        // Column step
+        GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, mxL, mxH);
+        GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, myL, myH);
+
+        // Diagonalize
+        PermuteNeon(ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H);
+
+        // Diagonal step
+        GRoundXNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, dxL, dxH);
+        GRoundYNeon(ref r0L, ref r0H, ref r1L, ref r1H, ref r2L, ref r2H, ref r3L, ref r3H, dyL, dyH);
+
+        // Un-diagonalize
+        PermuteNeon(ref r3L, ref r3H, ref r2L, ref r2H, ref r1L, ref r1H);
     }
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -10,10 +10,6 @@ using System;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-#if NET8_0_OR_GREATER
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
-#endif
 
 /// <summary>
 /// Computes the BLAKE2b hash for the input data.
@@ -76,6 +72,7 @@ public sealed partial class Blake2b : HashAlgorithm
         0x5be0cd19137e2179UL
     ];
 
+#if NOT_USED
     // BLAKE2b sigma permutations for message scheduling
     private static readonly byte[] Sigma = new byte[Rounds * ScratchSize]
     {
@@ -92,13 +89,7 @@ public sealed partial class Blake2b : HashAlgorithm
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
         14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3
     };
-
-    // Delegate types for SIMD dispatch — set once in constructor, avoiding per-call branch checks
-    private delegate void InitializeStateAction(ulong paramBlock);
-    private delegate void ExtractOutputAction(Span<byte> destination);
-
-    private readonly InitializeStateAction _initializeState;
-    private readonly ExtractOutputAction _extractOutput;
+#endif
 
     // Scalar state for non-AVX2 path and output extraction
     private readonly SimdSupport _simdSupport;
@@ -159,15 +150,8 @@ public sealed partial class Blake2b : HashAlgorithm
         _buffer = new byte[BlockSizeBytes];
 
         _simdSupport = SimdSupport.None;
-        _initializeState = InitializeStateScalar;
-        _extractOutput = ExtractOutputScalar;
 #if NET8_0_OR_GREATER
         _simdSupport = simdSupport & Blake2b.SimdSupport;
-        if ((simdSupport & Blake2b.SimdSupport & SimdSupport.Neon) != 0)
-        {
-            _initializeState = InitializeStateNeon;
-            _extractOutput = ExtractOutputNeon;
-        }
 #endif
 
         if (key != null && key.Length > 0)
@@ -241,7 +225,7 @@ public sealed partial class Blake2b : HashAlgorithm
         int keyLength = _key?.Length ?? 0;
         ulong paramBlock = 0x01010000UL | ((ulong)keyLength << 8) | (uint)_outputBytes;
 
-        _initializeState(paramBlock);
+        InitializeState(paramBlock);
 
         _bytesCompressed = 0;
         _bufferLength = 0;
@@ -274,7 +258,7 @@ public sealed partial class Blake2b : HashAlgorithm
         }
     }
 
-    private void InitializeStateScalar(ulong paramBlock)
+    private void InitializeState(ulong paramBlock)
     {
         Array.Copy(IV, _state, StateSize);
         _state[0] ^= paramBlock;
@@ -342,14 +326,14 @@ public sealed partial class Blake2b : HashAlgorithm
         // Compress final block
         Compress(_buffer, _bufferLength, true);
 
-        // Extract output using dispatch delegate
-        _extractOutput(destination);
+        // Extract output
+        ExtractOutput(destination);
 
         bytesWritten = _outputBytes;
         return true;
     }
 
-    private void ExtractOutputScalar(Span<byte> destination)
+    private void ExtractOutput(Span<byte> destination)
     {
         int fullWords = _outputBytes / sizeof(UInt64);
 

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -1,7 +1,8 @@
-﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 #pragma warning disable IDE1006 // Naming rule violation - IV and Sigma are standard cryptographic constant names per RFC 7693
+#pragma warning disable CS0414  // _simdSupport is read inside #if NET8_0_OR_GREATER guard
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
@@ -93,15 +94,14 @@ public sealed partial class Blake2b : HashAlgorithm
     };
 
     // Delegate types for SIMD dispatch — set once in constructor, avoiding per-call branch checks
-    private delegate void CompressAction(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal);
     private delegate void InitializeStateAction(ulong paramBlock);
     private delegate void ExtractOutputAction(Span<byte> destination);
 
-    private readonly CompressAction _compress;
     private readonly InitializeStateAction _initializeState;
     private readonly ExtractOutputAction _extractOutput;
 
     // Scalar state for non-AVX2 path and output extraction
+    private readonly SimdSupport _simdSupport;
     private readonly ulong[] _state;
     private readonly byte[] _buffer;
     private readonly byte[]? _key;
@@ -158,26 +158,17 @@ public sealed partial class Blake2b : HashAlgorithm
         _state = new ulong[StateSize];
         _buffer = new byte[BlockSizeBytes];
 
+        _simdSupport = SimdSupport.None;
+        _initializeState = InitializeStateScalar;
+        _extractOutput = ExtractOutputScalar;
 #if NET8_0_OR_GREATER
-        if ((simdSupport & Blake2b.SimdSupport & SimdSupport.Avx2) != 0)
+        _simdSupport = simdSupport & Blake2b.SimdSupport;
+        if ((simdSupport & Blake2b.SimdSupport & SimdSupport.Neon) != 0)
         {
-            _compress = CompressAvx2;
-            _initializeState = InitializeStateAvx2;
-            _extractOutput = ExtractOutputAvx2;
-        }
-        else if ((simdSupport & Blake2b.SimdSupport & SimdSupport.Neon) != 0)
-        {
-            _compress = CompressNeon;
             _initializeState = InitializeStateNeon;
             _extractOutput = ExtractOutputNeon;
         }
-        else
 #endif
-        {
-            _compress = CompressScalar;
-            _initializeState = InitializeStateScalar;
-            _extractOutput = ExtractOutputScalar;
-        }
 
         if (key != null && key.Length > 0)
         {
@@ -264,6 +255,25 @@ public sealed partial class Blake2b : HashAlgorithm
         }
     }
 
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private void Compress(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    {
+#if NET8_0_OR_GREATER
+        if ((_simdSupport & SimdSupport.Avx2) != 0)
+        {
+            CompressAvx2(block, bytesConsumed, isFinal);
+        }
+        else if ((_simdSupport & SimdSupport.Neon) != 0)
+        {
+            CompressNeon(block, bytesConsumed, isFinal);
+        }
+        else
+#endif
+        {
+            CompressScalar(block, bytesConsumed, isFinal);
+        }
+    }
+
     private void InitializeStateScalar(ulong paramBlock)
     {
         Array.Copy(IV, _state, StateSize);
@@ -287,7 +297,7 @@ public sealed partial class Blake2b : HashAlgorithm
             // (we need to keep the last block for finalization)
             if (_bufferLength == BlockSizeBytes && offset < source.Length)
             {
-                _compress(_buffer, BlockSizeBytes, false);
+                Compress(_buffer, BlockSizeBytes, false);
                 _bufferLength = 0;
             }
         }
@@ -295,7 +305,7 @@ public sealed partial class Blake2b : HashAlgorithm
         // Process full blocks, but always keep at least one block for finalization
         while (offset + BlockSizeBytes < source.Length)
         {
-            _compress(source.Slice(offset, BlockSizeBytes), BlockSizeBytes, false);
+            Compress(source.Slice(offset, BlockSizeBytes), BlockSizeBytes, false);
             offset += BlockSizeBytes;
         }
 
@@ -330,7 +340,7 @@ public sealed partial class Blake2b : HashAlgorithm
         _buffer.AsSpan(_bufferLength).Clear();
 
         // Compress final block
-        _compress(_buffer, _bufferLength, true);
+        Compress(_buffer, _bufferLength, true);
 
         // Extract output using dispatch delegate
         _extractOutput(destination);
@@ -360,10 +370,6 @@ public sealed partial class Blake2b : HashAlgorithm
     {
         if (disposing)
         {
-#if NET8_0_OR_GREATER
-            _stateVec0 = default;
-            _stateVec1 = default;
-#endif
             Array.Clear(_state, 0, _state.Length);
             ClearBuffer(_buffer);
             if (_key != null)

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -10,7 +10,6 @@ using System;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 /// <summary>
 /// Computes the BLAKE2b hash for the input data.
@@ -52,7 +51,7 @@ public sealed partial class Blake2b : HashAlgorithm
     public const int BlockSizeBytes = 128;
 
     // Rounds of mixing
-    private const int Rounds = 12;
+    // private const int Rounds = 12;
 
     // The size of the state buffer
     private const int StateSize = 8;
@@ -72,25 +71,6 @@ public sealed partial class Blake2b : HashAlgorithm
         0x1f83d9abfb41bd6bUL,
         0x5be0cd19137e2179UL
     ];
-
-#if NOT_USED
-    // BLAKE2b sigma permutations for message scheduling
-    private static readonly byte[] Sigma = new byte[Rounds * ScratchSize]
-    {
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
-        11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4,
-        7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8,
-        9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13,
-        2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9,
-        12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11,
-        13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10,
-        6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5,
-        10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0,
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3
-    };
-#endif
 
     // Scalar state for non-AVX2 path and output extraction
     private readonly SimdSupport _simdSupport;
@@ -152,7 +132,7 @@ public sealed partial class Blake2b : HashAlgorithm
 
         _simdSupport = SimdSupport.None;
 #if NET8_0_OR_GREATER
-        _simdSupport = simdSupport & Blake2b.SimdSupport;
+        _simdSupport = simdSupport & SimdSupport;
 #endif
 
         if (key != null && key.Length > 0)
@@ -241,21 +221,42 @@ public sealed partial class Blake2b : HashAlgorithm
     }
 
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    private void Compress(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private unsafe void Compress(byte* msgPtr, ulong* state, int bytesConsumed, bool isFinal)
     {
+        _bytesCompressed += (ulong)bytesConsumed;
+
 #if NET8_0_OR_GREATER
         if ((_simdSupport & SimdSupport.Avx2) != 0)
         {
-            CompressAvx2(block, bytesConsumed, isFinal);
+            CompressAvx2(msgPtr, state, _bytesCompressed, isFinal);
         }
         else if ((_simdSupport & SimdSupport.Neon) != 0)
         {
-            CompressNeon(block, bytesConsumed, isFinal);
+            CompressNeon(msgPtr, state, _bytesCompressed, isFinal);
         }
         else
 #endif
         {
-            CompressScalar(block, bytesConsumed, isFinal);
+            CompressScalar(msgPtr, state, _bytesCompressed, isFinal);
+        }
+    }
+
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private unsafe void Compress(ReadOnlySpan<byte> block, ulong* state, int bytesConsumed, bool isFinal)
+    {
+        fixed (byte* msgPtr = block)
+        {
+            Compress(msgPtr, state, bytesConsumed, isFinal);
+        }
+    }
+
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private unsafe void Compress(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    {
+        fixed (ulong* state = _state)
+        fixed (byte* msgPtr = block)
+        {
+            Compress(msgPtr, state, bytesConsumed, isFinal);
         }
     }
 
@@ -266,32 +267,38 @@ public sealed partial class Blake2b : HashAlgorithm
     }
 
     /// <inheritdoc/>
-    protected override void HashCore(ReadOnlySpan<byte> source)
+    protected override unsafe void HashCore(ReadOnlySpan<byte> source)
     {
         int offset = 0;
 
-        // If we have data in buffer, fill it first
-        if (_bufferLength > 0)
+        fixed (ulong* state = _state)
         {
-            int toCopy = Math.Min(BlockSizeBytes - _bufferLength, source.Length);
-            source.Slice(0, toCopy).CopyTo(_buffer.AsSpan(_bufferLength));
-            _bufferLength += toCopy;
-            offset += toCopy;
-
-            // Only compress if buffer is full AND there's more data coming
-            // (we need to keep the last block for finalization)
-            if (_bufferLength == BlockSizeBytes && offset < source.Length)
+            // If we have data in buffer, fill it first
+            if (_bufferLength > 0)
             {
-                Compress(_buffer, BlockSizeBytes, false);
-                _bufferLength = 0;
-            }
-        }
+                int toCopy = Math.Min(BlockSizeBytes - _bufferLength, source.Length);
+                source.Slice(0, toCopy).CopyTo(_buffer.AsSpan(_bufferLength));
+                _bufferLength += toCopy;
+                offset += toCopy;
 
-        // Process full blocks, but always keep at least one block for finalization
-        while (offset + BlockSizeBytes < source.Length)
-        {
-            Compress(source.Slice(offset, BlockSizeBytes), BlockSizeBytes, false);
-            offset += BlockSizeBytes;
+                // Only compress if buffer is full AND there's more data coming
+                // (we need to keep the last block for finalization)
+                if (_bufferLength == BlockSizeBytes && offset < source.Length)
+                {
+                    Compress(_buffer, state, BlockSizeBytes, false);
+                    _bufferLength = 0;
+                }
+            }
+
+            // Process full blocks, but always keep at least one block for finalization
+            fixed (byte* msgPtr = source)
+            {
+                while (offset + BlockSizeBytes < source.Length)
+                {
+                    Compress(msgPtr + offset, state, BlockSizeBytes, false);
+                    offset += BlockSizeBytes;
+                }
+            }
         }
 
         // Store remaining bytes in buffer
@@ -367,51 +374,36 @@ public sealed partial class Blake2b : HashAlgorithm
 
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private void CompressScalar(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private static unsafe void CompressScalar(byte* msgPtr, ulong* state, ulong bytesCompressed, bool isFinal)
     {
-        _bytesCompressed += (ulong)bytesConsumed;
-
-        // Load all 16 message words into locals — eliminates span bounds checks and
-        // Sigma array indirections from the 12 fully-unrolled rounds below.
-        Span<ulong> msgBuf = stackalloc ulong[ScratchSize];
-        ref ulong mr = ref msgBuf[0];
-        ref byte br = ref MemoryMarshal.GetReference(block);
-        if (BitConverter.IsLittleEndian && IsAlignedForUlong(ref br))
+        // On little-endian platforms (all current .NET targets), the message bytes can be
+        // interpreted directly as ulong words via pointer cast — unaligned reads are handled
+        // correctly by all x86-64 and ARM64 hardware. On big-endian, we byte-swap into a
+        // scratch buffer via BinarySpans. BitConverter.IsLittleEndian is a JIT constant,
+        // so the dead branch and its stackalloc are eliminated entirely.
+        ulong* mr = (ulong*)msgPtr;
+        if (!BitConverter.IsLittleEndian)
         {
-            mr = ref Unsafe.As<byte, ulong>(ref br);
+            ulong* scratch = stackalloc ulong[ScratchSize];
+            BinarySpans.ReadUInt64LittleEndian(msgPtr, scratch, ScratchSize);
+            mr = scratch;
         }
-        else
-        {
-            // If the platform is big-endian, we need to reverse byte order and use the scratch buffer.
-            BinarySpans.ReadUInt64LittleEndian(block, msgBuf);
-        }
-
-        ulong m0 = mr, m1 = Unsafe.Add(ref mr, 1),
-              m2 = Unsafe.Add(ref mr, 2), m3 = Unsafe.Add(ref mr, 3),
-              m4 = Unsafe.Add(ref mr, 4), m5 = Unsafe.Add(ref mr, 5),
-              m6 = Unsafe.Add(ref mr, 6), m7 = Unsafe.Add(ref mr, 7),
-              m8 = Unsafe.Add(ref mr, 8), m9 = Unsafe.Add(ref mr, 9),
-              m10 = Unsafe.Add(ref mr, 10), m11 = Unsafe.Add(ref mr, 11),
-              m12 = Unsafe.Add(ref mr, 12), m13 = Unsafe.Add(ref mr, 13),
-              m14 = Unsafe.Add(ref mr, 14), m15 = Unsafe.Add(ref mr, 15);
 
         // Load current hash state into 16 local working-vector variables.
-        // The JIT can allocate these in registers — unlike Span<ulong> which forces
-        // every element access through a bounds-checked memory dereference.
-        ref ulong sr = ref _state[0];
-        ulong v0 = sr, v1 = Unsafe.Add(ref sr, 1),
-              v2 = Unsafe.Add(ref sr, 2), v3 = Unsafe.Add(ref sr, 3),
-              v4 = Unsafe.Add(ref sr, 4), v5 = Unsafe.Add(ref sr, 5),
-              v6 = Unsafe.Add(ref sr, 6), v7 = Unsafe.Add(ref sr, 7);
+        // Pointer dereference — no bounds checks, no ref tracking overhead.
+        ulong v0 = state[0], v1 = state[1], v2 = state[2], v3 = state[3],
+              v4 = state[4], v5 = state[5], v6 = state[6], v7 = state[7];
 
         // IV constants
-        ulong v8 = IV[0], v9 = IV[1],
-              v10 = IV[2], v11 = IV[3],
-              v12 = IV[4] ^ _bytesCompressed,
-              v13 = IV[5],
-              v14 = isFinal ? ~IV[6] : IV[6],
-              v15 = IV[7];
-              
+        ulong v8 = IV[0], v9 = IV[1], v10 = IV[2], v11 = IV[3],
+              v12 = IV[4] ^ bytesCompressed, v13 = IV[5],
+              v14 = isFinal ? ~IV[6] : IV[6], v15 = IV[7];
+
+        ulong m0 = mr[0], m1 = mr[1], m2 = mr[2], m3 = mr[3],
+              m4 = mr[4], m5 = mr[5], m6 = mr[6], m7 = mr[7],
+              m8 = mr[8], m9 = mr[9], m10 = mr[10], m11 = mr[11],
+              m12 = mr[12], m13 = mr[13], m14 = mr[14], m15 = mr[15];
+
         bool step11and12 = false;
         while (true)
         {
@@ -472,15 +464,11 @@ public sealed partial class Blake2b : HashAlgorithm
             G(ref v2, ref v7, ref v8, ref v13, m3, m12); G(ref v3, ref v4, ref v9, ref v14, m13, m0);
         }
 
-        // Finalize: state[i] ^= v[i] ^ v[i+8] — bounds-check-free via Unsafe.Add
-        sr ^= v0 ^ v8;
-        Unsafe.Add(ref sr, 1) ^= v1 ^ v9;
-        Unsafe.Add(ref sr, 2) ^= v2 ^ v10;
-        Unsafe.Add(ref sr, 3) ^= v3 ^ v11;
-        Unsafe.Add(ref sr, 4) ^= v4 ^ v12;
-        Unsafe.Add(ref sr, 5) ^= v5 ^ v13;
-        Unsafe.Add(ref sr, 6) ^= v6 ^ v14;
-        Unsafe.Add(ref sr, 7) ^= v7 ^ v15;
+        // Finalize: state[i] ^= v[i] ^ v[i+8]
+        state[0] ^= v0 ^ v8; state[1] ^= v1 ^ v9;
+        state[2] ^= v2 ^ v10; state[3] ^= v3 ^ v11;
+        state[4] ^= v4 ^ v12; state[5] ^= v5 ^ v13;
+        state[6] ^= v6 ^ v14; state[7] ^= v7 ^ v15;
     }
 
     /// <summary>
@@ -500,12 +488,5 @@ public sealed partial class Blake2b : HashAlgorithm
             c = c + d;
             b = BitOperations.RotateRight(b ^ c, 63);
         }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private unsafe static bool IsAlignedForUlong<T>(ref T value) where T : unmanaged
-    {
-        void* p = Unsafe.AsPointer(ref value);
-        return (((nuint)p) & ((nuint)sizeof(ulong) - 1)) == 0;
     }
 }

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 #pragma warning disable IDE1006 // Naming rule violation - IV and Sigma are standard cryptographic constant names per RFC 7693
@@ -386,46 +386,108 @@ public sealed partial class Blake2b : HashAlgorithm
     {
         _bytesCompressed += (ulong)bytesConsumed;
 
-        // Use stackalloc for working vectors to avoid heap allocations
-        Span<ulong> v = stackalloc ulong[ScratchSize];
-        Span<ulong> m = stackalloc ulong[ScratchSize];
+        // Load all 16 message words into locals — eliminates span bounds checks and
+        // Sigma array indirections from the 12 fully-unrolled rounds below.
+        Span<ulong> msgBuf = stackalloc ulong[ScratchSize];
+        BinarySpans.ReadUInt64LittleEndian(block, msgBuf);
+        ref ulong mr = ref msgBuf[0];
+        ulong m0  = mr,                     m1  = Unsafe.Add(ref mr, 1),
+              m2  = Unsafe.Add(ref mr, 2),  m3  = Unsafe.Add(ref mr, 3),
+              m4  = Unsafe.Add(ref mr, 4),  m5  = Unsafe.Add(ref mr, 5),
+              m6  = Unsafe.Add(ref mr, 6),  m7  = Unsafe.Add(ref mr, 7),
+              m8  = Unsafe.Add(ref mr, 8),  m9  = Unsafe.Add(ref mr, 9),
+              m10 = Unsafe.Add(ref mr, 10), m11 = Unsafe.Add(ref mr, 11),
+              m12 = Unsafe.Add(ref mr, 12), m13 = Unsafe.Add(ref mr, 13),
+              m14 = Unsafe.Add(ref mr, 14), m15 = Unsafe.Add(ref mr, 15);
 
-        // Parse message block into 16 64-bit words (little-endian)
-        BinarySpans.ReadUInt64LittleEndian(block, m);
+        // Load current hash state into 16 local working-vector variables.
+        // The JIT can allocate these in registers — unlike Span<ulong> which forces
+        // every element access through a bounds-checked memory dereference.
+        ref ulong sr = ref _state[0];
+        ulong v0  = sr,                     v1  = Unsafe.Add(ref sr, 1),
+              v2  = Unsafe.Add(ref sr, 2),  v3  = Unsafe.Add(ref sr, 3),
+              v4  = Unsafe.Add(ref sr, 4),  v5  = Unsafe.Add(ref sr, 5),
+              v6  = Unsafe.Add(ref sr, 6),  v7  = Unsafe.Add(ref sr, 7);
 
-        // Initialize working vector
-        _state.CopyTo(v.Slice(0, StateSize));
-        IV.CopyTo(v.Slice(StateSize, StateSize));
+        // IV constants
+        ulong v8  = IV[0], v9  = IV[1],
+              v10 = IV[2], v11 = IV[3],
+              v12 = IV[4] ^ _bytesCompressed,
+              v13 = IV[5],
+              v14 = isFinal ? ~IV[6] : IV[6],
+              v15 = IV[7];
 
-        v[12] ^= _bytesCompressed;                  // XOR with low 64 bits of counter
-                                                    // v[13] = IV[5];                           // XOR with high 64 bits (always 0 for us)
-        v[14] = isFinal ? ~IV[6] : IV[6];           // Invert if final block
+        // 10+2 rounds, fully unrolled — no loop counter, no Sigma table access at runtime.
+        // Round 0 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+        G(ref v0, ref v4, ref v8,  ref v12, m0,  m1);  G(ref v1, ref v5, ref v9,  ref v13, m2,  m3);
+        G(ref v2, ref v6, ref v10, ref v14, m4,  m5);  G(ref v3, ref v7, ref v11, ref v15, m6,  m7);
+        G(ref v0, ref v5, ref v10, ref v15, m8,  m9);  G(ref v1, ref v6, ref v11, ref v12, m10, m11);
+        G(ref v2, ref v7, ref v8,  ref v13, m12, m13); G(ref v3, ref v4, ref v9,  ref v14, m14, m15);
+        // Round 1 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+        G(ref v0, ref v4, ref v8,  ref v12, m14, m10); G(ref v1, ref v5, ref v9,  ref v13, m4,  m8);
+        G(ref v2, ref v6, ref v10, ref v14, m9,  m15); G(ref v3, ref v7, ref v11, ref v15, m13, m6);
+        G(ref v0, ref v5, ref v10, ref v15, m1,  m12); G(ref v1, ref v6, ref v11, ref v12, m0,  m2);
+        G(ref v2, ref v7, ref v8,  ref v13, m11, m7);  G(ref v3, ref v4, ref v9,  ref v14, m5,  m3);
+        // Round 2 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+        G(ref v0, ref v4, ref v8,  ref v12, m11, m8);  G(ref v1, ref v5, ref v9,  ref v13, m12, m0);
+        G(ref v2, ref v6, ref v10, ref v14, m5,  m2);  G(ref v3, ref v7, ref v11, ref v15, m15, m13);
+        G(ref v0, ref v5, ref v10, ref v15, m10, m14); G(ref v1, ref v6, ref v11, ref v12, m3,  m6);
+        G(ref v2, ref v7, ref v8,  ref v13, m7,  m1);  G(ref v3, ref v4, ref v9,  ref v14, m9,  m4);
+        // Round 3 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+        G(ref v0, ref v4, ref v8,  ref v12, m7,  m9);  G(ref v1, ref v5, ref v9,  ref v13, m3,  m1);
+        G(ref v2, ref v6, ref v10, ref v14, m13, m12); G(ref v3, ref v7, ref v11, ref v15, m11, m14);
+        G(ref v0, ref v5, ref v10, ref v15, m2,  m6);  G(ref v1, ref v6, ref v11, ref v12, m5,  m10);
+        G(ref v2, ref v7, ref v8,  ref v13, m4,  m0);  G(ref v3, ref v4, ref v9,  ref v14, m15, m8);
+        // Round 4 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+        G(ref v0, ref v4, ref v8,  ref v12, m9,  m0);  G(ref v1, ref v5, ref v9,  ref v13, m5,  m7);
+        G(ref v2, ref v6, ref v10, ref v14, m2,  m4);  G(ref v3, ref v7, ref v11, ref v15, m10, m15);
+        G(ref v0, ref v5, ref v10, ref v15, m14, m1);  G(ref v1, ref v6, ref v11, ref v12, m11, m12);
+        G(ref v2, ref v7, ref v8,  ref v13, m6,  m8);  G(ref v3, ref v4, ref v9,  ref v14, m3,  m13);
+        // Round 5 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+        G(ref v0, ref v4, ref v8,  ref v12, m2,  m12); G(ref v1, ref v5, ref v9,  ref v13, m6,  m10);
+        G(ref v2, ref v6, ref v10, ref v14, m0,  m11); G(ref v3, ref v7, ref v11, ref v15, m8,  m3);
+        G(ref v0, ref v5, ref v10, ref v15, m4,  m13); G(ref v1, ref v6, ref v11, ref v12, m7,  m5);
+        G(ref v2, ref v7, ref v8,  ref v13, m15, m14); G(ref v3, ref v4, ref v9,  ref v14, m1,  m9);
+        // Round 6 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+        G(ref v0, ref v4, ref v8,  ref v12, m12, m5);  G(ref v1, ref v5, ref v9,  ref v13, m1,  m15);
+        G(ref v2, ref v6, ref v10, ref v14, m14, m13); G(ref v3, ref v7, ref v11, ref v15, m4,  m10);
+        G(ref v0, ref v5, ref v10, ref v15, m0,  m7);  G(ref v1, ref v6, ref v11, ref v12, m6,  m3);
+        G(ref v2, ref v7, ref v8,  ref v13, m9,  m2);  G(ref v3, ref v4, ref v9,  ref v14, m8,  m11);
+        // Round 7 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+        G(ref v0, ref v4, ref v8,  ref v12, m13, m11); G(ref v1, ref v5, ref v9,  ref v13, m7,  m14);
+        G(ref v2, ref v6, ref v10, ref v14, m12, m1);  G(ref v3, ref v7, ref v11, ref v15, m3,  m9);
+        G(ref v0, ref v5, ref v10, ref v15, m5,  m0);  G(ref v1, ref v6, ref v11, ref v12, m15, m4);
+        G(ref v2, ref v7, ref v8,  ref v13, m8,  m6);  G(ref v3, ref v4, ref v9,  ref v14, m2,  m10);
+        // Round 8 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+        G(ref v0, ref v4, ref v8,  ref v12, m6,  m15); G(ref v1, ref v5, ref v9,  ref v13, m14, m9);
+        G(ref v2, ref v6, ref v10, ref v14, m11, m3);  G(ref v3, ref v7, ref v11, ref v15, m0,  m8);
+        G(ref v0, ref v5, ref v10, ref v15, m12, m2);  G(ref v1, ref v6, ref v11, ref v12, m13, m7);
+        G(ref v2, ref v7, ref v8,  ref v13, m1,  m4);  G(ref v3, ref v4, ref v9,  ref v14, m10, m5);
+        // Round 9 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+        G(ref v0, ref v4, ref v8,  ref v12, m10, m2);  G(ref v1, ref v5, ref v9,  ref v13, m8,  m4);
+        G(ref v2, ref v6, ref v10, ref v14, m7,  m6);  G(ref v3, ref v7, ref v11, ref v15, m1,  m5);
+        G(ref v0, ref v5, ref v10, ref v15, m15, m11); G(ref v1, ref v6, ref v11, ref v12, m9,  m14);
+        G(ref v2, ref v7, ref v8,  ref v13, m3,  m12); G(ref v3, ref v4, ref v9,  ref v14, m13, m0);
+        // Round 10 — (same as round 0)
+        G(ref v0, ref v4, ref v8,  ref v12, m0,  m1);  G(ref v1, ref v5, ref v9,  ref v13, m2,  m3);
+        G(ref v2, ref v6, ref v10, ref v14, m4,  m5);  G(ref v3, ref v7, ref v11, ref v15, m6,  m7);
+        G(ref v0, ref v5, ref v10, ref v15, m8,  m9);  G(ref v1, ref v6, ref v11, ref v12, m10, m11);
+        G(ref v2, ref v7, ref v8,  ref v13, m12, m13); G(ref v3, ref v4, ref v9,  ref v14, m14, m15);
+        // Round 11 — (same as round 1)
+        G(ref v0, ref v4, ref v8,  ref v12, m14, m10); G(ref v1, ref v5, ref v9,  ref v13, m4,  m8);
+        G(ref v2, ref v6, ref v10, ref v14, m9,  m15); G(ref v3, ref v7, ref v11, ref v15, m13, m6);
+        G(ref v0, ref v5, ref v10, ref v15, m1,  m12); G(ref v1, ref v6, ref v11, ref v12, m0,  m2);
+        G(ref v2, ref v7, ref v8,  ref v13, m11, m7);  G(ref v3, ref v4, ref v9,  ref v14, m5,  m3);
 
-        // 12 rounds of mixing
-        for (int round = 0; round < Rounds * ScratchSize; round += ScratchSize)
-        {
-            // Column step
-            G(ref v[0], ref v[4], ref v[8], ref v[12], m[Sigma[round + 0]], m[Sigma[round + 1]]);
-            G(ref v[1], ref v[5], ref v[9], ref v[13], m[Sigma[round + 2]], m[Sigma[round + 3]]);
-            G(ref v[2], ref v[6], ref v[10], ref v[14], m[Sigma[round + 4]], m[Sigma[round + 5]]);
-            G(ref v[3], ref v[7], ref v[11], ref v[15], m[Sigma[round + 6]], m[Sigma[round + 7]]);
-
-            // Diagonal step
-            G(ref v[0], ref v[5], ref v[10], ref v[15], m[Sigma[round + 8]], m[Sigma[round + 9]]);
-            G(ref v[1], ref v[6], ref v[11], ref v[12], m[Sigma[round + 10]], m[Sigma[round + 11]]);
-            G(ref v[2], ref v[7], ref v[8], ref v[13], m[Sigma[round + 12]], m[Sigma[round + 13]]);
-            G(ref v[3], ref v[4], ref v[9], ref v[14], m[Sigma[round + 14]], m[Sigma[round + 15]]);
-        }
-
-        // Finalize state
-        _state[0] ^= v[0] ^ v[8];
-        _state[1] ^= v[1] ^ v[9];
-        _state[2] ^= v[2] ^ v[10];
-        _state[3] ^= v[3] ^ v[11];
-        _state[4] ^= v[4] ^ v[12];
-        _state[5] ^= v[5] ^ v[13];
-        _state[6] ^= v[6] ^ v[14];
-        _state[7] ^= v[7] ^ v[15];
+        // Finalize: state[i] ^= v[i] ^ v[i+8] — bounds-check-free via Unsafe.Add
+        sr                      ^= v0 ^ v8;
+        Unsafe.Add(ref sr, 1)   ^= v1 ^ v9;
+        Unsafe.Add(ref sr, 2)   ^= v2 ^ v10;
+        Unsafe.Add(ref sr, 3)   ^= v3 ^ v11;
+        Unsafe.Add(ref sr, 4)   ^= v4 ^ v12;
+        Unsafe.Add(ref sr, 5)   ^= v5 ^ v13;
+        Unsafe.Add(ref sr, 6)   ^= v6 ^ v14;
+        Unsafe.Add(ref sr, 7)   ^= v7 ^ v15;
     }
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -10,6 +10,7 @@ using System;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 #if NET8_0_OR_GREATER
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -389,13 +390,23 @@ public sealed partial class Blake2b : HashAlgorithm
         // Load all 16 message words into locals — eliminates span bounds checks and
         // Sigma array indirections from the 12 fully-unrolled rounds below.
         Span<ulong> msgBuf = stackalloc ulong[ScratchSize];
-        BinarySpans.ReadUInt64LittleEndian(block, msgBuf);
         ref ulong mr = ref msgBuf[0];
-        ulong m0  = mr,                     m1  = Unsafe.Add(ref mr, 1),
-              m2  = Unsafe.Add(ref mr, 2),  m3  = Unsafe.Add(ref mr, 3),
-              m4  = Unsafe.Add(ref mr, 4),  m5  = Unsafe.Add(ref mr, 5),
-              m6  = Unsafe.Add(ref mr, 6),  m7  = Unsafe.Add(ref mr, 7),
-              m8  = Unsafe.Add(ref mr, 8),  m9  = Unsafe.Add(ref mr, 9),
+        ref byte br = ref MemoryMarshal.GetReference(block);
+        if (BitConverter.IsLittleEndian && IsAlignedForUlong(ref br))
+        {
+            mr = ref Unsafe.As<byte, ulong>(ref br);
+        }
+        else
+        {
+            // If the platform is big-endian, we need to reverse byte order and use the scratch buffer.
+            BinarySpans.ReadUInt64LittleEndian(block, msgBuf);
+        }
+
+        ulong m0 = mr, m1 = Unsafe.Add(ref mr, 1),
+              m2 = Unsafe.Add(ref mr, 2), m3 = Unsafe.Add(ref mr, 3),
+              m4 = Unsafe.Add(ref mr, 4), m5 = Unsafe.Add(ref mr, 5),
+              m6 = Unsafe.Add(ref mr, 6), m7 = Unsafe.Add(ref mr, 7),
+              m8 = Unsafe.Add(ref mr, 8), m9 = Unsafe.Add(ref mr, 9),
               m10 = Unsafe.Add(ref mr, 10), m11 = Unsafe.Add(ref mr, 11),
               m12 = Unsafe.Add(ref mr, 12), m13 = Unsafe.Add(ref mr, 13),
               m14 = Unsafe.Add(ref mr, 14), m15 = Unsafe.Add(ref mr, 15);
@@ -404,90 +415,88 @@ public sealed partial class Blake2b : HashAlgorithm
         // The JIT can allocate these in registers — unlike Span<ulong> which forces
         // every element access through a bounds-checked memory dereference.
         ref ulong sr = ref _state[0];
-        ulong v0  = sr,                     v1  = Unsafe.Add(ref sr, 1),
-              v2  = Unsafe.Add(ref sr, 2),  v3  = Unsafe.Add(ref sr, 3),
-              v4  = Unsafe.Add(ref sr, 4),  v5  = Unsafe.Add(ref sr, 5),
-              v6  = Unsafe.Add(ref sr, 6),  v7  = Unsafe.Add(ref sr, 7);
+        ulong v0 = sr, v1 = Unsafe.Add(ref sr, 1),
+              v2 = Unsafe.Add(ref sr, 2), v3 = Unsafe.Add(ref sr, 3),
+              v4 = Unsafe.Add(ref sr, 4), v5 = Unsafe.Add(ref sr, 5),
+              v6 = Unsafe.Add(ref sr, 6), v7 = Unsafe.Add(ref sr, 7);
 
         // IV constants
-        ulong v8  = IV[0], v9  = IV[1],
+        ulong v8 = IV[0], v9 = IV[1],
               v10 = IV[2], v11 = IV[3],
               v12 = IV[4] ^ _bytesCompressed,
               v13 = IV[5],
               v14 = isFinal ? ~IV[6] : IV[6],
               v15 = IV[7];
+              
+        bool step11and12 = false;
+        while (true)
+        {
+            // 10+2 rounds, fully unrolled — no loop counter, no Sigma table access at runtime.
+            // Round 0 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+            G(ref v0, ref v4, ref v8, ref v12, m0, m1); G(ref v1, ref v5, ref v9, ref v13, m2, m3);
+            G(ref v2, ref v6, ref v10, ref v14, m4, m5); G(ref v3, ref v7, ref v11, ref v15, m6, m7);
+            G(ref v0, ref v5, ref v10, ref v15, m8, m9); G(ref v1, ref v6, ref v11, ref v12, m10, m11);
+            G(ref v2, ref v7, ref v8, ref v13, m12, m13); G(ref v3, ref v4, ref v9, ref v14, m14, m15);
+            // Round 1 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+            G(ref v0, ref v4, ref v8, ref v12, m14, m10); G(ref v1, ref v5, ref v9, ref v13, m4, m8);
+            G(ref v2, ref v6, ref v10, ref v14, m9, m15); G(ref v3, ref v7, ref v11, ref v15, m13, m6);
+            G(ref v0, ref v5, ref v10, ref v15, m1, m12); G(ref v1, ref v6, ref v11, ref v12, m0, m2);
+            G(ref v2, ref v7, ref v8, ref v13, m11, m7); G(ref v3, ref v4, ref v9, ref v14, m5, m3);
 
-        // 10+2 rounds, fully unrolled — no loop counter, no Sigma table access at runtime.
-        // Round 0 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-        G(ref v0, ref v4, ref v8,  ref v12, m0,  m1);  G(ref v1, ref v5, ref v9,  ref v13, m2,  m3);
-        G(ref v2, ref v6, ref v10, ref v14, m4,  m5);  G(ref v3, ref v7, ref v11, ref v15, m6,  m7);
-        G(ref v0, ref v5, ref v10, ref v15, m8,  m9);  G(ref v1, ref v6, ref v11, ref v12, m10, m11);
-        G(ref v2, ref v7, ref v8,  ref v13, m12, m13); G(ref v3, ref v4, ref v9,  ref v14, m14, m15);
-        // Round 1 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
-        G(ref v0, ref v4, ref v8,  ref v12, m14, m10); G(ref v1, ref v5, ref v9,  ref v13, m4,  m8);
-        G(ref v2, ref v6, ref v10, ref v14, m9,  m15); G(ref v3, ref v7, ref v11, ref v15, m13, m6);
-        G(ref v0, ref v5, ref v10, ref v15, m1,  m12); G(ref v1, ref v6, ref v11, ref v12, m0,  m2);
-        G(ref v2, ref v7, ref v8,  ref v13, m11, m7);  G(ref v3, ref v4, ref v9,  ref v14, m5,  m3);
-        // Round 2 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
-        G(ref v0, ref v4, ref v8,  ref v12, m11, m8);  G(ref v1, ref v5, ref v9,  ref v13, m12, m0);
-        G(ref v2, ref v6, ref v10, ref v14, m5,  m2);  G(ref v3, ref v7, ref v11, ref v15, m15, m13);
-        G(ref v0, ref v5, ref v10, ref v15, m10, m14); G(ref v1, ref v6, ref v11, ref v12, m3,  m6);
-        G(ref v2, ref v7, ref v8,  ref v13, m7,  m1);  G(ref v3, ref v4, ref v9,  ref v14, m9,  m4);
-        // Round 3 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
-        G(ref v0, ref v4, ref v8,  ref v12, m7,  m9);  G(ref v1, ref v5, ref v9,  ref v13, m3,  m1);
-        G(ref v2, ref v6, ref v10, ref v14, m13, m12); G(ref v3, ref v7, ref v11, ref v15, m11, m14);
-        G(ref v0, ref v5, ref v10, ref v15, m2,  m6);  G(ref v1, ref v6, ref v11, ref v12, m5,  m10);
-        G(ref v2, ref v7, ref v8,  ref v13, m4,  m0);  G(ref v3, ref v4, ref v9,  ref v14, m15, m8);
-        // Round 4 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
-        G(ref v0, ref v4, ref v8,  ref v12, m9,  m0);  G(ref v1, ref v5, ref v9,  ref v13, m5,  m7);
-        G(ref v2, ref v6, ref v10, ref v14, m2,  m4);  G(ref v3, ref v7, ref v11, ref v15, m10, m15);
-        G(ref v0, ref v5, ref v10, ref v15, m14, m1);  G(ref v1, ref v6, ref v11, ref v12, m11, m12);
-        G(ref v2, ref v7, ref v8,  ref v13, m6,  m8);  G(ref v3, ref v4, ref v9,  ref v14, m3,  m13);
-        // Round 5 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
-        G(ref v0, ref v4, ref v8,  ref v12, m2,  m12); G(ref v1, ref v5, ref v9,  ref v13, m6,  m10);
-        G(ref v2, ref v6, ref v10, ref v14, m0,  m11); G(ref v3, ref v7, ref v11, ref v15, m8,  m3);
-        G(ref v0, ref v5, ref v10, ref v15, m4,  m13); G(ref v1, ref v6, ref v11, ref v12, m7,  m5);
-        G(ref v2, ref v7, ref v8,  ref v13, m15, m14); G(ref v3, ref v4, ref v9,  ref v14, m1,  m9);
-        // Round 6 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
-        G(ref v0, ref v4, ref v8,  ref v12, m12, m5);  G(ref v1, ref v5, ref v9,  ref v13, m1,  m15);
-        G(ref v2, ref v6, ref v10, ref v14, m14, m13); G(ref v3, ref v7, ref v11, ref v15, m4,  m10);
-        G(ref v0, ref v5, ref v10, ref v15, m0,  m7);  G(ref v1, ref v6, ref v11, ref v12, m6,  m3);
-        G(ref v2, ref v7, ref v8,  ref v13, m9,  m2);  G(ref v3, ref v4, ref v9,  ref v14, m8,  m11);
-        // Round 7 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
-        G(ref v0, ref v4, ref v8,  ref v12, m13, m11); G(ref v1, ref v5, ref v9,  ref v13, m7,  m14);
-        G(ref v2, ref v6, ref v10, ref v14, m12, m1);  G(ref v3, ref v7, ref v11, ref v15, m3,  m9);
-        G(ref v0, ref v5, ref v10, ref v15, m5,  m0);  G(ref v1, ref v6, ref v11, ref v12, m15, m4);
-        G(ref v2, ref v7, ref v8,  ref v13, m8,  m6);  G(ref v3, ref v4, ref v9,  ref v14, m2,  m10);
-        // Round 8 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
-        G(ref v0, ref v4, ref v8,  ref v12, m6,  m15); G(ref v1, ref v5, ref v9,  ref v13, m14, m9);
-        G(ref v2, ref v6, ref v10, ref v14, m11, m3);  G(ref v3, ref v7, ref v11, ref v15, m0,  m8);
-        G(ref v0, ref v5, ref v10, ref v15, m12, m2);  G(ref v1, ref v6, ref v11, ref v12, m13, m7);
-        G(ref v2, ref v7, ref v8,  ref v13, m1,  m4);  G(ref v3, ref v4, ref v9,  ref v14, m10, m5);
-        // Round 9 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
-        G(ref v0, ref v4, ref v8,  ref v12, m10, m2);  G(ref v1, ref v5, ref v9,  ref v13, m8,  m4);
-        G(ref v2, ref v6, ref v10, ref v14, m7,  m6);  G(ref v3, ref v7, ref v11, ref v15, m1,  m5);
-        G(ref v0, ref v5, ref v10, ref v15, m15, m11); G(ref v1, ref v6, ref v11, ref v12, m9,  m14);
-        G(ref v2, ref v7, ref v8,  ref v13, m3,  m12); G(ref v3, ref v4, ref v9,  ref v14, m13, m0);
-        // Round 10 — (same as round 0)
-        G(ref v0, ref v4, ref v8,  ref v12, m0,  m1);  G(ref v1, ref v5, ref v9,  ref v13, m2,  m3);
-        G(ref v2, ref v6, ref v10, ref v14, m4,  m5);  G(ref v3, ref v7, ref v11, ref v15, m6,  m7);
-        G(ref v0, ref v5, ref v10, ref v15, m8,  m9);  G(ref v1, ref v6, ref v11, ref v12, m10, m11);
-        G(ref v2, ref v7, ref v8,  ref v13, m12, m13); G(ref v3, ref v4, ref v9,  ref v14, m14, m15);
-        // Round 11 — (same as round 1)
-        G(ref v0, ref v4, ref v8,  ref v12, m14, m10); G(ref v1, ref v5, ref v9,  ref v13, m4,  m8);
-        G(ref v2, ref v6, ref v10, ref v14, m9,  m15); G(ref v3, ref v7, ref v11, ref v15, m13, m6);
-        G(ref v0, ref v5, ref v10, ref v15, m1,  m12); G(ref v1, ref v6, ref v11, ref v12, m0,  m2);
-        G(ref v2, ref v7, ref v8,  ref v13, m11, m7);  G(ref v3, ref v4, ref v9,  ref v14, m5,  m3);
+            if (step11and12) break;
+            step11and12 = true;
+
+            // Round 2 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+            G(ref v0, ref v4, ref v8, ref v12, m11, m8); G(ref v1, ref v5, ref v9, ref v13, m12, m0);
+            G(ref v2, ref v6, ref v10, ref v14, m5, m2); G(ref v3, ref v7, ref v11, ref v15, m15, m13);
+            G(ref v0, ref v5, ref v10, ref v15, m10, m14); G(ref v1, ref v6, ref v11, ref v12, m3, m6);
+            G(ref v2, ref v7, ref v8, ref v13, m7, m1); G(ref v3, ref v4, ref v9, ref v14, m9, m4);
+            // Round 3 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+            G(ref v0, ref v4, ref v8, ref v12, m7, m9); G(ref v1, ref v5, ref v9, ref v13, m3, m1);
+            G(ref v2, ref v6, ref v10, ref v14, m13, m12); G(ref v3, ref v7, ref v11, ref v15, m11, m14);
+            G(ref v0, ref v5, ref v10, ref v15, m2, m6); G(ref v1, ref v6, ref v11, ref v12, m5, m10);
+            G(ref v2, ref v7, ref v8, ref v13, m4, m0); G(ref v3, ref v4, ref v9, ref v14, m15, m8);
+            // Round 4 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+            G(ref v0, ref v4, ref v8, ref v12, m9, m0); G(ref v1, ref v5, ref v9, ref v13, m5, m7);
+            G(ref v2, ref v6, ref v10, ref v14, m2, m4); G(ref v3, ref v7, ref v11, ref v15, m10, m15);
+            G(ref v0, ref v5, ref v10, ref v15, m14, m1); G(ref v1, ref v6, ref v11, ref v12, m11, m12);
+            G(ref v2, ref v7, ref v8, ref v13, m6, m8); G(ref v3, ref v4, ref v9, ref v14, m3, m13);
+            // Round 5 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+            G(ref v0, ref v4, ref v8, ref v12, m2, m12); G(ref v1, ref v5, ref v9, ref v13, m6, m10);
+            G(ref v2, ref v6, ref v10, ref v14, m0, m11); G(ref v3, ref v7, ref v11, ref v15, m8, m3);
+            G(ref v0, ref v5, ref v10, ref v15, m4, m13); G(ref v1, ref v6, ref v11, ref v12, m7, m5);
+            G(ref v2, ref v7, ref v8, ref v13, m15, m14); G(ref v3, ref v4, ref v9, ref v14, m1, m9);
+            // Round 6 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+            G(ref v0, ref v4, ref v8, ref v12, m12, m5); G(ref v1, ref v5, ref v9, ref v13, m1, m15);
+            G(ref v2, ref v6, ref v10, ref v14, m14, m13); G(ref v3, ref v7, ref v11, ref v15, m4, m10);
+            G(ref v0, ref v5, ref v10, ref v15, m0, m7); G(ref v1, ref v6, ref v11, ref v12, m6, m3);
+            G(ref v2, ref v7, ref v8, ref v13, m9, m2); G(ref v3, ref v4, ref v9, ref v14, m8, m11);
+            // Round 7 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+            G(ref v0, ref v4, ref v8, ref v12, m13, m11); G(ref v1, ref v5, ref v9, ref v13, m7, m14);
+            G(ref v2, ref v6, ref v10, ref v14, m12, m1); G(ref v3, ref v7, ref v11, ref v15, m3, m9);
+            G(ref v0, ref v5, ref v10, ref v15, m5, m0); G(ref v1, ref v6, ref v11, ref v12, m15, m4);
+            G(ref v2, ref v7, ref v8, ref v13, m8, m6); G(ref v3, ref v4, ref v9, ref v14, m2, m10);
+            // Round 8 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+            G(ref v0, ref v4, ref v8, ref v12, m6, m15); G(ref v1, ref v5, ref v9, ref v13, m14, m9);
+            G(ref v2, ref v6, ref v10, ref v14, m11, m3); G(ref v3, ref v7, ref v11, ref v15, m0, m8);
+            G(ref v0, ref v5, ref v10, ref v15, m12, m2); G(ref v1, ref v6, ref v11, ref v12, m13, m7);
+            G(ref v2, ref v7, ref v8, ref v13, m1, m4); G(ref v3, ref v4, ref v9, ref v14, m10, m5);
+            // Round 9 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+            G(ref v0, ref v4, ref v8, ref v12, m10, m2); G(ref v1, ref v5, ref v9, ref v13, m8, m4);
+            G(ref v2, ref v6, ref v10, ref v14, m7, m6); G(ref v3, ref v7, ref v11, ref v15, m1, m5);
+            G(ref v0, ref v5, ref v10, ref v15, m15, m11); G(ref v1, ref v6, ref v11, ref v12, m9, m14);
+            G(ref v2, ref v7, ref v8, ref v13, m3, m12); G(ref v3, ref v4, ref v9, ref v14, m13, m0);
+        }
 
         // Finalize: state[i] ^= v[i] ^ v[i+8] — bounds-check-free via Unsafe.Add
-        sr                      ^= v0 ^ v8;
-        Unsafe.Add(ref sr, 1)   ^= v1 ^ v9;
-        Unsafe.Add(ref sr, 2)   ^= v2 ^ v10;
-        Unsafe.Add(ref sr, 3)   ^= v3 ^ v11;
-        Unsafe.Add(ref sr, 4)   ^= v4 ^ v12;
-        Unsafe.Add(ref sr, 5)   ^= v5 ^ v13;
-        Unsafe.Add(ref sr, 6)   ^= v6 ^ v14;
-        Unsafe.Add(ref sr, 7)   ^= v7 ^ v15;
+        sr ^= v0 ^ v8;
+        Unsafe.Add(ref sr, 1) ^= v1 ^ v9;
+        Unsafe.Add(ref sr, 2) ^= v2 ^ v10;
+        Unsafe.Add(ref sr, 3) ^= v3 ^ v11;
+        Unsafe.Add(ref sr, 4) ^= v4 ^ v12;
+        Unsafe.Add(ref sr, 5) ^= v5 ^ v13;
+        Unsafe.Add(ref sr, 6) ^= v6 ^ v14;
+        Unsafe.Add(ref sr, 7) ^= v7 ^ v15;
     }
 
     /// <summary>
@@ -507,5 +516,12 @@ public sealed partial class Blake2b : HashAlgorithm
             c = c + d;
             b = BitOperations.RotateRight(b ^ c, 63);
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private unsafe static bool IsAlignedForUlong<T>(ref T value) where T : unmanaged
+    {
+        void* p = Unsafe.AsPointer(ref value);
+        return (((nuint)p) & ((nuint)sizeof(ulong) - 1)) == 0;
     }
 }

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -230,10 +230,12 @@ public sealed partial class Blake2b : HashAlgorithm
         {
             CompressAvx2(msgPtr, state, _bytesCompressed, isFinal);
         }
+#if EXPERIMENTAL
         else if ((_simdSupport & SimdSupport.Neon) != 0)
         {
             CompressNeon(msgPtr, state, _bytesCompressed, isFinal);
         }
+#endif
         else
 #endif
         {

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.Neon.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.Neon.cs
@@ -7,134 +7,170 @@ namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 #if NET8_0_OR_GREATER
 
-using System;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 
 /// <summary>
-/// BLAKE2s ARM NEON-accelerated compression using AdvSimd intrinsics.
+/// BLAKE2s ARM NEON-accelerated compression with fully unrolled rounds.
 /// </summary>
+/// <remarks>
+/// State is loaded from and stored back to the shared <c>_state[]</c> array via pointers.
+/// Uses <c>VectorTableLookup</c> for byte-aligned rotations (16, 8) and shift+or for
+/// non-byte-aligned rotations (12, 7).
+/// </remarks>
 public sealed partial class Blake2s
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void InitializeStateNeon(uint paramBlock)
-    {
-        // Reuses Vector128<uint> state fields declared in Blake2s.Simd.cs.
-        _stateVec0 = IVLow ^ Vector128.Create(paramBlock, 0U, 0U, 0U);
-        _stateVec1 = IVHigh;
-    }
-
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private void CompressNeon(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private static unsafe void CompressNeon(byte* msgPtr, uint* state, ulong bytesCompressed, bool isFinal)
     {
-        _bytesCompressed += (ulong)bytesConsumed;
-
-        // row0 = v[0..3] = state[0..3], row1 = v[4..7] = state[4..7]
-        // row2 = v[8..11] = IV[0..3],   row3 = v[12..15] = IV[4..7] + counter
-        var row0 = _stateVec0;
-        var row1 = _stateVec1;
+        var row0 = AdvSimd.LoadVector128(state);
+        var row1 = AdvSimd.LoadVector128(state + 4);
         var row2 = IVLow;
-
-        var counterVec = Vector128.Create((uint)_bytesCompressed, (uint)(_bytesCompressed >> 32), 0U, 0U);
+        var counterVec = Vector128.Create((uint)bytesCompressed, (uint)(bytesCompressed >> 32), 0U, 0U);
         var row3 = IVHigh ^ counterVec;
-        if (isFinal)
-            row3 ^= FinalMask;
+        if (isFinal) row3 ^= FinalMask;
 
-        // Parse message block into 16 little-endian 32-bit words
-        // (ARM64 is always little-endian, so no byte-swapping needed)
-        Span<uint> m = stackalloc uint[ScratchSize];
-        BinarySpans.ReadUInt32LittleEndian(block, m);
+        var orig0 = row0;
+        var orig1 = row1;
 
-        ref byte sigmaBase = ref MemoryMarshal.GetArrayDataReference(Sigma);
-        ref uint mBase = ref MemoryMarshal.GetReference(m);
+        uint* mr = (uint*)msgPtr;
+        uint w0  = mr[0],  w1  = mr[1],  w2  = mr[2],  w3  = mr[3],
+             w4  = mr[4],  w5  = mr[5],  w6  = mr[6],  w7  = mr[7],
+             w8  = mr[8],  w9  = mr[9],  w10 = mr[10], w11 = mr[11],
+             w12 = mr[12], w13 = mr[13], w14 = mr[14], w15 = mr[15];
 
-        // 10 rounds of mixing
-        for (int sigmaIdx = 0; sigmaIdx < Rounds * ScratchSize; sigmaIdx += ScratchSize)
-        {
-            // Column step
-            var mx0 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 0)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 2)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 4)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 6)));
-            var my0 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 1)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 3)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 5)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 7)));
+        // Round 0 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w0, w2, w4, w6));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w1, w3, w5, w7));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w8, w10, w12, w14));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w9, w11, w13, w15));
+        PermuteNeon(ref row3, ref row2, ref row1);
 
-            GRoundNeon(ref row0, ref row1, ref row2, ref row3, mx0, my0);
+        // Round 1 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w14, w4, w9, w13));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w10, w8, w15, w6));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w1, w0, w11, w5));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w12, w2, w7, w3));
+        PermuteNeon(ref row3, ref row2, ref row1);
 
-            // Diagonal step: rotate rows to align diagonals.
-            // AdvSimd.ExtractVector128(v, v, n) extracts 16 bytes starting at byte-offset n
-            // from the 32-byte concatenation [v, v], equivalent to Sse2.Shuffle with element rotation.
-            row1 = AdvSimd.ExtractVector128(row1.AsByte(), row1.AsByte(), 4).AsUInt32();   // rotate left 1
-            row2 = AdvSimd.ExtractVector128(row2.AsByte(), row2.AsByte(), 8).AsUInt32();   // swap halves
-            row3 = AdvSimd.ExtractVector128(row3.AsByte(), row3.AsByte(), 12).AsUInt32();  // rotate right 1
+        // Round 2 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w11, w12, w5, w15));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w8, w0, w2, w13));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w10, w3, w7, w9));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w14, w6, w1, w4));
+        PermuteNeon(ref row3, ref row2, ref row1);
 
-            var mx1 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 8)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 10)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 12)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 14)));
-            var my1 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 9)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 11)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 13)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 15)));
+        // Round 3 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w7, w3, w13, w11));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w9, w1, w12, w14));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w2, w5, w4, w15));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w6, w10, w0, w8));
+        PermuteNeon(ref row3, ref row2, ref row1);
 
-            GRoundNeon(ref row0, ref row1, ref row2, ref row3, mx1, my1);
+        // Round 4 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w9, w5, w2, w10));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w0, w7, w4, w15));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w14, w11, w6, w3));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w1, w12, w8, w13));
+        PermuteNeon(ref row3, ref row2, ref row1);
 
-            // Un-rotate rows to restore column order
-            row1 = AdvSimd.ExtractVector128(row1.AsByte(), row1.AsByte(), 12).AsUInt32();  // rotate right 1
-            row2 = AdvSimd.ExtractVector128(row2.AsByte(), row2.AsByte(), 8).AsUInt32();   // swap halves
-            row3 = AdvSimd.ExtractVector128(row3.AsByte(), row3.AsByte(), 4).AsUInt32();   // rotate left 1
-        }
+        // Round 5 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w2, w6, w0, w8));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w12, w10, w11, w3));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w4, w7, w15, w1));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w13, w5, w14, w9));
+        PermuteNeon(ref row3, ref row2, ref row1);
 
-        // Finalize: state ^= row0 ^ row2, state ^= row1 ^ row3
-        _stateVec0 ^= row0 ^ row2;
-        _stateVec1 ^= row1 ^ row3;
+        // Round 6 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w12, w1, w14, w4));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w5, w15, w13, w10));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w0, w6, w9, w8));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w7, w3, w2, w11));
+        PermuteNeon(ref row3, ref row2, ref row1);
+
+        // Round 7 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w13, w7, w12, w3));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w11, w14, w1, w9));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w5, w15, w8, w2));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w0, w4, w6, w10));
+        PermuteNeon(ref row3, ref row2, ref row1);
+
+        // Round 8 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w6, w14, w11, w0));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w15, w9, w3, w8));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w12, w13, w1, w10));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w2, w7, w4, w5));
+        PermuteNeon(ref row3, ref row2, ref row1);
+
+        // Round 9 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w10, w8, w7, w1));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w2, w4, w6, w5));
+        PermuteNeon(ref row1, ref row2, ref row3);
+        GRoundXNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w15, w9, w3, w13));
+        GRoundYNeon(ref row0, ref row1, ref row2, ref row3, Vector128.Create(w11, w14, w12, w0));
+        PermuteNeon(ref row3, ref row2, ref row1);
+
+        row0 = AdvSimd.Xor(AdvSimd.Xor(row0, row2), orig0);
+        row1 = AdvSimd.Xor(AdvSimd.Xor(row1, row3), orig1);
+
+        AdvSimd.Store(state, row0);
+        AdvSimd.Store(state + 4, row1);
     }
 
     /// <summary>
-    /// Performs one G round on 4 parallel lanes using ARM NEON intrinsics.
+    /// Performs one Gx half-round: <c>a += b + x; d = ror(d^a, 16); c += d; b = ror(b^c, 12)</c>.
     /// </summary>
-    /// <remarks>
-    /// Uses NEON TBL (VectorTableLookup) for byte-aligned rotations (16, 8) and
-    /// shift+or for non-byte-aligned rotations (12, 7). The shuffle masks
-    /// <see cref="RotateMask16"/> and <see cref="RotateMask8"/> are identical for
-    /// both PSHUFB (x86 SSSE3) and TBL (ARM NEON) on little-endian systems.
-    /// </remarks>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    private static void GRoundNeon(
-        ref Vector128<uint> a,
-        ref Vector128<uint> b,
-        ref Vector128<uint> c,
-        ref Vector128<uint> d,
-        Vector128<uint> x,
+    private static void GRoundXNeon(
+        ref Vector128<uint> a, ref Vector128<uint> b,
+        ref Vector128<uint> c, ref Vector128<uint> d,
+        Vector128<uint> x)
+    {
+        a = AdvSimd.Add(a, AdvSimd.Add(b, x));
+        d = AdvSimd.Arm64.VectorTableLookup((d ^ a).AsByte(), RotateMask16).AsUInt32();
+        c = AdvSimd.Add(c, d);
+        var t = b ^ c;
+        b = AdvSimd.Or(AdvSimd.ShiftRightLogical(t, 12), AdvSimd.ShiftLeftLogical(t, 20));
+    }
+
+    /// <summary>
+    /// Performs one Gy half-round: <c>a += b + y; d = ror(d^a, 8); c += d; b = ror(b^c, 7)</c>.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private static void GRoundYNeon(
+        ref Vector128<uint> a, ref Vector128<uint> b,
+        ref Vector128<uint> c, ref Vector128<uint> d,
         Vector128<uint> y)
     {
-        // a = a + b + x
-        a = AdvSimd.Add(a, AdvSimd.Add(b, x));
-        // d = ror(d ^ a, 16) — TBL byte shuffle (same semantics as PSHUFB on little-endian)
-        d = AdvSimd.Arm64.VectorTableLookup((d ^ a).AsByte(), RotateMask16).AsUInt32();
-        // c = c + d
-        c = AdvSimd.Add(c, d);
-        // b = ror(b ^ c, 12) — shift+or (12 is not byte-aligned)
-        var t1 = b ^ c;
-        b = AdvSimd.Or(AdvSimd.ShiftRightLogical(t1, 12), AdvSimd.ShiftLeftLogical(t1, 20));
-        // a = a + b + y
         a = AdvSimd.Add(a, AdvSimd.Add(b, y));
-        // d = ror(d ^ a, 8) — TBL byte shuffle
         d = AdvSimd.Arm64.VectorTableLookup((d ^ a).AsByte(), RotateMask8).AsUInt32();
-        // c = c + d
         c = AdvSimd.Add(c, d);
-        // b = ror(b ^ c, 7) — shift+or (7 is not byte-aligned)
-        var t2 = b ^ c;
-        b = AdvSimd.Or(AdvSimd.ShiftRightLogical(t2, 7), AdvSimd.ShiftLeftLogical(t2, 25));
+        var t = b ^ c;
+        b = AdvSimd.Or(AdvSimd.ShiftRightLogical(t, 7), AdvSimd.ShiftLeftLogical(t, 25));
+    }
+
+    /// <summary>
+    /// Diagonal permutation. Call as <c>PermuteNeon(ref row1, ref row2, ref row3)</c> to
+    /// diagonalize and <c>PermuteNeon(ref row3, ref row2, ref row1)</c> to un-diagonalize.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private static void PermuteNeon(
+        ref Vector128<uint> a, ref Vector128<uint> b, ref Vector128<uint> c)
+    {
+        a = AdvSimd.ExtractVector128(a.AsByte(), a.AsByte(), 4).AsUInt32();
+        b = AdvSimd.ExtractVector128(b.AsByte(), b.AsByte(), 8).AsUInt32();
+        c = AdvSimd.ExtractVector128(c.AsByte(), c.AsByte(), 12).AsUInt32();
     }
 }
 

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.Neon.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.Neon.cs
@@ -5,7 +5,7 @@
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER && EXPERIMENTAL
 
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.Simd.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.Simd.cs
@@ -8,20 +8,18 @@ namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 #if NET8_0_OR_GREATER
 
 using System;
-using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 /// <summary>
-/// BLAKE2s SIMD-accelerated compression using SSE2, SSSE3 and AVX2 intrinsics.
+/// BLAKE2s x86 SIMD-accelerated compression.
 /// </summary>
 public sealed partial class Blake2s
 {
     // Pre-computed shuffle masks for byte-aligned rotations on 32-bit words
-    // BLAKE2s rotations: 16, 12, 8, 7 bits
-
     // Rotate right by 16 bits (swap high/low 16-bit halves within each 32-bit word)
     private static readonly Vector128<byte> RotateMask16 = Vector128.Create(
         (byte)2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
@@ -30,23 +28,17 @@ public sealed partial class Blake2s
     private static readonly Vector128<byte> RotateMask8 = Vector128.Create(
         (byte)1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12);
 
-    // Pre-computed IV vectors for SSE/AVX path (Vector128<uint> holds 4 elements = 1 row)
     private static readonly Vector128<uint> IVLow = Vector128.Create(
         0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU);
 
     private static readonly Vector128<uint> IVHigh = Vector128.Create(
         0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U);
 
-    // Finalization mask for inverting element 2 of row3 (v[14])
     private static readonly Vector128<uint> FinalMask = Vector128.Create(0U, 0U, ~0U, 0U);
 
     // Pre-computed Vector128<int> indices for gather operations (scaled by 4 for uint stride)
     private static readonly Vector128<int>[] GatherIndicesX = new Vector128<int>[Rounds * 2];
     private static readonly Vector128<int>[] GatherIndicesY = new Vector128<int>[Rounds * 2];
-
-    // Vector state for SSE path (2 x Vector128<uint> = 8 elements = full state)
-    private Vector128<uint> _stateVec0;
-    private Vector128<uint> _stateVec1;
 
     static Blake2s()
     {
@@ -72,241 +64,179 @@ public sealed partial class Blake2s
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void InitializeStateSse2(uint paramBlock)
+    /// <summary>
+    /// Gets the SIMD instruction sets supported by this algorithm on the current platform.
+    /// </summary>
+    internal static new SimdSupport SimdSupport
     {
-        _stateVec0 = Sse2.Xor(IVLow, Vector128.Create(paramBlock, 0U, 0U, 0U));
-        _stateVec1 = IVHigh;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ExtractOutputSse2(Span<byte> destination)
-    {
-        // Store vectors to stack, then copy required bytes
-        Span<uint> temp = stackalloc uint[8];
-        _stateVec0.CopyTo(temp[..4]);
-        _stateVec1.CopyTo(temp[4..]);
-
-        int fullWords = _outputBytes / sizeof(UInt32);
-
-        BinarySpans.WriteUInt32LittleEndian(temp.Slice(0, fullWords), destination);
-
-        int remainingBytes = _outputBytes % sizeof(UInt32);
-        if (remainingBytes > 0)
+        get
         {
-            Span<byte> tempBytes = stackalloc byte[sizeof(UInt32)];
-            BinaryPrimitives.WriteUInt32LittleEndian(tempBytes, temp[fullWords]);
-            tempBytes.Slice(0, remainingBytes).CopyTo(destination.Slice(fullWords * sizeof(UInt32)));
+            var support = SimdSupport.None;
+            if (Sse2.IsSupported) support |= SimdSupport.Sse2;
+            if (Ssse3.IsSupported) support |= SimdSupport.Ssse3;
+            if (Avx2.IsSupported) support |= SimdSupport.Avx2;
+            if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
+            return support;
         }
     }
 
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private unsafe void CompressSse2(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private static unsafe void CompressSse2(byte* msgPtr, uint* state, ulong bytesCompressed, bool isFinal)
     {
-        _bytesCompressed += (ulong)bytesConsumed;
-
         // Initialize rows from vector state
         // row0 = v[0..3] = state[0..3]
         // row1 = v[4..7] = state[4..7]
         // row2 = v[8..11] = IV[0..3]
         // row3 = v[12..15] = IV[4..7] with counter/finalization
-        var row0 = _stateVec0;
-        var row1 = _stateVec1;
+        var row0 = Sse2.LoadVector128(state);
+        var row1 = Sse2.LoadVector128(state + 4);
         var row2 = IVLow;
-
-        // row3 = IVHigh with counter/finalization applied
-        var counterVec = Vector128.Create((uint)_bytesCompressed, (uint)(_bytesCompressed >> 32), 0U, 0U);
+        var counterVec = Vector128.Create((uint)bytesCompressed, (uint)(bytesCompressed >> 32), 0U, 0U);
         var row3 = Sse2.Xor(IVHigh, counterVec);
+        if (isFinal) row3 = Sse2.Xor(row3, FinalMask);
 
-        if (isFinal)
+        var orig0 = row0;
+        var orig1 = row1;
+        fixed (byte* sigmaPtr = Sigma)
         {
-            row3 = Sse2.Xor(row3, FinalMask);
-        }
-
-        // Parse message block into 16 32-bit words (little-endian)
-        Span<uint> m = stackalloc uint[ScratchSize];
-        BinarySpans.ReadUInt32LittleEndian(block, m);
-
-        // Get base references (avoids bounds checking in loop)
-        ref byte sigmaBase = ref MemoryMarshal.GetArrayDataReference(Sigma);
-        ref uint mBase = ref MemoryMarshal.GetReference(m);
-
-        // 10 rounds of mixing
-        for (int sigmaIdx = 0; sigmaIdx < Rounds * ScratchSize; sigmaIdx += ScratchSize)
-        {
-            // Column step: G on (v[0],v[4],v[8],v[12]), (v[1],v[5],v[9],v[13]), etc.
-            var mx0 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 0)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 2)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 4)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 6)));
-            var my0 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 1)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 3)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 5)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 7)));
-
-            GRoundSse2(ref row0, ref row1, ref row2, ref row3, mx0, my0);
-
-            // Diagonal step: rotate rows to align diagonals
-            row1 = Sse2.Shuffle(row1, 0b00_11_10_01); // 1,2,3,0
-            row2 = Sse2.Shuffle(row2, 0b01_00_11_10); // 2,3,0,1
-            row3 = Sse2.Shuffle(row3, 0b10_01_00_11); // 3,0,1,2
-
-            var mx1 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 8)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 10)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 12)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 14)));
-            var my1 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 9)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 11)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 13)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 15)));
-
-            GRoundSse2(ref row0, ref row1, ref row2, ref row3, mx1, my1);
-
-            // Un-rotate rows to restore column order
-            row1 = Sse2.Shuffle(row1, 0b10_01_00_11); // 3,0,1,2
-            row2 = Sse2.Shuffle(row2, 0b01_00_11_10); // 2,3,0,1
-            row3 = Sse2.Shuffle(row3, 0b00_11_10_01); // 1,2,3,0
-        }
-
-        // Finalize: state ^= row0 ^ row2, state ^= row1 ^ row3
-        _stateVec0 = Sse2.Xor(_stateVec0, Sse2.Xor(row0, row2));
-        _stateVec1 = Sse2.Xor(_stateVec1, Sse2.Xor(row1, row3));
-    }
-
-    [SkipLocalsInit]
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private unsafe void CompressSsse3(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
-    {
-        _bytesCompressed += (ulong)bytesConsumed;
-
-        // Initialize rows from vector state
-        var row0 = _stateVec0;
-        var row1 = _stateVec1;
-        var row2 = IVLow;
-
-        var counterVec = Vector128.Create((uint)_bytesCompressed, (uint)(_bytesCompressed >> 32), 0U, 0U);
-        var row3 = Sse2.Xor(IVHigh, counterVec);
-
-        if (isFinal)
-        {
-            row3 = Sse2.Xor(row3, FinalMask);
-        }
-
-        // Parse message block into 16 32-bit words (little-endian)
-        Span<uint> m = stackalloc uint[ScratchSize];
-        BinarySpans.ReadUInt32LittleEndian(block, m);
-
-        // Get base references (avoids bounds checking in loop)
-        ref byte sigmaBase = ref MemoryMarshal.GetArrayDataReference(Sigma);
-        ref uint mBase = ref MemoryMarshal.GetReference(m);
-
-        // 10 rounds of mixing
-        for (int sigmaIdx = 0; sigmaIdx < Rounds * ScratchSize; sigmaIdx += ScratchSize)
-        {
-            // Column step
-            var mx0 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 0)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 2)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 4)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 6)));
-            var my0 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 1)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 3)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 5)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 7)));
-
-            GRoundSsse3(ref row0, ref row1, ref row2, ref row3, mx0, my0);
-
-            // Diagonal step: rotate rows
-            row1 = Sse2.Shuffle(row1, 0b00_11_10_01); // 1,2,3,0
-            row2 = Sse2.Shuffle(row2, 0b01_00_11_10); // 2,3,0,1
-            row3 = Sse2.Shuffle(row3, 0b10_01_00_11); // 3,0,1,2
-
-            var mx1 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 8)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 10)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 12)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 14)));
-            var my1 = Vector128.Create(
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 9)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 11)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 13)),
-                Unsafe.Add(ref mBase, Unsafe.Add(ref sigmaBase, sigmaIdx + 15)));
-
-            GRoundSsse3(ref row0, ref row1, ref row2, ref row3, mx1, my1);
-
-            // Un-rotate rows
-            row1 = Sse2.Shuffle(row1, 0b10_01_00_11); // 3,0,1,2
-            row2 = Sse2.Shuffle(row2, 0b01_00_11_10); // 2,3,0,1
-            row3 = Sse2.Shuffle(row3, 0b00_11_10_01); // 1,2,3,0
-        }
-
-        _stateVec0 = Sse2.Xor(_stateVec0, Sse2.Xor(row0, row2));
-        _stateVec1 = Sse2.Xor(_stateVec1, Sse2.Xor(row1, row3));
-    }
-
-    [SkipLocalsInit]
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private unsafe void CompressAvx2(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
-    {
-        _bytesCompressed += (ulong)bytesConsumed;
-
-        // Pin the message block for gather operations
-        fixed (byte* mPtr = block)
-        {
-            // Get base references for gather indices (avoids bounds checking in loop)
-            ref Vector128<int> gatherXBase = ref MemoryMarshal.GetArrayDataReference(GatherIndicesX);
-            ref Vector128<int> gatherYBase = ref MemoryMarshal.GetArrayDataReference(GatherIndicesY);
-
-            // Initialize rows from vector state
-            var row0 = _stateVec0;
-            var row1 = _stateVec1;
-            var row2 = IVLow;
-
-            // row3 = IVHigh with counter/finalization applied
-            var counterVec = Vector128.Create((uint)_bytesCompressed, (uint)(_bytesCompressed >> 32), 0U, 0U);
-            var row3 = Sse2.Xor(IVHigh, counterVec);
-
-            if (isFinal)
-            {
-                row3 = Sse2.Xor(row3, FinalMask);
-            }
+            uint* m = (uint*)msgPtr;
+            byte* s = sigmaPtr;
 
             // 10 rounds of mixing
-            for (int gatherIdx = 0; gatherIdx < Rounds * 2; gatherIdx+=2)
+            for (int round = 0; round < Rounds; round++)
             {
-                // Column step - use AVX2 gather for message words
-                var mx0 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherXBase, gatherIdx), 1).AsUInt32();
-                var my0 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherYBase, gatherIdx), 1).AsUInt32();
+                // Column step
+                var mx0 = Vector128.Create(m[s[0]], m[s[2]], m[s[4]], m[s[6]]);
+                var my0 = Vector128.Create(m[s[1]], m[s[3]], m[s[5]], m[s[7]]);
+
+                GRoundSse2(ref row0, ref row1, ref row2, ref row3, mx0, my0);
+
+                // Diagonal step: rotate rows
+                Permute(ref row1, ref row2, ref row3);
+
+                var mx1 = Vector128.Create(m[s[8]], m[s[10]], m[s[12]], m[s[14]]);
+                var my1 = Vector128.Create(m[s[9]], m[s[11]], m[s[13]], m[s[15]]);
+
+                GRoundSse2(ref row0, ref row1, ref row2, ref row3, mx1, my1);
+
+                // Un-rotate rows
+                Permute(ref row3, ref row2, ref row1);
+
+                s += ScratchSize;
+            }
+        }
+
+
+        row0 = Sse2.Xor(Sse2.Xor(row0, row2), orig0);
+        row1 = Sse2.Xor(Sse2.Xor(row1, row3), orig1);
+
+        Sse2.Store(state, row0);
+        Sse2.Store(state + 4, row1);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private static unsafe void CompressSsse3(byte* msgPtr, uint* state, ulong bytesCompressed, bool isFinal)
+    {
+        var row0 = Sse2.LoadVector128(state);
+        var row1 = Sse2.LoadVector128(state + 4);
+        var row2 = IVLow;
+        var counterVec = Vector128.Create((uint)bytesCompressed, (uint)(bytesCompressed >> 32), 0U, 0U);
+        var row3 = Sse2.Xor(IVHigh, counterVec);
+        if (isFinal) row3 = Sse2.Xor(row3, FinalMask);
+
+        var orig0 = row0;
+        var orig1 = row1;
+
+        fixed (byte* sigmaPtr = Sigma)
+        {
+            uint* m = (uint*)msgPtr;
+            byte* s = sigmaPtr;
+
+            // 10 rounds of mixing
+            for (int round = 0; round < Rounds; round++)
+            {
+                // Column step
+                var mx0 = Vector128.Create(m[s[0]], m[s[2]], m[s[4]], m[s[6]]);
+                var my0 = Vector128.Create(m[s[1]], m[s[3]], m[s[5]], m[s[7]]);
 
                 GRoundSsse3(ref row0, ref row1, ref row2, ref row3, mx0, my0);
 
-                // Diagonal step: rotate rows to align diagonals
-                row1 = Sse2.Shuffle(row1, 0b00_11_10_01); // 1,2,3,0
-                row2 = Sse2.Shuffle(row2, 0b01_00_11_10); // 2,3,0,1
-                row3 = Sse2.Shuffle(row3, 0b10_01_00_11); // 3,0,1,2
+                // Diagonal step: rotate rows
+                Permute(ref row1, ref row2, ref row3);
 
-                // Diagonal step - use AVX2 gather for message words
-                var mx1 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherXBase, gatherIdx + 1), 1).AsUInt32();
-                var my1 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherYBase, gatherIdx + 1), 1).AsUInt32();
+                var mx1 = Vector128.Create(m[s[8]], m[s[10]], m[s[12]], m[s[14]]);
+                var my1 = Vector128.Create(m[s[9]], m[s[11]], m[s[13]], m[s[15]]);
 
                 GRoundSsse3(ref row0, ref row1, ref row2, ref row3, mx1, my1);
 
-                // Un-rotate rows to restore column order
-                row1 = Sse2.Shuffle(row1, 0b10_01_00_11); // 3,0,1,2
-                row2 = Sse2.Shuffle(row2, 0b01_00_11_10); // 2,3,0,1
-                row3 = Sse2.Shuffle(row3, 0b00_11_10_01); // 1,2,3,0
-            }
+                // Un-rotate rows
+                Permute(ref row3, ref row2, ref row1);
 
-            // Finalize: state ^= row0 ^ row2, state ^= row1 ^ row3
-            _stateVec0 = Sse2.Xor(_stateVec0, Sse2.Xor(row0, row2));
-            _stateVec1 = Sse2.Xor(_stateVec1, Sse2.Xor(row1, row3));
+                s += ScratchSize;
+            }
         }
+
+        row0 = Sse2.Xor(Sse2.Xor(row0, row2), orig0);
+        row1 = Sse2.Xor(Sse2.Xor(row1, row3), orig1);
+
+        Sse2.Store(state, row0);
+        Sse2.Store(state + 4, row1);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private static unsafe void CompressAvx2(byte* mPtr, uint* state, ulong bytesCompressed, bool isFinal)
+    {
+        // Get base references for gather indices (avoids bounds checking in loop)
+        ref Vector128<int> gatherXBase = ref MemoryMarshal.GetArrayDataReference(GatherIndicesX);
+        ref Vector128<int> gatherYBase = ref MemoryMarshal.GetArrayDataReference(GatherIndicesY);
+
+        // Initialize rows from vector state
+        var row0 = Sse2.LoadVector128(state);
+        var row1 = Sse2.LoadVector128(state + 4);
+        var row2 = IVLow;
+
+        // row3 = IVHigh with counter/finalization applied
+        var counterVec = Vector128.Create((uint)bytesCompressed, (uint)(bytesCompressed >> 32), 0U, 0U);
+        var row3 = Sse2.Xor(IVHigh, counterVec);
+
+        if (isFinal)
+        {
+            row3 = Sse2.Xor(row3, FinalMask);
+        }
+
+        var orig0 = row0;
+        var orig1 = row1;
+
+        // 10 rounds of mixing
+        for (int gatherIdx = 0; gatherIdx < Rounds * 2; gatherIdx += 2)
+        {
+            // Column step - use AVX2 gather for message words
+            var mx0 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherXBase, gatherIdx), 1).AsUInt32();
+            var my0 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherYBase, gatherIdx), 1).AsUInt32();
+
+            GRoundSsse3(ref row0, ref row1, ref row2, ref row3, mx0, my0);
+
+            // Diagonal step: rotate rows to align diagonals
+            Permute(ref row1, ref row2, ref row3);
+
+            // Diagonal step - use AVX2 gather for message words
+            var mx1 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherXBase, gatherIdx + 1), 1).AsUInt32();
+            var my1 = Avx2.GatherVector128((int*)mPtr, Unsafe.Add(ref gatherYBase, gatherIdx + 1), 1).AsUInt32();
+
+            GRoundSsse3(ref row0, ref row1, ref row2, ref row3, mx1, my1);
+
+            // Un-rotate rows to restore column order
+            Permute(ref row3, ref row2, ref row1);
+        }
+
+        row0 = Sse2.Xor(Sse2.Xor(row0, row2), orig0);
+        row1 = Sse2.Xor(Sse2.Xor(row1, row3), orig1);
+
+        Sse2.Store(state, row0);
+        Sse2.Store(state + 4, row1);
     }
 
     /// <summary>
@@ -379,6 +309,19 @@ public sealed partial class Blake2s
         // b = ror(b ^ c, 7) - must use shift+or (not byte-aligned)
         var t2 = Sse2.Xor(b, c);
         b = Sse2.Or(Sse2.ShiftRightLogical(t2, 7), Sse2.ShiftLeftLogical(t2, 25));
+    }
+
+    /// <summary>
+    /// Diagonal permutation. Call as <c>Permute(ref row1, ref row2, ref row3)</c> to
+    /// diagonalize and <c>Permute(ref row3, ref row2, ref row1)</c> to un-diagonalize.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private static void Permute(
+        ref Vector128<uint> a, ref Vector128<uint> b, ref Vector128<uint> c)
+    {
+        a = Sse2.Shuffle(a, 0b00_11_10_01);
+        b = Sse2.Shuffle(b, 0b01_00_11_10);
+        c = Sse2.Shuffle(c, 0b10_01_00_11);
     }
 }
 

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.Simd.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.Simd.cs
@@ -48,7 +48,7 @@ public sealed partial class Blake2s
 #if EXPERIMENTAL
             if (Avx2.IsSupported) support |= SimdSupport.Avx2;
             if (Sse2.IsSupported) support |= SimdSupport.Sse2;
-            if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
+            if (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) support |= SimdSupport.Neon;
 #endif
             return support;
         }

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.Simd.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.Simd.cs
@@ -36,6 +36,25 @@ public sealed partial class Blake2s
 
     private static readonly Vector128<uint> FinalMask = Vector128.Create(0U, 0U, ~0U, 0U);
 
+    /// <summary>
+    /// Gets the SIMD instruction sets supported by this algorithm on the current platform.
+    /// </summary>
+    internal static new SimdSupport SimdSupport
+    {
+        get
+        {
+            var support = SimdSupport.None;
+            if (Ssse3.IsSupported) support |= SimdSupport.Ssse3;
+#if EXPERIMENTAL
+            if (Avx2.IsSupported) support |= SimdSupport.Avx2;
+            if (Sse2.IsSupported) support |= SimdSupport.Sse2;
+            if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
+#endif
+            return support;
+        }
+    }
+
+#if EXPERIMENTAL
     // Pre-computed Vector128<int> indices for gather operations (scaled by 4 for uint stride)
     private static readonly Vector128<int>[] GatherIndicesX = new Vector128<int>[Rounds * 2];
     private static readonly Vector128<int>[] GatherIndicesY = new Vector128<int>[Rounds * 2];
@@ -61,22 +80,6 @@ public sealed partial class Blake2s
             GatherIndicesY[round * 2 + 1] = Vector128.Create(
                 Sigma[offset + 9] * 4, Sigma[offset + 11] * 4,
                 Sigma[offset + 13] * 4, Sigma[offset + 15] * 4);
-        }
-    }
-
-    /// <summary>
-    /// Gets the SIMD instruction sets supported by this algorithm on the current platform.
-    /// </summary>
-    internal static new SimdSupport SimdSupport
-    {
-        get
-        {
-            var support = SimdSupport.None;
-            if (Sse2.IsSupported) support |= SimdSupport.Sse2;
-            if (Ssse3.IsSupported) support |= SimdSupport.Ssse3;
-            if (Avx2.IsSupported) support |= SimdSupport.Avx2;
-            if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
-            return support;
         }
     }
 
@@ -134,6 +137,7 @@ public sealed partial class Blake2s
         Sse2.Store(state, row0);
         Sse2.Store(state + 4, row1);
     }
+#endif
 
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
@@ -185,6 +189,7 @@ public sealed partial class Blake2s
         Sse2.Store(state + 4, row1);
     }
 
+#if EXPERIMENTAL
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private static unsafe void CompressAvx2(byte* mPtr, uint* state, ulong bytesCompressed, bool isFinal)
@@ -275,6 +280,7 @@ public sealed partial class Blake2s
         var t3 = Sse2.Xor(b, c);
         b = Sse2.Or(Sse2.ShiftRightLogical(t3, 7), Sse2.ShiftLeftLogical(t3, 25));
     }
+#endif
 
     /// <summary>
     /// Performs one G round on 4 parallel lanes using SSSE3 shuffle for byte-aligned rotations.

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.cs
@@ -241,13 +241,14 @@ public sealed partial class Blake2s : HashAlgorithm
         _bytesCompressed += (ulong)bytesConsumed;
 
 #if NET8_0_OR_GREATER
-        if ((_simdSupport & SimdSupport.Avx2) != 0)
-        {
-            CompressAvx2(msgPtr, state, _bytesCompressed, isFinal);
-        }
-        else if ((_simdSupport & SimdSupport.Ssse3) != 0)
+        if ((_simdSupport & SimdSupport.Ssse3) != 0)
         {
             CompressSsse3(msgPtr, state, _bytesCompressed, isFinal);
+        }
+#if EXPERIMENTAL
+        else if ((_simdSupport & SimdSupport.Avx2) != 0)
+        {
+            CompressAvx2(msgPtr, state, _bytesCompressed, isFinal);
         }
         else if ((_simdSupport & SimdSupport.Sse2) != 0)
         {
@@ -258,6 +259,7 @@ public sealed partial class Blake2s : HashAlgorithm
             CompressNeon(msgPtr, state, _bytesCompressed, isFinal);
         }
         else
+#endif
 #endif
         {
             CompressScalar(msgPtr, state, _bytesCompressed, isFinal);
@@ -396,7 +398,7 @@ public sealed partial class Blake2s : HashAlgorithm
         uint v0 = state[0], v1 = state[1], v2 = state[2], v3 = state[3],
              v4 = state[4], v5 = state[5], v6 = state[6], v7 = state[7];
 
-        uint v8  = 0x6a09e667U, v9 = 0xbb67ae85U,
+        uint v8 = 0x6a09e667U, v9 = 0xbb67ae85U,
              v10 = 0x3c6ef372U, v11 = 0xa54ff53aU,
              v12 = 0x510e527fU ^ (uint)bytesCompressed,
              v13 = 0x9b05688cU ^ (uint)(bytesCompressed >> 32),

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma warning disable IDE1006 // Naming rule violation - IV and Sigma are standard cryptographic constant names per RFC 7693
+#pragma warning disable CS0414  // _simdSupport is read inside #if NET8_0_OR_GREATER guard
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
@@ -9,10 +10,6 @@ using System;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-#if NET8_0_OR_GREATER
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
-#endif
 
 /// <summary>
 /// Computes the BLAKE2s hash for the input data.
@@ -90,22 +87,13 @@ public sealed partial class Blake2s : HashAlgorithm
         10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0
     };
 
-    // Scalar state for non-SSE path and output extraction
+    private readonly SimdSupport _simdSupport;
     private readonly uint[] _state;
     private readonly byte[] _buffer;
     private readonly byte[]? _key;
     private readonly int _outputBytes;
     private ulong _bytesCompressed;
     private int _bufferLength;
-
-    // Delegate types for SIMD dispatch — set once in constructor, avoiding per-call branch checks
-    private delegate void CompressAction(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal);
-    private delegate void InitializeStateAction(uint paramBlock);
-    private delegate void ExtractOutputAction(Span<byte> destination);
-
-    private readonly CompressAction _compress;
-    private readonly InitializeStateAction _initializeState;
-    private readonly ExtractOutputAction _extractOutput;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Blake2s"/> class with default output size (32 bytes).
@@ -156,39 +144,10 @@ public sealed partial class Blake2s : HashAlgorithm
         _state = new uint[StateSize];
         _buffer = new byte[BlockSizeBytes];
 
-        simdSupport &= Blake2s.SimdSupport;
+        _simdSupport = SimdSupport.None;
 #if NET8_0_OR_GREATER
-        if ((simdSupport & SimdSupport.Avx2) != 0)
-        {
-            _compress = CompressAvx2;
-            _initializeState = InitializeStateSse2;
-            _extractOutput = ExtractOutputSse2;
-        }
-        else if ((simdSupport & SimdSupport.Ssse3) != 0)
-        {
-            _compress = CompressSsse3;
-            _initializeState = InitializeStateSse2;
-            _extractOutput = ExtractOutputSse2;
-        }
-        else if ((simdSupport & SimdSupport.Sse2) != 0)
-        {
-            _compress = CompressSse2;
-            _initializeState = InitializeStateSse2;
-            _extractOutput = ExtractOutputSse2;
-        }
-        else if ((simdSupport & SimdSupport.Neon) != 0)
-        {
-            _compress = CompressNeon;
-            _initializeState = InitializeStateNeon;
-            _extractOutput = ExtractOutputSse2;  // portable: only uses CopyTo on Vector128<uint>
-        }
-        else
+        _simdSupport = simdSupport & SimdSupport;
 #endif
-        {
-            _compress = CompressScalar;
-            _initializeState = InitializeStateScalar;
-            _extractOutput = ExtractOutputScalar;
-        }
 
         if (key != null && key.Length > 0)
         {
@@ -209,25 +168,6 @@ public sealed partial class Blake2s : HashAlgorithm
     /// Gets a value indicating whether this instance is configured for keyed hashing (MAC mode).
     /// </summary>
     public bool IsKeyed => _key != null;
-
-    /// <summary>
-    /// Gets the SIMD instruction sets supported by this algorithm on the current platform.
-    /// </summary>
-    /// <returns>Flags indicating which SIMD instruction sets are available.</returns>
-    internal static new SimdSupport SimdSupport
-    {
-        get
-        {
-            var support = SimdSupport.None;
-#if NET8_0_OR_GREATER
-            if (Ssse3.IsSupported) support |= SimdSupport.Ssse3;
-            if (Sse2.IsSupported) support |= SimdSupport.Sse2;
-            if (Avx2.IsSupported) support |= SimdSupport.Avx2;
-            if (System.Runtime.Intrinsics.Arm.AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
-#endif
-            return support;
-        }
-    }
 
     /// <summary>
     /// Creates a new instance of the <see cref="Blake2s"/> class with default output size.
@@ -280,7 +220,8 @@ public sealed partial class Blake2s : HashAlgorithm
         int keyLength = _key?.Length ?? 0;
         uint paramBlock = 0x01010000U | ((uint)keyLength << 8) | (uint)_outputBytes;
 
-        _initializeState(paramBlock);
+        Array.Copy(IV, _state, StateSize);
+        _state[0] ^= paramBlock;
 
         _bytesCompressed = 0;
         _bufferLength = 0;
@@ -294,14 +235,47 @@ public sealed partial class Blake2s : HashAlgorithm
         }
     }
 
-    private void InitializeStateScalar(uint paramBlock)
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private unsafe void Compress(byte* msgPtr, uint* state, int bytesConsumed, bool isFinal)
     {
-        Array.Copy(IV, _state, StateSize);
-        _state[0] ^= paramBlock;
+        _bytesCompressed += (ulong)bytesConsumed;
+
+#if NET8_0_OR_GREATER
+        if ((_simdSupport & SimdSupport.Avx2) != 0)
+        {
+            CompressAvx2(msgPtr, state, _bytesCompressed, isFinal);
+        }
+        else if ((_simdSupport & SimdSupport.Ssse3) != 0)
+        {
+            CompressSsse3(msgPtr, state, _bytesCompressed, isFinal);
+        }
+        else if ((_simdSupport & SimdSupport.Sse2) != 0)
+        {
+            CompressSse2(msgPtr, state, _bytesCompressed, isFinal);
+        }
+        else if ((_simdSupport & SimdSupport.Neon) != 0)
+        {
+            CompressNeon(msgPtr, state, _bytesCompressed, isFinal);
+        }
+        else
+#endif
+        {
+            CompressScalar(msgPtr, state, _bytesCompressed, isFinal);
+        }
+    }
+
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private unsafe void Compress(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    {
+        fixed (uint* state = _state)
+        fixed (byte* msgPtr = block)
+        {
+            Compress(msgPtr, state, bytesConsumed, isFinal);
+        }
     }
 
     /// <inheritdoc/>
-    protected override void HashCore(ReadOnlySpan<byte> source)
+    protected override unsafe void HashCore(ReadOnlySpan<byte> source)
     {
         int offset = 0;
 
@@ -316,16 +290,20 @@ public sealed partial class Blake2s : HashAlgorithm
             // Only compress if buffer is full AND there's more data coming
             if (_bufferLength == BlockSizeBytes && offset < source.Length)
             {
-                _compress(_buffer, BlockSizeBytes, false);
+                Compress(_buffer, BlockSizeBytes, false);
                 _bufferLength = 0;
             }
         }
 
         // Process full blocks, but always keep at least one block for finalization
-        while (offset + BlockSizeBytes < source.Length)
+        fixed (uint* state = _state)
+        fixed (byte* msgPtr = source)
         {
-            _compress(source.Slice(offset, BlockSizeBytes), BlockSizeBytes, false);
-            offset += BlockSizeBytes;
+            while (offset + BlockSizeBytes < source.Length)
+            {
+                Compress(msgPtr + offset, state, BlockSizeBytes, false);
+                offset += BlockSizeBytes;
+            }
         }
 
         // Store remaining bytes in buffer
@@ -358,16 +336,16 @@ public sealed partial class Blake2s : HashAlgorithm
         _buffer.AsSpan(_bufferLength).Clear();
 
         // Compress final block
-        _compress(_buffer, _bufferLength, true);
+        Compress(_buffer, _bufferLength, true);
 
-        // Extract output using dispatch delegate
-        _extractOutput(destination);
+        // Extract output
+        ExtractOutput(destination);
 
         bytesWritten = _outputBytes;
         return true;
     }
 
-    private void ExtractOutputScalar(Span<byte> destination)
+    private void ExtractOutput(Span<byte> destination)
     {
         int fullWords = _outputBytes / sizeof(UInt32);
 
@@ -388,10 +366,6 @@ public sealed partial class Blake2s : HashAlgorithm
     {
         if (disposing)
         {
-#if NET8_0_OR_GREATER
-            _stateVec0 = default;
-            _stateVec1 = default;
-#endif
             Array.Clear(_state, 0, _state.Length);
             ClearBuffer(_buffer);
             if (_key != null)
@@ -404,59 +378,86 @@ public sealed partial class Blake2s : HashAlgorithm
 
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private void CompressScalar(ReadOnlySpan<byte> block, int bytesConsumed, bool isFinal)
+    private static unsafe void CompressScalar(byte* msgPtr, uint* state, ulong bytesCompressed, bool isFinal)
     {
-        // Update counter
-        _bytesCompressed += (ulong)bytesConsumed;
-
-        // Parse message block into 16 32-bit words (little-endian)
-        Span<uint> m = stackalloc uint[ScratchSize];
-        BinarySpans.ReadUInt32LittleEndian(block, m);
-
-        // Initialize working vector
-        Span<uint> v = stackalloc uint[ScratchSize];
-        v[0] = _state[0];
-        v[1] = _state[1];
-        v[2] = _state[2];
-        v[3] = _state[3];
-        v[4] = _state[4];
-        v[5] = _state[5];
-        v[6] = _state[6];
-        v[7] = _state[7];
-        v[8] = IV[0];
-        v[9] = IV[1];
-        v[10] = IV[2];
-        v[11] = IV[3];
-        v[12] = IV[4] ^ (uint)_bytesCompressed;
-        v[13] = IV[5] ^ (uint)(_bytesCompressed >> 32);
-        v[14] = isFinal ? ~IV[6] : IV[6];
-        v[15] = IV[7];
-
-        // 10 rounds of mixing
-        for (int round = 0; round < Rounds * ScratchSize; round += ScratchSize)
+        uint* mr = (uint*)msgPtr;
+        if (!BitConverter.IsLittleEndian)
         {
-            // Column step
-            G(ref v[0], ref v[4], ref v[8], ref v[12], m[Sigma[round + 0]], m[Sigma[round + 1]]);
-            G(ref v[1], ref v[5], ref v[9], ref v[13], m[Sigma[round + 2]], m[Sigma[round + 3]]);
-            G(ref v[2], ref v[6], ref v[10], ref v[14], m[Sigma[round + 4]], m[Sigma[round + 5]]);
-            G(ref v[3], ref v[7], ref v[11], ref v[15], m[Sigma[round + 6]], m[Sigma[round + 7]]);
-
-            // Diagonal step
-            G(ref v[0], ref v[5], ref v[10], ref v[15], m[Sigma[round + 8]], m[Sigma[round + 9]]);
-            G(ref v[1], ref v[6], ref v[11], ref v[12], m[Sigma[round + 10]], m[Sigma[round + 11]]);
-            G(ref v[2], ref v[7], ref v[8], ref v[13], m[Sigma[round + 12]], m[Sigma[round + 13]]);
-            G(ref v[3], ref v[4], ref v[9], ref v[14], m[Sigma[round + 14]], m[Sigma[round + 15]]);
+            uint* scratch = stackalloc uint[ScratchSize];
+            BinarySpans.ReadUInt32LittleEndian(msgPtr, scratch, ScratchSize);
+            mr = scratch;
         }
 
-        // Finalize state
-        _state[0] ^= v[0] ^ v[8];
-        _state[1] ^= v[1] ^ v[9];
-        _state[2] ^= v[2] ^ v[10];
-        _state[3] ^= v[3] ^ v[11];
-        _state[4] ^= v[4] ^ v[12];
-        _state[5] ^= v[5] ^ v[13];
-        _state[6] ^= v[6] ^ v[14];
-        _state[7] ^= v[7] ^ v[15];
+        uint m0 = mr[0], m1 = mr[1], m2 = mr[2], m3 = mr[3],
+             m4 = mr[4], m5 = mr[5], m6 = mr[6], m7 = mr[7],
+             m8 = mr[8], m9 = mr[9], m10 = mr[10], m11 = mr[11],
+             m12 = mr[12], m13 = mr[13], m14 = mr[14], m15 = mr[15];
+
+        uint v0 = state[0], v1 = state[1], v2 = state[2], v3 = state[3],
+             v4 = state[4], v5 = state[5], v6 = state[6], v7 = state[7];
+
+        uint v8  = 0x6a09e667U, v9 = 0xbb67ae85U,
+             v10 = 0x3c6ef372U, v11 = 0xa54ff53aU,
+             v12 = 0x510e527fU ^ (uint)bytesCompressed,
+             v13 = 0x9b05688cU ^ (uint)(bytesCompressed >> 32),
+             v14 = isFinal ? ~0x1f83d9abU : 0x1f83d9abU,
+             v15 = 0x5be0cd19U;
+
+        // Round 0 — sigma: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+        G(ref v0, ref v4, ref v8, ref v12, m0, m1); G(ref v1, ref v5, ref v9, ref v13, m2, m3);
+        G(ref v2, ref v6, ref v10, ref v14, m4, m5); G(ref v3, ref v7, ref v11, ref v15, m6, m7);
+        G(ref v0, ref v5, ref v10, ref v15, m8, m9); G(ref v1, ref v6, ref v11, ref v12, m10, m11);
+        G(ref v2, ref v7, ref v8, ref v13, m12, m13); G(ref v3, ref v4, ref v9, ref v14, m14, m15);
+        // Round 1 — sigma: 14,10,4,8,9,15,13,6,1,12,0,2,11,7,5,3
+        G(ref v0, ref v4, ref v8, ref v12, m14, m10); G(ref v1, ref v5, ref v9, ref v13, m4, m8);
+        G(ref v2, ref v6, ref v10, ref v14, m9, m15); G(ref v3, ref v7, ref v11, ref v15, m13, m6);
+        G(ref v0, ref v5, ref v10, ref v15, m1, m12); G(ref v1, ref v6, ref v11, ref v12, m0, m2);
+        G(ref v2, ref v7, ref v8, ref v13, m11, m7); G(ref v3, ref v4, ref v9, ref v14, m5, m3);
+        // Round 2 — sigma: 11,8,12,0,5,2,15,13,10,14,3,6,7,1,9,4
+        G(ref v0, ref v4, ref v8, ref v12, m11, m8); G(ref v1, ref v5, ref v9, ref v13, m12, m0);
+        G(ref v2, ref v6, ref v10, ref v14, m5, m2); G(ref v3, ref v7, ref v11, ref v15, m15, m13);
+        G(ref v0, ref v5, ref v10, ref v15, m10, m14); G(ref v1, ref v6, ref v11, ref v12, m3, m6);
+        G(ref v2, ref v7, ref v8, ref v13, m7, m1); G(ref v3, ref v4, ref v9, ref v14, m9, m4);
+        // Round 3 — sigma: 7,9,3,1,13,12,11,14,2,6,5,10,4,0,15,8
+        G(ref v0, ref v4, ref v8, ref v12, m7, m9); G(ref v1, ref v5, ref v9, ref v13, m3, m1);
+        G(ref v2, ref v6, ref v10, ref v14, m13, m12); G(ref v3, ref v7, ref v11, ref v15, m11, m14);
+        G(ref v0, ref v5, ref v10, ref v15, m2, m6); G(ref v1, ref v6, ref v11, ref v12, m5, m10);
+        G(ref v2, ref v7, ref v8, ref v13, m4, m0); G(ref v3, ref v4, ref v9, ref v14, m15, m8);
+        // Round 4 — sigma: 9,0,5,7,2,4,10,15,14,1,11,12,6,8,3,13
+        G(ref v0, ref v4, ref v8, ref v12, m9, m0); G(ref v1, ref v5, ref v9, ref v13, m5, m7);
+        G(ref v2, ref v6, ref v10, ref v14, m2, m4); G(ref v3, ref v7, ref v11, ref v15, m10, m15);
+        G(ref v0, ref v5, ref v10, ref v15, m14, m1); G(ref v1, ref v6, ref v11, ref v12, m11, m12);
+        G(ref v2, ref v7, ref v8, ref v13, m6, m8); G(ref v3, ref v4, ref v9, ref v14, m3, m13);
+        // Round 5 — sigma: 2,12,6,10,0,11,8,3,4,13,7,5,15,14,1,9
+        G(ref v0, ref v4, ref v8, ref v12, m2, m12); G(ref v1, ref v5, ref v9, ref v13, m6, m10);
+        G(ref v2, ref v6, ref v10, ref v14, m0, m11); G(ref v3, ref v7, ref v11, ref v15, m8, m3);
+        G(ref v0, ref v5, ref v10, ref v15, m4, m13); G(ref v1, ref v6, ref v11, ref v12, m7, m5);
+        G(ref v2, ref v7, ref v8, ref v13, m15, m14); G(ref v3, ref v4, ref v9, ref v14, m1, m9);
+        // Round 6 — sigma: 12,5,1,15,14,13,4,10,0,7,6,3,9,2,8,11
+        G(ref v0, ref v4, ref v8, ref v12, m12, m5); G(ref v1, ref v5, ref v9, ref v13, m1, m15);
+        G(ref v2, ref v6, ref v10, ref v14, m14, m13); G(ref v3, ref v7, ref v11, ref v15, m4, m10);
+        G(ref v0, ref v5, ref v10, ref v15, m0, m7); G(ref v1, ref v6, ref v11, ref v12, m6, m3);
+        G(ref v2, ref v7, ref v8, ref v13, m9, m2); G(ref v3, ref v4, ref v9, ref v14, m8, m11);
+        // Round 7 — sigma: 13,11,7,14,12,1,3,9,5,0,15,4,8,6,2,10
+        G(ref v0, ref v4, ref v8, ref v12, m13, m11); G(ref v1, ref v5, ref v9, ref v13, m7, m14);
+        G(ref v2, ref v6, ref v10, ref v14, m12, m1); G(ref v3, ref v7, ref v11, ref v15, m3, m9);
+        G(ref v0, ref v5, ref v10, ref v15, m5, m0); G(ref v1, ref v6, ref v11, ref v12, m15, m4);
+        G(ref v2, ref v7, ref v8, ref v13, m8, m6); G(ref v3, ref v4, ref v9, ref v14, m2, m10);
+        // Round 8 — sigma: 6,15,14,9,11,3,0,8,12,2,13,7,1,4,10,5
+        G(ref v0, ref v4, ref v8, ref v12, m6, m15); G(ref v1, ref v5, ref v9, ref v13, m14, m9);
+        G(ref v2, ref v6, ref v10, ref v14, m11, m3); G(ref v3, ref v7, ref v11, ref v15, m0, m8);
+        G(ref v0, ref v5, ref v10, ref v15, m12, m2); G(ref v1, ref v6, ref v11, ref v12, m13, m7);
+        G(ref v2, ref v7, ref v8, ref v13, m1, m4); G(ref v3, ref v4, ref v9, ref v14, m10, m5);
+        // Round 9 — sigma: 10,2,8,4,7,6,1,5,15,11,9,14,3,12,13,0
+        G(ref v0, ref v4, ref v8, ref v12, m10, m2); G(ref v1, ref v5, ref v9, ref v13, m8, m4);
+        G(ref v2, ref v6, ref v10, ref v14, m7, m6); G(ref v3, ref v7, ref v11, ref v15, m1, m5);
+        G(ref v0, ref v5, ref v10, ref v15, m15, m11); G(ref v1, ref v6, ref v11, ref v12, m9, m14);
+        G(ref v2, ref v7, ref v8, ref v13, m3, m12); G(ref v3, ref v4, ref v9, ref v14, m13, m0);
+
+        state[0] ^= v0 ^ v8; state[1] ^= v1 ^ v9;
+        state[2] ^= v2 ^ v10; state[3] ^= v3 ^ v11;
+        state[4] ^= v4 ^ v12; state[5] ^= v5 ^ v13;
+        state[6] ^= v6 ^ v14; state[7] ^= v7 ^ v15;
     }
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.cs
@@ -258,8 +258,8 @@ public sealed partial class Blake2s : HashAlgorithm
         {
             CompressNeon(msgPtr, state, _bytesCompressed, isFinal);
         }
-        else
 #endif
+        else
 #endif
         {
             CompressScalar(msgPtr, state, _bytesCompressed, isFinal);

--- a/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.cs
@@ -402,7 +402,7 @@ internal unsafe struct KeccakCoreState
     /// <summary>
     /// Performs 64-bit rotation using AVX2 shift and OR operations.
     /// </summary>
-    [SuppressMessage("Performance", "CA1857:A constant is expected for the parameter", Justification = "Caller uses always constants.")]
+    [SuppressMessage("Performance", "CA1857:A constant is expected for the parameter", Justification = "False negative due to bug in .NET 8 runtime metadata.")]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Vector256<ulong> Rol64Avx2(Vector256<ulong> a, byte offset)
     {

--- a/src/Security/Cryptography/shared/BinarySpans.cs
+++ b/src/Security/Cryptography/shared/BinarySpans.cs
@@ -69,6 +69,52 @@ internal static class BinarySpans
     }
 
     /// <summary>
+    /// Reads little-endian <see cref="UInt32"/> words from a byte pointer into a destination pointer.
+    /// </summary>
+    /// <param name="source">Pointer to the source bytes (at least <paramref name="count"/> × 4 bytes).</param>
+    /// <param name="destination">Pointer to the destination words.</param>
+    /// <param name="count">The number of 64-bit words to read.</param>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public static unsafe void ReadUInt32LittleEndian(byte* source, uint* destination, int count)
+    {
+        if (BitConverter.IsLittleEndian)
+        {
+            Unsafe.CopyBlockUnaligned(destination, source, (uint)(count * sizeof(uint)));
+        }
+        else
+        {
+            for (int i = 0; i < count; i++)
+            {
+                destination[i] = BinaryPrimitives.ReadUInt32LittleEndian(
+                    new ReadOnlySpan<byte>(source + i * sizeof(uint), sizeof(uint)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads little-endian <see cref="UInt64"/> words from a byte pointer into a destination pointer.
+    /// </summary>
+    /// <param name="source">Pointer to the source bytes (at least <paramref name="count"/> × 8 bytes).</param>
+    /// <param name="destination">Pointer to the destination words.</param>
+    /// <param name="count">The number of 64-bit words to read.</param>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public static unsafe void ReadUInt64LittleEndian(byte* source, ulong* destination, int count)
+    {
+        if (BitConverter.IsLittleEndian)
+        {
+            Unsafe.CopyBlockUnaligned(destination, source, (uint)(count * sizeof(ulong)));
+        }
+        else
+        {
+            for (int i = 0; i < count; i++)
+            {
+                destination[i] = BinaryPrimitives.ReadUInt64LittleEndian(
+                    new ReadOnlySpan<byte>(source + i * sizeof(ulong), sizeof(ulong)));
+            }
+        }
+    }
+
+    /// <summary>
     /// Writes <see cref="UInt32"/> words to a byte span in little-endian order.
     /// </summary>
     /// <param name="source">The source word span.</param>

--- a/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
+++ b/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
@@ -1,0 +1,53 @@
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace Cryptography.Tests.Adapter.Hash;
+
+using Blake2Fast;
+using Blake2Fast.Implementation;
+using System;
+using CH = CryptoHives.Foundation.Security.Cryptography;
+
+/// <summary>
+/// Wraps <see cref="Blake2b"/> from SauceControl.Blake2Fast as a <see cref="CH.Hash.HashAlgorithm"/>.
+/// </summary>
+/// <remarks>
+/// The incremental <see cref="Blake2bHashState"/> struct is held directly as a field,
+/// avoiding interface-dispatch boxing on every <c>Update</c> call.
+/// <see cref="HA.HashAlgorithm.Initialize"/> recreates the struct to reset the hasher state.
+/// </remarks>
+internal sealed class Blake2FastAdapter : CH.Hash.HashAlgorithm
+{
+    private readonly int _outputBytes;
+    private readonly string _algorithmName;
+    private Blake2bHashState _state;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Blake2FastAdapter"/> class.
+    /// </summary>
+    /// <param name="hashSizeBits">The hash output size in bits (e.g. 256, 512).</param>
+    public Blake2FastAdapter(int hashSizeBits)
+    {
+        _outputBytes = hashSizeBits / 8;
+        _algorithmName = $"BLAKE2b-{hashSizeBits} (Blake2Fast)";
+        _state = Blake2b.CreateIncrementalHasher(_outputBytes);
+        HashSizeValue = hashSizeBits;
+    }
+
+    /// <inheritdoc/>
+    public override string AlgorithmName => _algorithmName;
+
+    /// <inheritdoc/>
+    public override int BlockSize => 128;
+
+    /// <inheritdoc/>
+    protected override void HashCore(ReadOnlySpan<byte> source) => _state.Update(source);
+
+    /// <inheritdoc/>
+    protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten) =>
+        _state.TryFinish(destination, out bytesWritten);
+
+    /// <inheritdoc/>
+    public override void Initialize() =>
+        _state = Blake2b.CreateIncrementalHasher(_outputBytes);
+}

--- a/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
+++ b/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
@@ -71,11 +71,15 @@ internal sealed class Blake2FastAdapter : CH.Hash.HashAlgorithm
 #if NET6_0_OR_GREATER
         // Overwrite the already-boxed struct in-place via a managed interior ref — no allocation.
         if (_isBlake2b)
+        {
             Unsafe.Unbox<Blake2bHashState>(_state) = Blake2b.CreateIncrementalHasher(_outputBytes);
+        }
         else
+        {
             Unsafe.Unbox<Blake2sHashState>(_state) = Blake2s.CreateIncrementalHasher(_outputBytes);
+        }
 #else
-        // Benchmarks target .NET 8+; re-boxing is acceptable on legacy frameworks.
+        // Benchmarks target < .NET 6+; re-boxing is acceptable on legacy frameworks.
         _state = _isBlake2b
             ? (IBlake2Incremental)Blake2b.CreateIncrementalHasher(_outputBytes)
             : (IBlake2Incremental)Blake2s.CreateIncrementalHasher(_outputBytes);

--- a/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
+++ b/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
@@ -4,7 +4,9 @@
 namespace Cryptography.Tests.Adapter.Hash;
 
 using Blake2Fast;
+using Blake2Fast.Implementation;
 using System;
+using System.Runtime.CompilerServices;
 using CH = CryptoHives.Foundation.Security.Cryptography;
 
 /// <summary>
@@ -12,10 +14,11 @@ using CH = CryptoHives.Foundation.Security.Cryptography;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The common <see cref="IBlake2Incremental"/> interface is used for both BLAKE2b and BLAKE2s,
-/// making the adapter variant-agnostic. The underlying struct is boxed once per
-/// <see cref="Initialize"/> call; all subsequent <c>Update</c> and <c>TryFinish</c> calls
-/// are interface dispatch on the existing boxed instance with no additional allocation.
+/// The underlying hash state struct is boxed once at construction and stored as
+/// <see cref="IBlake2Incremental"/>. On <see cref="Initialize"/>, <see cref="Unsafe.Unbox{T}"/>
+/// returns a managed reference directly into the existing boxed object, allowing the struct to be
+/// overwritten in-place — zero allocation per benchmark iteration on .NET 6+.
+/// On older frameworks the box is recreated (benchmarks target .NET 8+).
 /// </para>
 /// <para>
 /// Use <see cref="CreateBlake2b"/> or <see cref="CreateBlake2s"/> to construct instances.
@@ -23,31 +26,31 @@ using CH = CryptoHives.Foundation.Security.Cryptography;
 /// </remarks>
 internal sealed class Blake2FastAdapter : CH.Hash.HashAlgorithm
 {
-    private readonly Func<IBlake2Incremental> _factory;
     private readonly string _algorithmName;
     private readonly int _blockSize;
+    private readonly int _outputBytes;
+    private readonly bool _isBlake2b;
     private IBlake2Incremental _state;
 
-    private Blake2FastAdapter(Func<IBlake2Incremental> factory, string algorithmName, int blockSize, int hashSizeBits)
+    private Blake2FastAdapter(bool isBlake2b, int hashSizeBits)
     {
-        _factory = factory;
-        _algorithmName = algorithmName;
-        _blockSize = blockSize;
+        _isBlake2b = isBlake2b;
+        _outputBytes = hashSizeBits / 8;
+        _algorithmName = $"BLAKE2{(isBlake2b ? 'b' : 's')}-{hashSizeBits} (Blake2Fast)";
+        _blockSize = isBlake2b ? 128 : 64;
         HashSizeValue = hashSizeBits;
-        _state = factory();
+        _state = isBlake2b
+            ? (IBlake2Incremental)Blake2b.CreateIncrementalHasher(_outputBytes)
+            : (IBlake2Incremental)Blake2s.CreateIncrementalHasher(_outputBytes);
     }
 
     /// <summary>Creates a BLAKE2b adapter with the specified output size.</summary>
     /// <param name="hashSizeBits">Output size in bits (e.g. 256, 512).</param>
-    public static Blake2FastAdapter CreateBlake2b(int hashSizeBits) => new(
-        () => Blake2b.CreateIncrementalHasher(hashSizeBits / 8),
-        $"BLAKE2b-{hashSizeBits} (Blake2Fast)", blockSize: 128, hashSizeBits);
+    public static Blake2FastAdapter CreateBlake2b(int hashSizeBits) => new(isBlake2b: true, hashSizeBits);
 
     /// <summary>Creates a BLAKE2s adapter with the specified output size.</summary>
     /// <param name="hashSizeBits">Output size in bits (e.g. 128, 256).</param>
-    public static Blake2FastAdapter CreateBlake2s(int hashSizeBits) => new(
-        () => Blake2s.CreateIncrementalHasher(hashSizeBits / 8),
-        $"BLAKE2s-{hashSizeBits} (Blake2Fast)", blockSize: 64, hashSizeBits);
+    public static Blake2FastAdapter CreateBlake2s(int hashSizeBits) => new(isBlake2b: false, hashSizeBits);
 
     /// <inheritdoc/>
     public override string AlgorithmName => _algorithmName;
@@ -63,5 +66,19 @@ internal sealed class Blake2FastAdapter : CH.Hash.HashAlgorithm
         _state.TryFinish(destination, out bytesWritten);
 
     /// <inheritdoc/>
-    public override void Initialize() => _state = _factory();
+    public override void Initialize()
+    {
+#if NET6_0_OR_GREATER
+        // Overwrite the already-boxed struct in-place via a managed interior ref — no allocation.
+        if (_isBlake2b)
+            Unsafe.Unbox<Blake2bHashState>(_state) = Blake2b.CreateIncrementalHasher(_outputBytes);
+        else
+            Unsafe.Unbox<Blake2sHashState>(_state) = Blake2s.CreateIncrementalHasher(_outputBytes);
+#else
+        // Benchmarks target .NET 8+; re-boxing is acceptable on legacy frameworks.
+        _state = _isBlake2b
+            ? (IBlake2Incremental)Blake2b.CreateIncrementalHasher(_outputBytes)
+            : (IBlake2Incremental)Blake2s.CreateIncrementalHasher(_outputBytes);
+#endif
+    }
 }

--- a/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
+++ b/tests/Security/Cryptography/Adapter/Hash/Blake2FastAdapter.cs
@@ -4,41 +4,56 @@
 namespace Cryptography.Tests.Adapter.Hash;
 
 using Blake2Fast;
-using Blake2Fast.Implementation;
 using System;
 using CH = CryptoHives.Foundation.Security.Cryptography;
 
 /// <summary>
-/// Wraps <see cref="Blake2b"/> from SauceControl.Blake2Fast as a <see cref="CH.Hash.HashAlgorithm"/>.
+/// Wraps SauceControl.Blake2Fast BLAKE2b and BLAKE2s implementations as a <see cref="CH.Hash.HashAlgorithm"/>.
 /// </summary>
 /// <remarks>
-/// The incremental <see cref="Blake2bHashState"/> struct is held directly as a field,
-/// avoiding interface-dispatch boxing on every <c>Update</c> call.
-/// <see cref="HA.HashAlgorithm.Initialize"/> recreates the struct to reset the hasher state.
+/// <para>
+/// The common <see cref="IBlake2Incremental"/> interface is used for both BLAKE2b and BLAKE2s,
+/// making the adapter variant-agnostic. The underlying struct is boxed once per
+/// <see cref="Initialize"/> call; all subsequent <c>Update</c> and <c>TryFinish</c> calls
+/// are interface dispatch on the existing boxed instance with no additional allocation.
+/// </para>
+/// <para>
+/// Use <see cref="CreateBlake2b"/> or <see cref="CreateBlake2s"/> to construct instances.
+/// </para>
 /// </remarks>
 internal sealed class Blake2FastAdapter : CH.Hash.HashAlgorithm
 {
-    private readonly int _outputBytes;
+    private readonly Func<IBlake2Incremental> _factory;
     private readonly string _algorithmName;
-    private Blake2bHashState _state;
+    private readonly int _blockSize;
+    private IBlake2Incremental _state;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Blake2FastAdapter"/> class.
-    /// </summary>
-    /// <param name="hashSizeBits">The hash output size in bits (e.g. 256, 512).</param>
-    public Blake2FastAdapter(int hashSizeBits)
+    private Blake2FastAdapter(Func<IBlake2Incremental> factory, string algorithmName, int blockSize, int hashSizeBits)
     {
-        _outputBytes = hashSizeBits / 8;
-        _algorithmName = $"BLAKE2b-{hashSizeBits} (Blake2Fast)";
-        _state = Blake2b.CreateIncrementalHasher(_outputBytes);
+        _factory = factory;
+        _algorithmName = algorithmName;
+        _blockSize = blockSize;
         HashSizeValue = hashSizeBits;
+        _state = factory();
     }
+
+    /// <summary>Creates a BLAKE2b adapter with the specified output size.</summary>
+    /// <param name="hashSizeBits">Output size in bits (e.g. 256, 512).</param>
+    public static Blake2FastAdapter CreateBlake2b(int hashSizeBits) => new(
+        () => Blake2b.CreateIncrementalHasher(hashSizeBits / 8),
+        $"BLAKE2b-{hashSizeBits} (Blake2Fast)", blockSize: 128, hashSizeBits);
+
+    /// <summary>Creates a BLAKE2s adapter with the specified output size.</summary>
+    /// <param name="hashSizeBits">Output size in bits (e.g. 128, 256).</param>
+    public static Blake2FastAdapter CreateBlake2s(int hashSizeBits) => new(
+        () => Blake2s.CreateIncrementalHasher(hashSizeBits / 8),
+        $"BLAKE2s-{hashSizeBits} (Blake2Fast)", blockSize: 64, hashSizeBits);
 
     /// <inheritdoc/>
     public override string AlgorithmName => _algorithmName;
 
     /// <inheritdoc/>
-    public override int BlockSize => 128;
+    public override int BlockSize => _blockSize;
 
     /// <inheritdoc/>
     protected override void HashCore(ReadOnlySpan<byte> source) => _state.Update(source);
@@ -48,6 +63,5 @@ internal sealed class Blake2FastAdapter : CH.Hash.HashAlgorithm
         _state.TryFinish(destination, out bytesWritten);
 
     /// <inheritdoc/>
-    public override void Initialize() =>
-        _state = Blake2b.CreateIncrementalHasher(_outputBytes);
+    public override void Initialize() => _state = _factory();
 }

--- a/tests/Security/Cryptography/Cryptography.Tests.csproj
+++ b/tests/Security/Cryptography/Cryptography.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<!-- SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives -->
+<!-- SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives -->
 <!-- SPDX-License-Identifier: MIT -->
 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -33,6 +33,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="OpenGost.Security.Cryptography" />
+    <PackageReference Include="SauceControl.Blake2Fast" />
   </ItemGroup>
 
   <!-- Konscious.Security.Cryptography.Blake2 is not strong name signed -->

--- a/tests/Security/Cryptography/Hash/HashAlgorithmRegistry.cs
+++ b/tests/Security/Cryptography/Hash/HashAlgorithmRegistry.cs
@@ -53,7 +53,9 @@ public static class HashAlgorithmRegistry
         /// <summary>Native implementation.</summary>
         Native,
         /// <summary>Konscious.Security.Cryptography implementation.</summary>
-        Konscious
+        Konscious,
+        /// <summary>SauceControl.Blake2Fast implementation.</summary>
+        Blake2Fast
     }
 
     /// <summary>
@@ -472,6 +474,10 @@ public static class HashAlgorithmRegistry
         list.Add(new("BLAKE2b-512", "Konscious", 512,
             () => new KonsciousBlake2Adapter(512), Source.Konscious));
 #endif
+#if BLAKE2FAST
+        list.Add(new("BLAKE2b-512", "Blake2Fast", 512,
+            () => new Blake2FastAdapter(512), Source.Blake2Fast));
+#endif
 
         // BLAKE2b-256
         if ((blake2bSimd & CHRoot.SimdSupport.Avx2) != 0)
@@ -494,6 +500,10 @@ public static class HashAlgorithmRegistry
 #if KONSCIOUS_BLAKE2
         list.Add(new("BLAKE2b-256", "Konscious", 256,
             () => new KonsciousBlake2Adapter(256), Source.Konscious));
+#endif
+#if BLAKE2FAST
+        list.Add(new("BLAKE2b-256", "Blake2Fast", 256,
+            () => new Blake2FastAdapter(256), Source.Blake2Fast));
 #endif
 
         // BLAKE2s-256

--- a/tests/Security/Cryptography/Hash/HashAlgorithmRegistry.cs
+++ b/tests/Security/Cryptography/Hash/HashAlgorithmRegistry.cs
@@ -474,10 +474,8 @@ public static class HashAlgorithmRegistry
         list.Add(new("BLAKE2b-512", "Konscious", 512,
             () => new KonsciousBlake2Adapter(512), Source.Konscious));
 #endif
-#if BLAKE2FAST
         list.Add(new("BLAKE2b-512", "Blake2Fast", 512,
-            () => new Blake2FastAdapter(512), Source.Blake2Fast));
-#endif
+            () => Blake2FastAdapter.CreateBlake2b(512), Source.Blake2Fast));
 
         // BLAKE2b-256
         if ((blake2bSimd & CHRoot.SimdSupport.Avx2) != 0)
@@ -501,10 +499,8 @@ public static class HashAlgorithmRegistry
         list.Add(new("BLAKE2b-256", "Konscious", 256,
             () => new KonsciousBlake2Adapter(256), Source.Konscious));
 #endif
-#if BLAKE2FAST
         list.Add(new("BLAKE2b-256", "Blake2Fast", 256,
-            () => new Blake2FastAdapter(256), Source.Blake2Fast));
-#endif
+            () => Blake2FastAdapter.CreateBlake2b(256), Source.Blake2Fast));
 
         // BLAKE2s-256
         var blake2sSimd = CH.Blake2s.SimdSupport;
@@ -532,6 +528,8 @@ public static class HashAlgorithmRegistry
             () => CH.Blake2s.Create(CHRoot.SimdSupport.None, 32), Source.Managed));
         list.Add(new("BLAKE2s-256", "BouncyCastle", 256,
             () => new BouncyCastleHashAdapter(new BC.Blake2sDigest(256)), Source.BouncyCastle));
+        list.Add(new("BLAKE2s-256", "Blake2Fast", 256,
+            () => Blake2FastAdapter.CreateBlake2s(256), Source.Blake2Fast));
 
         // BLAKE2s-128
         if ((blake2sSimd & CHRoot.SimdSupport.Avx2) != 0)
@@ -558,6 +556,8 @@ public static class HashAlgorithmRegistry
             () => CH.Blake2s.Create(CHRoot.SimdSupport.None, 16), Source.Managed));
         list.Add(new("BLAKE2s-128", "BouncyCastle", 128,
             () => new BouncyCastleHashAdapter(new BC.Blake2sDigest(128)), Source.BouncyCastle));
+        list.Add(new("BLAKE2s-128", "Blake2Fast", 128,
+            () => Blake2FastAdapter.CreateBlake2s(128), Source.Blake2Fast));
     }
 
     #endregion


### PR DESCRIPTION
Improved the Blake2s and Blake2b hash functions which are now competitive with other reference packages.

Tested on windows x64 and macOS Mac M4.

- Neon implementations couldn't compete with optimized managed scalar, so they are marked as experimental
- on windows, AVX2 turned out as the fastest for Blake2b. For Blake2s, only managed scalar and Ssse3 implementations could compete with Blake2Fast, but are still trailing by a few percent. On macOS Blake2fast is still 10% ahead of bouncy castle and  managed.
- The improved managed and Simd implementations are ahead of bouncy castle most of the time 

**Benchmark Updates:**

* Added the `SauceControl.Blake2Fast` package (version 2.0.0) to the project dependencies in `Directory.Packages.props`.
* Latest runs on windows and macOS added
