### PR TITLE
Aria and Camellia perf improvements

### DIFF
--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/aria-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/aria-cbc-128.md
@@ -1,25 +1,25 @@
-﻿| Description                                 | TestDataSize | Mean         | Error      | StdDev     | Median       | Allocated |
-|-------------------------------------------- |------------- |-------------:|-----------:|-----------:|-------------:|----------:|
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2.565 μs |  0.0505 μs |  0.0519 μs |     2.572 μs |    1288 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |     2.618 μs |  0.0301 μs |  0.0281 μs |     2.615 μs |         - |
-|                                             |              |              |            |            |              |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2.283 μs |  0.0012 μs |  0.0010 μs |     2.284 μs |    1288 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |     2.424 μs |  0.0472 μs |  0.0441 μs |     2.418 μs |         - |
-|                                             |              |              |            |            |              |           |
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    16.079 μs |  0.2921 μs |  0.4281 μs |    16.092 μs |    3528 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |    19.021 μs |  0.1180 μs |  0.1104 μs |    19.067 μs |         - |
-|                                             |              |              |            |            |              |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    15.615 μs |  0.1471 μs |  0.1376 μs |    15.632 μs |    3528 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |    17.780 μs |  0.1723 μs |  0.1611 μs |    17.867 μs |         - |
-|                                             |              |              |            |            |              |           |
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   125.003 μs |  2.4931 μs |  4.3665 μs |   122.832 μs |   21448 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |   151.731 μs |  1.7939 μs |  1.6780 μs |   151.675 μs |         - |
-|                                             |              |              |            |            |              |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   118.059 μs |  1.8352 μs |  1.7166 μs |   118.476 μs |   21448 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |   139.950 μs |  1.2344 μs |  1.0308 μs |   139.971 μs |         - |
-|                                             |              |              |            |            |              |           |
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,995.736 μs | 39.8199 μs | 94.6361 μs | 1,955.931 μs |  328648 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        | 2,446.076 μs | 14.0884 μs | 13.1783 μs | 2,445.980 μs |         - |
-|                                             |              |              |            |            |              |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,980.068 μs | 39.2253 μs | 71.7257 μs | 1,939.091 μs |  328648 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        | 2,352.641 μs | 44.5210 μs | 73.1492 μs | 2,357.940 μs |         - |
+﻿| Description                                 | TestDataSize | Mean           | Error       | StdDev      | Allocated |
+|-------------------------------------------- |------------- |---------------:|------------:|------------:|----------:|
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |       927.8 ns |     1.82 ns |     1.70 ns |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2,324.1 ns |     8.46 ns |     7.91 ns |    1288 B |
+|                                             |              |                |             |             |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |       941.6 ns |     4.68 ns |     3.91 ns |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2,240.6 ns |     7.23 ns |     6.76 ns |    1288 B |
+|                                             |              |                |             |             |           |
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |     6,627.7 ns |     4.24 ns |     3.76 ns |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    14,412.4 ns |    40.69 ns |    36.07 ns |    3528 B |
+|                                             |              |                |             |             |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |     6,779.2 ns |    12.17 ns |    10.79 ns |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    14,089.4 ns |    36.20 ns |    33.86 ns |    3528 B |
+|                                             |              |                |             |             |           |
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |    52,162.7 ns |    46.58 ns |    43.57 ns |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   109,308.5 ns |   199.95 ns |   187.04 ns |   21448 B |
+|                                             |              |                |             |             |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |    52,727.6 ns |   693.84 ns |   649.02 ns |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   106,426.1 ns |   272.56 ns |   241.62 ns |   21448 B |
+|                                             |              |                |             |             |           |
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        |   830,361.3 ns | 2,946.62 ns | 2,756.27 ns |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,746,905.1 ns | 4,124.45 ns | 3,858.02 ns |  328648 B |
+|                                             |              |                |             |             |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        |   855,540.8 ns |   724.33 ns |   565.51 ns |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,719,585.5 ns | 3,806.57 ns | 3,560.67 ns |  328648 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/aria-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/aria-cbc-256.md
@@ -1,25 +1,25 @@
-﻿| Description                                 | TestDataSize | Mean          | Error      | StdDev     | Median        | Allocated |
-|-------------------------------------------- |------------- |--------------:|-----------:|-----------:|--------------:|----------:|
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |     13.950 μs |  0.0076 μs |  0.0067 μs |     13.950 μs |         - |
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     14.363 μs |  0.0094 μs |  0.0079 μs |     14.363 μs |    1496 B |
-|                                             |              |               |            |            |               |           |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |      3.702 μs |  0.0734 μs |  0.1121 μs |      3.639 μs |         - |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     13.823 μs |  0.0178 μs |  0.0148 μs |     13.824 μs |    1496 B |
-|                                             |              |               |            |            |               |           |
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |     89.631 μs |  0.0580 μs |  0.0484 μs |     89.629 μs |    3736 B |
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |    100.178 μs |  0.0888 μs |  0.0741 μs |    100.174 μs |         - |
-|                                             |              |               |            |            |               |           |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |     88.067 μs |  0.2277 μs |  0.2018 μs |     88.116 μs |    3736 B |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |    100.706 μs |  0.2030 μs |  0.1899 μs |    100.653 μs |         - |
-|                                             |              |               |            |            |               |           |
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |    683.643 μs |  1.4952 μs |  1.3986 μs |    684.128 μs |   21656 B |
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |    790.639 μs |  0.7298 μs |  0.6470 μs |    790.638 μs |         - |
-|                                             |              |               |            |            |               |           |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |    671.514 μs |  2.0876 μs |  1.9527 μs |    671.821 μs |   21656 B |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |    792.649 μs |  1.2037 μs |  1.0671 μs |    792.220 μs |         - |
-|                                             |              |               |            |            |               |           |
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 10,854.067 μs | 17.9846 μs | 16.8228 μs | 10,858.107 μs |  328856 B |
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 12,636.719 μs |  8.9280 μs |  8.3513 μs | 12,634.152 μs |         - |
-|                                             |              |               |            |            |               |           |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 10,730.781 μs | 17.6026 μs | 14.6990 μs | 10,730.607 μs |  328856 B |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 12,671.084 μs | 10.0120 μs |  8.3605 μs | 12,672.146 μs |         - |
+﻿| Description                                 | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|-------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |     1.210 μs | 0.0005 μs | 0.0005 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     3.003 μs | 0.0050 μs | 0.0047 μs |    1496 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |     1.245 μs | 0.0011 μs | 0.0010 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     2.914 μs | 0.0058 μs | 0.0054 μs |    1496 B |
+|                                             |              |              |           |           |           |
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |     8.639 μs | 0.0104 μs | 0.0097 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |    18.666 μs | 0.0537 μs | 0.0476 μs |    3736 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |     8.922 μs | 0.0042 μs | 0.0039 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |    18.424 μs | 0.0485 μs | 0.0454 μs |    3736 B |
+|                                             |              |              |           |           |           |
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |    68.079 μs | 0.0810 μs | 0.0758 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |   143.145 μs | 0.3001 μs | 0.2807 μs |   21656 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |    70.319 μs | 0.1612 μs | 0.1346 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |   140.554 μs | 0.2828 μs | 0.2645 μs |   21656 B |
+|                                             |              |              |           |           |           |
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 1,088.538 μs | 2.2789 μs | 2.1317 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 2,266.721 μs | 6.7677 μs | 6.3305 μs |  328856 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 1,124.559 μs | 0.7575 μs | 0.7085 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 2,246.388 μs | 6.5943 μs | 6.1683 μs |  328856 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b256.md
@@ -1,37 +1,37 @@
-﻿| Description                                       | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
-|-------------------------------------------------- |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128B         |      90.09 ns |     0.290 ns |     0.271 ns |      90.05 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128B         |      94.51 ns |     0.378 ns |     0.335 ns |      94.58 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128B         |     126.66 ns |     0.156 ns |     0.138 ns |     126.70 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 128B         |     168.61 ns |     1.059 ns |     0.939 ns |     168.58 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 128B         |     606.43 ns |    11.953 ns |    18.254 ns |     614.08 ns |    1120 B |
-|                                                   |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 137B         |     169.01 ns |     0.278 ns |     0.232 ns |     168.99 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 137B         |     190.02 ns |     3.180 ns |     6.568 ns |     186.46 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 137B         |     232.34 ns |     0.340 ns |     0.318 ns |     232.18 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 137B         |     358.43 ns |     1.618 ns |     1.435 ns |     358.69 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 137B         |   1,098.53 ns |    12.144 ns |    10.766 ns |   1,093.54 ns |    1136 B |
-|                                                   |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1KB          |     647.91 ns |     1.581 ns |     1.402 ns |     648.04 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1KB          |     729.72 ns |     2.691 ns |     2.517 ns |     729.47 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1KB          |     871.22 ns |     0.850 ns |     0.795 ns |     871.36 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 1KB          |   1,483.93 ns |     2.575 ns |     2.283 ns |   1,484.01 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 1KB          |   3,756.68 ns |    30.537 ns |    28.564 ns |   3,751.53 ns |    2016 B |
-|                                                   |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1025B        |     725.72 ns |     2.288 ns |     2.141 ns |     724.92 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1025B        |     818.62 ns |     3.075 ns |     2.876 ns |     818.54 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1025B        |     975.06 ns |     1.233 ns |     1.153 ns |     975.16 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 1025B        |   1,668.99 ns |     2.164 ns |     1.918 ns |   1,668.54 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 1025B        |   4,230.54 ns |    25.087 ns |    22.239 ns |   4,230.03 ns |    2024 B |
-|                                                   |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 8KB          |   5,101.80 ns |    17.069 ns |    15.966 ns |   5,104.16 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 8KB          |   5,770.21 ns |    25.357 ns |    23.719 ns |   5,769.81 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 8KB          |   6,797.81 ns |     5.632 ns |     4.992 ns |   6,799.71 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 8KB          |  11,950.63 ns |     1.545 ns |     1.445 ns |  11,950.18 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 8KB          |  28,730.66 ns |    98.118 ns |    91.780 ns |  28,731.31 ns |    9184 B |
-|                                                   |              |               |              |              |               |           |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128KB        |  81,778.96 ns |   254.385 ns |   237.952 ns |  81,747.10 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128KB        |  92,546.43 ns |   346.204 ns |   323.839 ns |  92,624.49 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128KB        | 108,467.23 ns |    26.923 ns |    23.867 ns | 108,466.47 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 128KB        | 192,047.47 ns |    29.348 ns |    26.016 ns | 192,052.68 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 128KB        | 465,228.76 ns | 1,685.835 ns | 1,494.449 ns | 464,909.40 ns |  132092 B |
+﻿| Description                                       | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128B         |      90.21 ns |     0.287 ns |     0.268 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128B         |      94.42 ns |     0.421 ns |     0.373 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128B         |     126.65 ns |     0.173 ns |     0.154 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 128B         |     175.06 ns |     1.923 ns |     1.798 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 128B         |     580.56 ns |     2.447 ns |     2.289 ns |    1120 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 137B         |     167.61 ns |     0.536 ns |     0.501 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 137B         |     181.89 ns |     0.816 ns |     0.764 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 137B         |     231.56 ns |     0.295 ns |     0.276 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 137B         |     359.77 ns |     3.134 ns |     2.931 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 137B         |   1,071.16 ns |     6.749 ns |     6.313 ns |    1136 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1KB          |     640.41 ns |     2.543 ns |     2.378 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1KB          |     718.15 ns |     1.917 ns |     1.793 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1KB          |     869.99 ns |     0.782 ns |     0.693 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 1KB          |   1,482.78 ns |     3.662 ns |     3.246 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 1KB          |   3,703.12 ns |    10.129 ns |     9.474 ns |    2016 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1025B        |     723.58 ns |     2.977 ns |     2.784 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1025B        |     809.98 ns |     2.489 ns |     2.328 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1025B        |     974.48 ns |     1.068 ns |     0.999 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 1025B        |   1,671.57 ns |     3.627 ns |     3.215 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 1025B        |   4,224.25 ns |    41.654 ns |    36.926 ns |    2024 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 8KB          |   5,088.96 ns |    20.869 ns |    19.521 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 8KB          |   5,758.37 ns |    20.977 ns |    19.622 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 8KB          |   6,794.02 ns |     5.772 ns |     5.117 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 8KB          |  11,941.81 ns |     4.603 ns |     3.843 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 8KB          |  28,735.68 ns |   107.900 ns |   100.929 ns |    9184 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128KB        |  81,489.19 ns |   296.898 ns |   277.718 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128KB        |  92,497.55 ns |   356.361 ns |   333.340 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128KB        | 108,355.99 ns |    52.738 ns |    44.039 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Neon   | 128KB        | 191,376.36 ns |    68.707 ns |    57.373 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 128KB        | 465,280.36 ns | 1,665.225 ns | 1,557.652 ns |  132092 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2b512.md
@@ -1,37 +1,37 @@
 ﻿| Description                                       | TestDataSize | Mean          | Error        | StdDev       | Allocated |
 |-------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128B         |      91.55 ns |     0.171 ns |     0.160 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128B         |      95.93 ns |     0.190 ns |     0.178 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128B         |     128.89 ns |     0.152 ns |     0.142 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 128B         |     173.92 ns |     2.717 ns |     2.542 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 128B         |     605.17 ns |     2.472 ns |     2.312 ns |    1216 B |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128B         |      91.83 ns |     0.609 ns |     0.508 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128B         |      95.61 ns |     0.314 ns |     0.293 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128B         |     128.95 ns |     0.251 ns |     0.222 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 128B         |     175.13 ns |     2.369 ns |     2.216 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 128B         |     602.52 ns |     3.409 ns |     3.189 ns |    1216 B |
 |                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 137B         |     169.47 ns |     0.351 ns |     0.311 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 137B         |     186.74 ns |     0.490 ns |     0.458 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 137B         |     234.33 ns |     0.205 ns |     0.192 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 137B         |     360.09 ns |     3.530 ns |     3.129 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 137B         |   1,103.89 ns |     5.406 ns |     5.057 ns |    1232 B |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 137B         |     168.54 ns |     0.427 ns |     0.379 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 137B         |     186.32 ns |     0.386 ns |     0.361 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 137B         |     234.90 ns |     0.203 ns |     0.180 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 137B         |     359.18 ns |     3.128 ns |     2.926 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 137B         |   1,103.62 ns |     5.495 ns |     5.140 ns |    1232 B |
 |                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1KB          |     648.39 ns |     1.807 ns |     1.691 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1KB          |     729.54 ns |     3.572 ns |     3.167 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1KB          |     874.16 ns |     0.731 ns |     0.648 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 1KB          |   1,481.04 ns |     2.863 ns |     2.678 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 1KB          |   3,749.92 ns |    13.458 ns |    12.589 ns |    2112 B |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1KB          |     643.30 ns |     3.045 ns |     2.848 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1KB          |     724.40 ns |     2.515 ns |     2.229 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1KB          |     873.38 ns |     0.500 ns |     0.443 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 1KB          |   1,482.35 ns |     3.817 ns |     3.571 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 1KB          |   3,728.16 ns |     8.684 ns |     7.699 ns |    2112 B |
 |                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1025B        |     729.22 ns |     1.586 ns |     1.484 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1025B        |     826.18 ns |     2.582 ns |     2.415 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1025B        |     980.23 ns |     0.948 ns |     0.887 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 1025B        |   1,670.54 ns |     4.952 ns |     3.866 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 1025B        |   4,271.15 ns |    29.610 ns |    24.726 ns |    2120 B |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1025B        |     731.73 ns |     1.548 ns |     1.448 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1025B        |     815.15 ns |     2.597 ns |     2.430 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1025B        |     976.76 ns |     1.149 ns |     1.019 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 1025B        |   1,668.03 ns |     5.068 ns |     4.492 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 1025B        |   4,275.44 ns |    24.982 ns |    23.368 ns |    2120 B |
 |                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 8KB          |   5,128.38 ns |    11.411 ns |    10.674 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 8KB          |   5,813.63 ns |    15.115 ns |    14.139 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 8KB          |   6,801.93 ns |     6.883 ns |     6.438 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 8KB          |  11,991.66 ns |     9.642 ns |     8.052 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 8KB          |  29,056.48 ns |   249.171 ns |   208.069 ns |    9280 B |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 8KB          |   5,147.42 ns |     3.068 ns |     2.720 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 8KB          |   5,851.02 ns |    15.999 ns |    14.182 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 8KB          |   6,794.57 ns |     3.258 ns |     2.888 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 8KB          |  11,965.72 ns |     7.008 ns |     5.852 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 8KB          |  29,267.41 ns |    80.778 ns |    75.560 ns |    9280 B |
 |                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128KB        |  82,166.78 ns |   218.132 ns |   204.040 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128KB        |  92,997.12 ns |   208.667 ns |   174.246 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128KB        | 108,532.62 ns |   316.635 ns |   247.208 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 128KB        | 191,894.21 ns |   505.710 ns |   422.291 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 128KB        | 469,601.99 ns | 1,733.368 ns | 1,621.394 ns |  132188 B |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128KB        |  82,466.15 ns |    67.661 ns |    59.980 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128KB        |  93,817.57 ns |   225.412 ns |   210.850 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128KB        | 108,382.96 ns |    18.711 ns |    17.502 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Neon   | 128KB        | 191,339.40 ns |    23.917 ns |    18.673 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 128KB        | 475,078.70 ns | 1,666.854 ns | 1,559.176 ns |  132188 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s128.md
@@ -1,31 +1,31 @@
 ﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev    | Allocated |
 |-------------------------------------------------- |------------- |-------------:|------------:|----------:|----------:|
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128B         |     140.6 ns |     0.63 ns |   0.55 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128B         |     154.3 ns |     0.45 ns |   0.42 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128B         |     196.7 ns |     0.22 ns |   0.18 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 128B         |     383.9 ns |     4.88 ns |   4.56 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128B         |     139.7 ns |     0.39 ns |   0.37 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128B         |     155.3 ns |     0.59 ns |   0.55 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128B         |     196.6 ns |     0.21 ns |   0.18 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 128B         |     389.3 ns |     6.76 ns |   6.32 ns |         - |
 |                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 137B         |     207.9 ns |     0.30 ns |   0.25 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 137B         |     230.6 ns |     0.56 ns |   0.47 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 137B         |     284.5 ns |     0.63 ns |   0.49 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 137B         |     590.6 ns |     7.38 ns |   6.16 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 137B         |     207.3 ns |     0.69 ns |   0.64 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 137B         |     230.2 ns |     0.65 ns |   0.61 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 137B         |     284.5 ns |     1.37 ns |   1.07 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 137B         |     591.7 ns |     5.89 ns |   5.50 ns |         - |
 |                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1KB          |   1,080.0 ns |     4.06 ns |   3.60 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1KB          |   1,223.7 ns |    19.91 ns |  16.63 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1KB          |   1,451.3 ns |     1.44 ns |   1.12 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 1KB          |   3,221.1 ns |     4.21 ns |   3.94 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1KB          |   1,086.1 ns |     5.77 ns |   5.40 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1KB          |   1,215.4 ns |     6.48 ns |   6.07 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1KB          |   1,470.1 ns |     2.63 ns |   2.46 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 1KB          |   3,225.5 ns |     2.89 ns |   2.41 ns |         - |
 |                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1025B        |   1,146.3 ns |     5.41 ns |   4.22 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1025B        |   1,295.7 ns |     4.94 ns |   4.13 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1025B        |   1,539.9 ns |     1.91 ns |   1.60 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 1025B        |   3,429.5 ns |    10.13 ns |   8.46 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1025B        |   1,151.3 ns |     5.50 ns |   5.15 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1025B        |   1,300.5 ns |     6.18 ns |   5.78 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1025B        |   1,556.2 ns |     4.99 ns |   4.67 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 1025B        |   3,469.4 ns |     9.10 ns |   7.60 ns |         - |
 |                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 8KB          |   8,587.0 ns |    38.03 ns |  35.58 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 8KB          |   9,699.9 ns |    29.68 ns |  27.76 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 8KB          |  11,455.3 ns |    15.77 ns |  13.17 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 8KB          |  25,915.5 ns |    19.26 ns |  16.08 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 8KB          |   8,585.2 ns |    52.71 ns |  49.30 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 8KB          |   9,755.4 ns |    48.32 ns |  45.20 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 8KB          |  11,616.9 ns |    19.73 ns |  18.45 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 8KB          |  26,318.5 ns |    19.93 ns |  18.65 ns |         - |
 |                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128KB        | 136,672.0 ns |   656.60 ns | 582.06 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128KB        | 155,274.1 ns |   969.16 ns | 906.55 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128KB        | 183,352.4 ns |   250.65 ns | 222.19 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 128KB        | 415,383.0 ns | 1,089.13 ns | 909.47 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128KB        | 137,050.7 ns |   576.60 ns | 539.35 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128KB        | 155,887.7 ns |   868.04 ns | 811.97 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128KB        | 185,352.5 ns |   348.15 ns | 325.66 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Neon   | 128KB        | 420,691.3 ns | 1,019.57 ns | 953.70 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake2s256.md
@@ -1,31 +1,31 @@
 ﻿| Description                                       | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |-------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128B         |     142.5 ns |   2.61 ns |   2.44 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128B         |     154.9 ns |   0.76 ns |   0.71 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128B         |     196.5 ns |   0.42 ns |   0.37 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 128B         |     383.0 ns |   3.19 ns |   2.98 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128B         |     141.6 ns |   0.59 ns |   0.55 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128B         |     155.6 ns |   0.59 ns |   0.55 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128B         |     199.3 ns |   0.84 ns |   0.79 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 128B         |     383.4 ns |   1.12 ns |   0.93 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 137B         |     208.7 ns |   0.55 ns |   0.51 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 137B         |     231.2 ns |   0.71 ns |   0.66 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 137B         |     285.9 ns |   0.54 ns |   0.51 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 137B         |     588.3 ns |   6.64 ns |   6.21 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 137B         |     209.6 ns |   0.50 ns |   0.44 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 137B         |     231.3 ns |   0.63 ns |   0.59 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 137B         |     288.8 ns |   1.35 ns |   1.26 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 137B         |     589.6 ns |   1.44 ns |   1.35 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1KB          |   1,078.0 ns |   6.87 ns |   5.37 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1KB          |   1,215.1 ns |   6.81 ns |   6.37 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1KB          |   1,451.1 ns |   1.60 ns |   1.42 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 1KB          |   3,225.0 ns |   4.37 ns |   3.87 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1KB          |   1,084.8 ns |   4.62 ns |   4.32 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1KB          |   1,224.5 ns |   5.10 ns |   4.77 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1KB          |   1,470.2 ns |   3.94 ns |   3.69 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 1KB          |   3,264.7 ns |   7.58 ns |   7.09 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1025B        |   1,143.5 ns |   5.65 ns |   5.29 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1025B        |   1,291.2 ns |   6.36 ns |   5.64 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1025B        |   1,539.7 ns |   0.84 ns |   0.75 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 1025B        |   3,424.1 ns |   5.68 ns |   5.03 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1025B        |   1,150.9 ns |   5.55 ns |   5.20 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1025B        |   1,300.6 ns |   4.77 ns |   4.46 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1025B        |   1,561.8 ns |   2.69 ns |   2.52 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 1025B        |   3,468.8 ns |  12.54 ns |  11.73 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 8KB          |   8,523.8 ns |  44.68 ns |  41.79 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 8KB          |   9,668.0 ns |  41.35 ns |  38.68 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 8KB          |  11,456.1 ns |  10.92 ns |   9.68 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 8KB          |  25,905.4 ns |   6.57 ns |   6.14 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 8KB          |   8,582.3 ns |  29.55 ns |  26.19 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 8KB          |   9,752.9 ns |  26.48 ns |  22.11 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 8KB          |  11,597.5 ns |  46.22 ns |  43.23 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 8KB          |  26,304.4 ns |  61.47 ns |  57.50 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128KB        | 136,164.5 ns | 613.20 ns | 573.58 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128KB        | 154,474.2 ns | 660.16 ns | 617.51 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128KB        | 182,927.8 ns | 244.39 ns | 228.60 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 128KB        | 414,732.6 ns |  27.53 ns |  22.99 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128KB        | 136,875.3 ns | 502.88 ns | 470.39 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128KB        | 156,048.7 ns | 718.24 ns | 671.84 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128KB        | 185,106.1 ns | 375.00 ns | 332.43 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Neon   | 128KB        | 421,315.6 ns | 506.18 ns | 448.72 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake3.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/blake3.md
@@ -1,31 +1,31 @@
 ﻿| Description                                  | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |--------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · BLAKE3 · Blake3Native       | 128B         |     100.5 ns |     0.04 ns |     0.04 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 128B         |     243.1 ns |     0.02 ns |     0.02 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128B         |     518.8 ns |     2.02 ns |     1.89 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 128B         |     721.3 ns |     3.49 ns |     3.09 ns |         - |
+| TryComputeHash · BLAKE3 · Blake3Native       | 128B         |     101.7 ns |     0.19 ns |     0.18 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 128B         |     247.3 ns |     0.43 ns |     0.40 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128B         |     514.9 ns |     2.62 ns |     2.33 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 128B         |     726.5 ns |     2.75 ns |     2.57 ns |         - |
 |                                              |              |              |             |             |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 137B         |     147.5 ns |     0.49 ns |     0.41 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 137B         |     365.6 ns |     0.02 ns |     0.02 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 137B         |     773.1 ns |     3.26 ns |     3.05 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 137B         |   1,065.8 ns |     4.53 ns |     4.01 ns |         - |
+| TryComputeHash · BLAKE3 · Blake3Native       | 137B         |     147.9 ns |     0.60 ns |     0.56 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 137B         |     371.9 ns |     0.77 ns |     0.72 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 137B         |     765.5 ns |     2.90 ns |     2.71 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 137B         |   1,073.6 ns |     3.78 ns |     3.35 ns |         - |
 |                                              |              |              |             |             |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 1KB          |     765.7 ns |     2.52 ns |     2.35 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 1KB          |   1,960.6 ns |     0.12 ns |     0.10 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1KB          |   4,050.0 ns |    17.08 ns |    15.98 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 1KB          |   5,327.4 ns |    14.12 ns |    13.21 ns |         - |
+| TryComputeHash · BLAKE3 · Blake3Native       | 1KB          |     771.9 ns |     3.18 ns |     2.82 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 1KB          |   1,994.2 ns |     4.83 ns |     4.52 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1KB          |   3,933.9 ns |    24.13 ns |    22.58 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 1KB          |   5,363.7 ns |    26.55 ns |    24.84 ns |         - |
 |                                              |              |              |             |             |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 1025B        |     873.2 ns |     2.54 ns |     2.37 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 1025B        |   2,200.2 ns |     0.26 ns |     0.20 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1025B        |   4,550.4 ns |    26.60 ns |    24.89 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 1025B        |   6,068.1 ns |    17.69 ns |    16.54 ns |      56 B |
+| TryComputeHash · BLAKE3 · Blake3Native       | 1025B        |     881.0 ns |     3.02 ns |     2.83 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 1025B        |   2,238.4 ns |     3.60 ns |     3.19 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1025B        |   4,584.5 ns |    17.72 ns |    15.71 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 1025B        |   6,120.7 ns |    20.35 ns |    19.03 ns |      56 B |
 |                                              |              |              |             |             |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 8KB          |   3,379.5 ns |    36.28 ns |    47.18 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 8KB          |  17,220.6 ns |     6.49 ns |     5.42 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 8KB          |  33,848.5 ns |   241.04 ns |   225.47 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 8KB          |  45,220.0 ns |   154.37 ns |   144.40 ns |     392 B |
+| TryComputeHash · BLAKE3 · Blake3Native       | 8KB          |   3,304.4 ns |    12.87 ns |    12.04 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 8KB          |  17,542.1 ns |    74.48 ns |    69.67 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 8KB          |  34,242.6 ns |   230.92 ns |   216.01 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 8KB          |  45,147.6 ns |   183.34 ns |   171.49 ns |     392 B |
 |                                              |              |              |             |             |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 128KB        |  52,635.9 ns |   205.90 ns |   182.52 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 128KB        | 283,197.0 ns | 2,381.90 ns | 1,988.99 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128KB        | 561,904.6 ns | 2,318.77 ns | 2,055.53 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 128KB        | 729,030.9 ns | 1,957.62 ns | 1,634.70 ns |    7112 B |
+| TryComputeHash · BLAKE3 · Blake3Native       | 128KB        |  52,182.4 ns |   207.42 ns |   194.02 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Neon   | 128KB        | 285,292.2 ns |   882.20 ns |   825.21 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128KB        | 552,471.3 ns | 2,326.83 ns | 2,176.52 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 128KB        | 725,677.2 ns | 2,436.17 ns | 2,278.80 ns |    7112 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-128.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error        | StdDev       | Allocated |
-|------------------------------------------------ |------------- |-------------:|-------------:|-------------:|----------:|
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     590.9 ns |      2.68 ns |      2.38 ns |         - |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     905.5 ns |      2.49 ns |      2.21 ns |     576 B |
-|                                                 |              |              |              |              |           |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     649.1 ns |      1.54 ns |      1.29 ns |         - |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     911.1 ns |     10.65 ns |      8.89 ns |     576 B |
-|                                                 |              |              |              |              |           |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,179.5 ns |     18.40 ns |     16.32 ns |         - |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   5,846.5 ns |      9.77 ns |      8.66 ns |    2816 B |
-|                                                 |              |              |              |              |           |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,760.4 ns |     44.73 ns |     39.66 ns |         - |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   5,959.5 ns |     16.92 ns |     13.21 ns |    2816 B |
-|                                                 |              |              |              |              |           |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  33,431.6 ns |    507.17 ns |    563.72 ns |         - |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  45,668.1 ns |    453.61 ns |    424.31 ns |   20736 B |
-|                                                 |              |              |              |              |           |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  37,693.0 ns |    209.48 ns |    195.95 ns |         - |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  45,668.4 ns |    182.61 ns |    142.57 ns |   20736 B |
-|                                                 |              |              |              |              |           |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 526,228.0 ns |  1,946.47 ns |  1,625.39 ns |         - |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 759,503.4 ns | 15,059.95 ns | 27,537.97 ns |  327936 B |
-|                                                 |              |              |              |              |           |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 606,558.0 ns |  3,336.54 ns |  2,786.16 ns |         - |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 727,640.7 ns |  1,858.36 ns |  1,551.82 ns |  327936 B |
+﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     583.4 ns |     2.61 ns |     2.44 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     900.0 ns |     3.16 ns |     2.96 ns |     576 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     635.4 ns |     3.71 ns |     3.47 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     892.1 ns |     2.70 ns |     2.52 ns |     576 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,109.9 ns |    20.70 ns |    19.36 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   5,837.9 ns |    17.67 ns |    16.53 ns |    2816 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,670.0 ns |    14.73 ns |    13.78 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   5,871.9 ns |    20.41 ns |    19.09 ns |    2816 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  32,465.9 ns |   140.94 ns |   131.84 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  45,009.8 ns |   137.31 ns |   128.44 ns |   20736 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  37,064.0 ns |   164.05 ns |   153.45 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  45,261.6 ns |   154.66 ns |   144.67 ns |   20736 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 521,839.9 ns | 2,451.14 ns | 2,292.80 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 728,615.9 ns | 2,845.84 ns | 2,662.00 ns |  327936 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 595,950.4 ns | 2,549.53 ns | 2,384.83 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 718,452.6 ns | 2,779.84 ns | 2,321.29 ns |  327936 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-128.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error      | StdDev     | Allocated |
-|------------------------------------------------ |------------- |-------------:|-----------:|-----------:|----------:|
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     4.251 μs |  0.0036 μs |  0.0032 μs |     576 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     6.859 μs |  0.0327 μs |  0.0255 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     4.286 μs |  0.0036 μs |  0.0032 μs |     576 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     7.457 μs |  0.1422 μs |  0.1522 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |    27.588 μs |  0.0301 μs |  0.0235 μs |    2816 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |    49.280 μs |  0.2645 μs |  0.2345 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |    28.157 μs |  0.0351 μs |  0.0311 μs |    2816 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |    51.373 μs |  0.0168 μs |  0.0131 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |   213.311 μs |  0.4259 μs |  0.3984 μs |   20736 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |   387.600 μs |  1.0836 μs |  0.9049 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |   215.684 μs |  0.4628 μs |  0.4329 μs |   20736 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |   418.124 μs |  3.9664 μs |  3.7102 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 3,381.051 μs | 16.0211 μs | 14.9862 μs |  327936 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 6,248.573 μs |  3.6815 μs |  2.8743 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 3,448.344 μs | 14.2716 μs | 11.9174 μs |  327936 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 6,467.416 μs |  2.4332 μs |  2.0319 μs |         - |
+﻿| Description                                     | TestDataSize | Mean         | Error        | StdDev       | Allocated |
+|------------------------------------------------ |------------- |-------------:|-------------:|-------------:|----------:|
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     590.9 ns |      2.68 ns |      2.38 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     905.5 ns |      2.49 ns |      2.21 ns |     576 B |
+|                                                 |              |              |              |              |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     649.1 ns |      1.54 ns |      1.29 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     911.1 ns |     10.65 ns |      8.89 ns |     576 B |
+|                                                 |              |              |              |              |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,179.5 ns |     18.40 ns |     16.32 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   5,846.5 ns |      9.77 ns |      8.66 ns |    2816 B |
+|                                                 |              |              |              |              |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,760.4 ns |     44.73 ns |     39.66 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   5,959.5 ns |     16.92 ns |     13.21 ns |    2816 B |
+|                                                 |              |              |              |              |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  33,431.6 ns |    507.17 ns |    563.72 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  45,668.1 ns |    453.61 ns |    424.31 ns |   20736 B |
+|                                                 |              |              |              |              |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  37,693.0 ns |    209.48 ns |    195.95 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  45,668.4 ns |    182.61 ns |    142.57 ns |   20736 B |
+|                                                 |              |              |              |              |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 526,228.0 ns |  1,946.47 ns |  1,625.39 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 759,503.4 ns | 15,059.95 ns | 27,537.97 ns |  327936 B |
+|                                                 |              |              |              |              |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 606,558.0 ns |  3,336.54 ns |  2,786.16 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 727,640.7 ns |  1,858.36 ns |  1,551.82 ns |  327936 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-192.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-192.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error      | StdDev     | Allocated |
-|------------------------------------------------ |------------- |-------------:|-----------:|-----------:|----------:|
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |     5.632 μs |  0.0034 μs |  0.0030 μs |     584 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     9.099 μs |  0.0481 μs |  0.0450 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |     5.479 μs |  0.0059 μs |  0.0055 μs |     584 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     9.608 μs |  0.0106 μs |  0.0099 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |    37.796 μs |  0.0199 μs |  0.0176 μs |    2824 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |    64.997 μs |  0.5909 μs |  0.5527 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |    37.508 μs |  0.0245 μs |  0.0204 μs |    2824 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |    69.262 μs |  0.0625 μs |  0.0584 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |   284.240 μs |  0.4419 μs |  0.4133 μs |   20744 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |   504.456 μs |  0.5698 μs |  0.5051 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |   280.094 μs |  0.8741 μs |  0.8176 μs |   20744 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |   548.789 μs |  3.4213 μs |  3.2003 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 4,417.579 μs | 23.1165 μs | 20.4922 μs |  327944 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 8,127.228 μs | 87.3355 μs | 81.6937 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 4,424.125 μs | 29.3133 μs | 27.4197 μs |  327944 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 8,724.017 μs |  8.3344 μs |  7.7960 μs |         - |
+﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     833.0 ns |     3.68 ns |     2.87 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |   1,199.2 ns |     2.48 ns |     1.93 ns |     584 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     914.9 ns |     9.90 ns |     8.77 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |   1,169.8 ns |     7.65 ns |     6.38 ns |     584 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |   5,899.5 ns |    41.86 ns |    37.11 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |   7,900.9 ns |    92.02 ns |    81.58 ns |    2824 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |   6,563.5 ns |    47.01 ns |    41.68 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |   7,682.9 ns |    29.80 ns |    24.89 ns |    2824 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |  46,299.1 ns |   305.23 ns |   285.51 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |  59,341.8 ns |   335.93 ns |   297.79 ns |   20744 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |  51,714.5 ns |   410.36 ns |   363.77 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |  59,750.9 ns |   863.56 ns |   765.52 ns |   20744 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 744,326.9 ns | 3,660.35 ns | 3,056.56 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 944,916.0 ns | 6,715.11 ns | 5,952.77 ns |  327944 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 825,813.1 ns | 3,981.76 ns | 3,724.54 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 945,858.6 ns | 1,782.26 ns | 1,667.13 ns |  327944 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-192.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-192.md
@@ -1,25 +1,25 @@
 ﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     833.0 ns |     3.68 ns |     2.87 ns |         - |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |   1,199.2 ns |     2.48 ns |     1.93 ns |     584 B |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     820.7 ns |     2.38 ns |     2.23 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |   1,188.6 ns |     3.76 ns |     3.52 ns |     584 B |
 |                                                 |              |              |             |             |           |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     914.9 ns |     9.90 ns |     8.77 ns |         - |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |   1,169.8 ns |     7.65 ns |     6.38 ns |     584 B |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     885.3 ns |     2.39 ns |     2.23 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |   1,156.7 ns |     4.04 ns |     3.77 ns |     584 B |
 |                                                 |              |              |             |             |           |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |   5,899.5 ns |    41.86 ns |    37.11 ns |         - |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |   7,900.9 ns |    92.02 ns |    81.58 ns |    2824 B |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |   5,834.2 ns |    25.49 ns |    23.85 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |   7,798.0 ns |    47.11 ns |    44.06 ns |    2824 B |
 |                                                 |              |              |             |             |           |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |   6,563.5 ns |    47.01 ns |    41.68 ns |         - |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |   7,682.9 ns |    29.80 ns |    24.89 ns |    2824 B |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |   6,427.0 ns |    20.27 ns |    18.96 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |   7,745.4 ns |    43.40 ns |    40.59 ns |    2824 B |
 |                                                 |              |              |             |             |           |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |  46,299.1 ns |   305.23 ns |   285.51 ns |         - |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |  59,341.8 ns |   335.93 ns |   297.79 ns |   20744 B |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |  45,869.3 ns |   195.60 ns |   182.96 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |  58,656.9 ns |   152.55 ns |   135.23 ns |   20744 B |
 |                                                 |              |              |             |             |           |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |  51,714.5 ns |   410.36 ns |   363.77 ns |         - |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |  59,750.9 ns |   863.56 ns |   765.52 ns |   20744 B |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |  51,318.2 ns |   116.53 ns |   109.00 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |  59,060.5 ns |   207.52 ns |   194.12 ns |   20744 B |
 |                                                 |              |              |             |             |           |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 744,326.9 ns | 3,660.35 ns | 3,056.56 ns |         - |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 944,916.0 ns | 6,715.11 ns | 5,952.77 ns |  327944 B |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 736,722.4 ns | 3,650.15 ns | 3,414.35 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 937,658.5 ns | 1,999.75 ns | 1,870.56 ns |  327944 B |
 |                                                 |              |              |             |             |           |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 825,813.1 ns | 3,981.76 ns | 3,724.54 ns |         - |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 945,858.6 ns | 1,782.26 ns | 1,667.13 ns |  327944 B |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 812,382.3 ns | 2,779.24 ns | 2,599.71 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 938,201.8 ns | 3,448.62 ns | 3,225.84 ns |  327944 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-256.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error      | StdDev     | Allocated |
-|------------------------------------------------ |------------- |-------------:|-----------:|-----------:|----------:|
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |     5.629 μs |  0.0080 μs |  0.0063 μs |     592 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     8.950 μs |  0.0193 μs |  0.0171 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |     5.469 μs |  0.0059 μs |  0.0055 μs |     592 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     9.612 μs |  0.0099 μs |  0.0092 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |    36.101 μs |  0.0404 μs |  0.0378 μs |    2832 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |    64.019 μs |  0.1037 μs |  0.0970 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |    36.965 μs |  0.0583 μs |  0.0517 μs |    2832 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |    69.154 μs |  0.1470 μs |  0.1375 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |   280.042 μs |  0.8990 μs |  0.7970 μs |   20752 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |   515.152 μs |  0.2538 μs |  0.2250 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |   280.038 μs |  0.8096 μs |  0.7177 μs |   20752 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |   546.403 μs |  1.0973 μs |  0.9728 μs |         - |
-|                                                 |              |              |            |            |           |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 4,436.875 μs | 16.6690 μs | 14.7766 μs |  327952 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 8,068.557 μs | 22.9966 μs | 17.9542 μs |         - |
-|                                                 |              |              |            |            |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 4,437.208 μs | 21.3359 μs | 19.9576 μs |  327952 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 8,779.871 μs | 40.6294 μs | 38.0047 μs |         - |
+﻿| Description                                     | TestDataSize | Mean         | Error        | StdDev      | Allocated |
+|------------------------------------------------ |------------- |-------------:|-------------:|------------:|----------:|
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     833.7 ns |      3.17 ns |     2.64 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |   1,197.1 ns |      3.20 ns |     2.50 ns |     592 B |
+|                                                 |              |              |              |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     919.9 ns |     10.67 ns |     9.45 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |   1,186.3 ns |     23.06 ns |    20.44 ns |     592 B |
+|                                                 |              |              |              |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |   5,980.4 ns |     72.86 ns |    68.15 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |   7,673.4 ns |     45.26 ns |    37.80 ns |    2832 B |
+|                                                 |              |              |              |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |   6,615.0 ns |     34.80 ns |    27.17 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |   7,722.3 ns |     10.67 ns |     8.33 ns |    2832 B |
+|                                                 |              |              |              |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |  46,472.1 ns |    134.30 ns |   112.15 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |  58,895.8 ns |    107.64 ns |    95.42 ns |   20752 B |
+|                                                 |              |              |              |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |  51,871.9 ns |    225.46 ns |   188.27 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |  59,646.4 ns |    193.08 ns |   171.16 ns |   20752 B |
+|                                                 |              |              |              |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 743,947.6 ns |  2,307.12 ns | 2,158.08 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 947,592.7 ns | 11,232.16 ns | 9,957.02 ns |  327952 B |
+|                                                 |              |              |              |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 827,772.7 ns |  2,624.53 ns | 2,326.58 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 945,784.0 ns |  1,517.25 ns | 1,345.00 ns |  327952 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/camellia-cbc-256.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error        | StdDev      | Allocated |
-|------------------------------------------------ |------------- |-------------:|-------------:|------------:|----------:|
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     833.7 ns |      3.17 ns |     2.64 ns |         - |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |   1,197.1 ns |      3.20 ns |     2.50 ns |     592 B |
-|                                                 |              |              |              |             |           |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     919.9 ns |     10.67 ns |     9.45 ns |         - |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |   1,186.3 ns |     23.06 ns |    20.44 ns |     592 B |
-|                                                 |              |              |              |             |           |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |   5,980.4 ns |     72.86 ns |    68.15 ns |         - |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |   7,673.4 ns |     45.26 ns |    37.80 ns |    2832 B |
-|                                                 |              |              |              |             |           |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |   6,615.0 ns |     34.80 ns |    27.17 ns |         - |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |   7,722.3 ns |     10.67 ns |     8.33 ns |    2832 B |
-|                                                 |              |              |              |             |           |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |  46,472.1 ns |    134.30 ns |   112.15 ns |         - |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |  58,895.8 ns |    107.64 ns |    95.42 ns |   20752 B |
-|                                                 |              |              |              |             |           |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |  51,871.9 ns |    225.46 ns |   188.27 ns |         - |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |  59,646.4 ns |    193.08 ns |   171.16 ns |   20752 B |
-|                                                 |              |              |              |             |           |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 743,947.6 ns |  2,307.12 ns | 2,158.08 ns |         - |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 947,592.7 ns | 11,232.16 ns | 9,957.02 ns |  327952 B |
-|                                                 |              |              |              |             |           |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 827,772.7 ns |  2,624.53 ns | 2,326.58 ns |         - |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 945,784.0 ns |  1,517.25 ns | 1,345.00 ns |  327952 B |
+﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     831.3 ns |     3.36 ns |     2.98 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |   1,196.5 ns |     3.71 ns |     3.29 ns |     592 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     888.3 ns |     4.69 ns |     4.39 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |   1,167.4 ns |     5.89 ns |     5.51 ns |     592 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |   5,884.4 ns |    71.64 ns |    63.50 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |   7,653.6 ns |    18.85 ns |    17.63 ns |    2832 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |   6,439.5 ns |    20.14 ns |    18.84 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |   7,675.2 ns |    25.75 ns |    20.11 ns |    2832 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |  46,431.4 ns |   179.93 ns |   168.31 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |  59,034.3 ns |    99.45 ns |    93.03 ns |   20752 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |  51,102.3 ns |   236.79 ns |   209.91 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |  59,348.3 ns |   200.40 ns |   187.46 ns |   20752 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 742,813.1 ns | 3,121.44 ns | 2,606.54 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 939,621.1 ns | 2,158.14 ns | 1,802.14 ns |  327952 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 818,136.6 ns | 4,710.09 ns | 3,933.14 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 946,057.0 ns | 4,722.34 ns | 3,943.36 ns |  327952 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/cipher.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/cipher.md
@@ -15,21 +15,21 @@ Each cipher family exposes multiple acceleration tiers. The runtime automaticall
 | Variant | Instructions | .NET Target | When Selected | Description |
 |---------|-------------|-------------|---------------|-------------|
 | **Managed** | Scalar | All | No ARM Crypto support | T-table AES using scalar `uint` arithmetic. Fully portable, zero-allocation. ~10–16× slower than ArmAes depending on mode and payload size. |
-| **ArmAes** | AES (ARM Crypto Ext.) | .NET 8+ | `ArmBase.IsSupported` | Hardware AES round instructions (`AESD`, `AESE`, `AESMC`, `AESIMC`). For CBC, uses 8-block interleaved decrypt for maximum instruction-level parallelism — all 8 plaintext blocks decoded simultaneously via parallel `AESD` dispatch. For GCM/CCM, accelerates counter-mode encryption and CBC-MAC. Decrypt is ~8.5× faster than OS at 128 B; at bulk sizes Apple CommonCrypto leads via Apple Silicon–specific AES pipelining. |
-| **ArmAes+ArmPmull** | AES + PMULL (ARM Crypto Ext.) | .NET 8+ | `AdvSimd.Arm64.IsSupported` | Adds carry-less polynomial multiplication (`PMULL`/`PMULL2`) for hardware-accelerated GHASH over GF(2¹²⁸). `PMULL` operates on 64-bit polynomial operands to produce 128-bit products; `PMULL2` reads from the upper halves of 128-bit NEON registers (a free lane-select requiring no additional instruction). Uses the same 8-block stitched AES+GHASH pipeline as the x86 PClMul path. Modular reduction uses a 2-PMULL SymCrypt-style `MODREDUCE`. Pre-computes Karatsuba cross-term halves for H¹–H⁸ powers. **~32× faster than OS at 17 B**; OS leads at ≥8 KiB due to Apple Silicon–specific bulk AES acceleration. |
+| **ArmAes** | AES (ARM Crypto Ext.) | .NET 8+ | `ArmBase.IsSupported` | Hardware AES round instructions (`AESD`, `AESE`, `AESMC`, `AESIMC`). For CBC, uses 8-block interleaved decrypt for maximum instruction-level parallelism — all 8 plaintext blocks decoded simultaneously via parallel `AESD` dispatch. For GCM/CCM, accelerates counter-mode encryption and CBC-MAC. Decrypt is ~5.8× faster than OS at 128 B; at bulk sizes Apple CommonCrypto leads via Apple Silicon–specific AES pipelining. |
+| **ArmAes+ArmPmull** | AES + PMULL (ARM Crypto Ext.) | .NET 8+ | `AdvSimd.Arm64.IsSupported` | Adds carry-less polynomial multiplication (`PMULL`/`PMULL2`) for hardware-accelerated GHASH over GF(2¹²⁸). `PMULL` operates on 64-bit polynomial operands to produce 128-bit products; `PMULL2` reads from the upper halves of 128-bit NEON registers (a free lane-select requiring no additional instruction). Uses the same 8-block stitched AES+GHASH pipeline as the x86 PClMul path. Modular reduction uses a 2-PMULL SymCrypt-style `MODREDUCE`. Pre-computes Karatsuba cross-term halves for H¹–H⁸ powers. **Encrypt: ~120× faster than OS at 17 B; ~14× at 128 B** (OS CommonCrypto incurs ~8 μs per-call overhead at these sizes). OS leads at ≥8 KiB due to Apple Silicon–specific bulk AES acceleration. |
 
 ### ChaCha20 Family
 
 | Variant | Instructions | .NET Target | When Selected | Description |
 |---------|-------------|-------------|---------------|-------------|
 | **Managed** | Scalar | All | No NEON support | Quarter-round operations using scalar `uint` arithmetic. Fully portable. ~4× slower than Neon at all payload sizes. |
-| **Neon** | AdvSIMD (NEON) | .NET 8+ | `AdvSimd.IsSupported` | Maps the 4×4 ChaCha state to four `Vector128<uint>` rows. Uses ARM NEON shift-left, shift-right, and byte-table permute instructions for the 16-bit, 12-bit, 8-bit, and 7-bit rotations. Diagonal rounds use `AdvSimd.ExtractVector128` to rotate rows by one element. Processes one 64-byte keystream block per iteration. ~4× faster than Managed; ~1.24× faster than BouncyCastle at 128 KiB. |
+| **Neon** | AdvSIMD (NEON) | .NET 8+ | `AdvSimd.IsSupported` | Maps the 4×4 ChaCha state to four `Vector128<uint>` rows. Uses ARM NEON shift-left, shift-right, and byte-table permute instructions for the 16-bit, 12-bit, 8-bit, and 7-bit rotations. Diagonal rounds use `AdvSimd.ExtractVector128` to rotate rows by one element. Processes one 64-byte keystream block per iteration. ~4× faster than Managed; faster than BouncyCastle at all sizes up to 1 KiB; OS leads from ~8 KiB. |
 
 ### When to Use Each Variant
 
-- **Small messages (≤256 B)**: AES-GCM with ArmAes+ArmPmull is **~32× faster than OS at 17 B** and ~14× at 128 B — zero P/Invoke overhead eliminates the ~1.7–1.9 μs kernel transition cost entirely. ChaCha20-Poly1305 NEON is ~3× faster than OS at 128 B.
-- **Medium messages (256 B–4 KB)**: ArmAes+ArmPmull leads through ~1 KiB. ChaCha20-Poly1305 NEON remains competitive at 1 KiB (~1.25× faster than OS). This range covers QUIC (~1.4 KB), WireGuard (~1.4 KB), and IPsec packets.
-- **Large messages (8 KB–128 KB)**: Apple CommonCrypto dominates — OS is ~2× faster for AES-GCM and ~1.7× faster for ChaCha20-Poly1305. This is likely due to Apple Silicon–specific AES/PMULL micro-architectural pipelining that .NET's current ARMv8 paths do not yet fully exploit. This range covers TLS records (1–16 KB) and OPC UA chunks (8 KB default).
+- **Small messages (≤256 B)**: AES-GCM with ArmAes+ArmPmull eliminates the ~8 μs CommonCrypto per-call overhead entirely — **~120× faster than OS at 17 B encrypt** and **~14× at 128 B**. ChaCha20-Poly1305 NEON is ~5× faster than OS at 128 B.
+- **Medium messages (256 B–4 KB)**: ArmAes+ArmPmull leads through ~1 KiB. ChaCha20-Poly1305 NEON remains competitive at 1 KiB (~1.4× faster than OS). This range covers QUIC (~1.4 KB), WireGuard (~1.4 KB), and IPsec packets.
+- **Large messages (8 KB–128 KB)**: Apple CommonCrypto dominates — OS is ~2× faster for AES-GCM and ~1.54× faster for ChaCha20-Poly1305. This is due to Apple Silicon–specific AES/PMULL micro-architectural pipelining that .NET's current ARMv8 paths do not yet fully exploit. This range covers TLS records (1–16 KB) and OPC UA chunks (8 KB default).
 - **No hardware AES**: Use ChaCha20-Poly1305 NEON — it outperforms Managed AES-GCM by 3–10× depending on payload size and is always zero-allocation.
 - **IoT / constrained devices**: AES-CCM with ArmAes provides ~4× speedup over BouncyCastle at 128 KiB. Supports variable nonce (7–13 bytes) and tag sizes.
 
@@ -37,11 +37,11 @@ Each cipher family exposes multiple acceleration tiers. The runtime automaticall
 
 | Family | Leader | Key Insight |
 |--------|--------|-------------|
-| **ChaCha20** | Neon | NEON ~4× faster than Managed; ~1.24× faster than BouncyCastle at 128 KiB; zero allocation |
-| **ChaCha20-Poly1305** | Neon | **~3× faster than OS at 128 B**; OS leads at ≥8 KiB; zero allocation |
+| **ChaCha20** | Neon | NEON ~4× faster than Managed; faster than BouncyCastle at all sizes up to 1 KiB; zero allocation |
+| **ChaCha20-Poly1305** | Neon | **~5× faster than OS at 128 B**; OS leads at ≥8 KiB; Neon on par with BouncyCastle at 128 KiB; zero allocation |
 | **XChaCha20-Poly1305** | Neon | ~3.3× faster than Managed at 128 KiB; zero allocation |
-| **AES-CBC** | ArmAes | **Decrypt ~8.5× faster than OS at 128 B**; OS leads at ≥8 KiB (Apple Silicon bulk path); zero allocation |
-| **AES-GCM** | ArmAes+ArmPmull | **~32× faster than OS at 17 B**; ~14× at 128 B; OS leads at ≥8 KiB; 8-block stitched AES+GHASH pipeline |
+| **AES-CBC** | ArmAes | **Decrypt ~5.8× faster than OS at 128 B**; OS leads at ≥8 KiB (Apple Silicon bulk path); zero allocation |
+| **AES-GCM** | ArmAes+ArmPmull | **~120× faster than OS encrypt at 17 B**; ~14× at 128 B; OS leads at ≥8 KiB; 8-block stitched AES+GHASH pipeline |
 | **AES-CCM** | ArmAes | ~4× faster than BouncyCastle at 128 KiB; zero allocation; no OS adapter available |
 
 ---
@@ -74,7 +74,7 @@ AES-CBC (Cipher Block Chaining) is the most widely deployed AES mode. Two accele
 - **Managed**: T-table AES using four 256-entry lookup tables per round. Fully portable, zero-allocation. Comparable to BouncyCastle at large sizes.
 
 **Key observations:**
-- **ArmAes Decrypt**: ~8.5× faster than OS at 128 B; near OS at 4 KiB; OS leads from ~8 KiB (Apple Silicon uses a wider AES pipeline at bulk sizes)
+- **ArmAes Decrypt**: ~5.8× faster than OS at 128 B; near OS at 4 KiB; OS leads from ~8 KiB (Apple Silicon uses a wider AES pipeline at bulk sizes)
 - **ArmAes Encrypt**: ~1.5× faster than OS at 128 B; OS leads from 1 KiB (CBC encrypt is inherently serial; CommonCrypto uses NEON-assisted interleaving for partial parallelism)
 - **Managed**: Zero-allocation T-table AES; comparable to BouncyCastle at large sizes
 - **OS**: Allocates 72 B per call (P/Invoke marshalling overhead)
@@ -97,11 +97,11 @@ Authenticated Encryption with Associated Data (AEAD) ciphers provide both confid
 
 AES-GCM combines counter-mode AES encryption (GCTR) with GHASH polynomial authentication over GF(2¹²⁸). Two acceleration tiers are available on Apple M4:
 
-- **ArmAes+ArmPmull** (.NET 8+): Uses ARM Cryptography Extension `AESD`/`AESE` for counter-mode encryption and `PMULL`/`PMULL2` for GHASH polynomial multiplication. `PMULL` operates on 64-bit polynomial operands to produce 128-bit products; `PMULL2` reads from the upper halves of 128-bit NEON registers (a free lane-select requiring no additional instruction). Uses an 8-block stitched loop that interleaves AES rounds with lagged GHASH of the previous 8 blocks. Modular reduction uses a 2-PMULL SymCrypt-style `MODREDUCE`. Pre-computes Karatsuba cross-term halves for H¹–H⁸ powers. Small payloads use the non-stitched path (≤8 blocks). **~32× faster than OS at 17 B; ~14× at 128 B.** At bulk sizes (≥8 KiB), Apple CommonCrypto leads — likely due to Apple Silicon–specific AES pipelining not yet accessible to the .NET ARM intrinsics layer.
+- **ArmAes+ArmPmull** (.NET 8+): Uses ARM Cryptography Extension `AESD`/`AESE` for counter-mode encryption and `PMULL`/`PMULL2` for GHASH polynomial multiplication. `PMULL` operates on 64-bit polynomial operands to produce 128-bit products; `PMULL2` reads from the upper halves of 128-bit NEON registers (a free lane-select requiring no additional instruction). Uses an 8-block stitched loop that interleaves AES rounds with lagged GHASH of the previous 8 blocks. Modular reduction uses a 2-PMULL SymCrypt-style `MODREDUCE`. Pre-computes Karatsuba cross-term halves for H¹–H⁸ powers. Small payloads use the non-stitched path (≤8 blocks). **~120× faster than OS encrypt at 17 B; ~14× at 128 B** (OS CommonCrypto incurs ~8 μs per-call overhead for small payloads). At bulk sizes (≥8 KiB), Apple CommonCrypto leads — due to Apple Silicon–specific AES pipelining not accessible via the .NET ARM intrinsics layer.
 - **Managed**: Scalar T-table AES with 4-bit Shoup table GHASH (16-entry reduction table, byte-by-byte multiplication). Fully portable, zero-allocation.
 
 **Key observations:**
-- **ArmAes+ArmPmull**: ~32× faster than OS at 17 B encrypt; ~14× at 128 B; ~2.5× at 1 KiB; OS leads from ~4–8 KiB
+- **ArmAes+ArmPmull**: ~120× faster than OS encrypt at 17 B; ~14× at 128 B; ~2.5× at 1 KiB; OS leads from ~4–8 KiB
 - **ArmAes+ArmPmull at 128 KiB**: OS is ~4.8× faster for both encrypt and decrypt
 - **Managed**: Uses 4-bit Shoup table GHASH, T-table AES; zero allocation
 - **BouncyCastle**: Uses ARM AES + PMULL internally on ARM64; allocates ~1.5 KB per call
@@ -116,7 +116,7 @@ AES-192-GCM uses 12 rounds (vs 10 for AES-128), adding ~10-15% overhead. The sam
 
 ### AES-256-GCM
 
-AES-256-GCM uses 14 rounds (vs 10 for AES-128), adding ~20-30% overhead per block. The same 2-tier architecture (ArmAes+ArmPmull → Managed) applies. Encrypt is ~14-16× faster than OS at 128 B; OS leads from ~4–8 KiB. The large-payload gap mirrors AES-128-GCM — Apple CommonCrypto likely exploits Apple Silicon–specific AES/PMULL execution units that are not yet accessible through the .NET ARMv8 intrinsics layer.
+AES-256-GCM uses 14 rounds (vs 10 for AES-128), adding ~20-30% overhead per block. The same 2-tier architecture (ArmAes+ArmPmull → Managed) applies. Encrypt is ~14–16× faster than OS at 128 B; OS leads from ~4–8 KiB. The large-payload gap mirrors AES-128-GCM — Apple CommonCrypto likely exploits Apple Silicon–specific AES/PMULL execution units that are not yet accessible through the .NET ARMv8 intrinsics layer.
 
 [!INCLUDE[](aes-gcm-256.md)]
 
@@ -145,12 +145,12 @@ AES-256-CCM uses 14 rounds (vs 10 for AES-128). The same ArmAes / Managed dispat
 
 ChaCha20-Poly1305 is a software-friendly AEAD cipher (RFC 8439) that combines ChaCha20 stream encryption with Poly1305 MAC authentication. It is the recommended AEAD cipher when hardware AES acceleration is unavailable. Two acceleration tiers are available on ARM:
 
-- **Neon**: Single-block ChaCha20 via `Vector128<uint>` combined with Poly1305 donna-64 MAC (3×44-bit limbs, 9 multiplications per 16-byte block using `Math.BigMul`). **~3× faster than OS at 128 B**; competitive with OS at 1 KiB; OS leads at ≥8 KiB.
+- **Neon**: Single-block ChaCha20 via `Vector128<uint>` combined with Poly1305 donna-64 MAC (3×44-bit limbs, 9 multiplications per 16-byte block using `Math.BigMul`). **~5× faster than OS at 128 B** (1.84 μs vs 9.58 μs); competitive with OS at 1 KiB; OS leads from 8 KiB. At 128 KiB, Neon (~1.19 ms) is ~1.54× slower than OS (~0.77 ms) and on par with BouncyCastle (~1.18 ms). A dual-block NEON path (comparable to the x86 AVX2 path) would be required to close this gap.
 - **Managed**: Scalar ChaCha20 + Poly1305 donna-32 (5×26-bit limbs, 25 multiplications per block on .NET Framework / .NET Standard). Fully portable.
 
 **Key observations:**
-- **Neon** ~3× faster than OS at 128 B encrypt; ~1.25× at 1 KiB; OS ~1.45× faster from 8 KiB; OS ~1.67× faster at 128 KiB
-- BouncyCastle is slightly faster than NEON at very small payloads (128 B) due to lower NEON setup overhead at that granularity
+- **Neon** ~5× faster than OS at 128 B; ~1.4× faster than OS at 1 KiB; OS leads from ~8 KiB (~1.54× faster at 128 KiB)
+- **Neon** beats BouncyCastle at all sizes up to ~4 KiB; on par with BouncyCastle at 128 KiB (potential improvement area: a dual-block NEON path)
 - **Managed** and **Neon** paths are zero-allocation
 - **BouncyCastle** allocates 336–416 B per call; **NaCl.Core** allocates 48–72 B per call
 

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/cshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/cshake128.md
@@ -1,19 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Median       | Allocated |
-|------------------------------------------------ |------------- |-------------:|------------:|------------:|-------------:|----------:|
-| TryComputeHash · cSHAKE128 · BouncyCastle       | 128B         |     179.5 ns |     1.21 ns |     1.08 ns |     179.1 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 128B         |     259.5 ns |     3.68 ns |     2.87 ns |     259.8 ns |         - |
-|                                                 |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE128 · BouncyCastle       | 137B         |     181.2 ns |     1.43 ns |     1.20 ns |     181.0 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 137B         |     243.2 ns |     4.80 ns |     4.26 ns |     244.3 ns |         - |
-|                                                 |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE128 · BouncyCastle       | 1KB          |   1,135.8 ns |    19.75 ns |    18.47 ns |   1,132.3 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 1KB          |   1,413.5 ns |    14.02 ns |    10.94 ns |   1,413.2 ns |         - |
-|                                                 |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE128 · BouncyCastle       | 1025B        |   1,115.0 ns |     2.89 ns |     2.41 ns |   1,114.0 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 1025B        |   1,408.6 ns |     9.69 ns |     8.09 ns |   1,409.9 ns |         - |
-|                                                 |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE128 · BouncyCastle       | 8KB          |   7,666.8 ns |    25.40 ns |    19.83 ns |   7,656.9 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 8KB          |   7,970.8 ns |    12.45 ns |    11.64 ns |   7,967.7 ns |         - |
-|                                                 |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE128 · BouncyCastle       | 128KB        | 122,230.4 ns |   497.16 ns |   465.05 ns | 122,058.4 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 128KB        | 127,380.1 ns | 2,540.76 ns | 3,477.82 ns | 125,383.0 ns |         - |
+﻿| Description                                     | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|------------------------------------------------ |------------- |-------------:|----------:|----------:|----------:|
+| TryComputeHash · cSHAKE128 · CryptoHives-Arm64  | 128B         |     159.5 ns |   0.81 ns |   0.63 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 128B         |     169.5 ns |   0.38 ns |   0.30 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle       | 128B         |     180.5 ns |   0.53 ns |   0.42 ns |         - |
+|                                                 |              |              |           |           |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Arm64  | 137B         |     158.8 ns |   0.67 ns |   0.60 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 137B         |     171.0 ns |   0.32 ns |   0.27 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle       | 137B         |     180.9 ns |   0.81 ns |   0.63 ns |         - |
+|                                                 |              |              |           |           |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Arm64  | 1KB          |   1,086.2 ns |   0.90 ns |   0.84 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle       | 1KB          |   1,127.3 ns |   2.13 ns |   1.89 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 1KB          |   1,131.8 ns |   1.66 ns |   1.47 ns |         - |
+|                                                 |              |              |           |           |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Arm64  | 1025B        |   1,065.1 ns |   1.30 ns |   1.09 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle       | 1025B        |   1,119.0 ns |   1.54 ns |   1.20 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 1025B        |   1,134.8 ns |   1.63 ns |   1.44 ns |         - |
+|                                                 |              |              |           |           |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Arm64  | 8KB          |   7,377.3 ns |  28.78 ns |  22.47 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle       | 8KB          |   7,719.5 ns |  51.91 ns |  46.02 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 8KB          |   7,849.9 ns |  12.06 ns |   9.41 ns |         - |
+|                                                 |              |              |           |           |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Arm64  | 128KB        | 119,435.1 ns |  76.29 ns |  63.70 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle       | 128KB        | 123,304.5 ns | 493.69 ns | 437.64 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar | 128KB        | 124,918.5 ns | 313.34 ns | 277.77 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/cshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/cshake256.md
@@ -1,19 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|------------------------------------------------ |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · cSHAKE256 · BouncyCastle       | 128B         |     178.0 ns |   0.54 ns |   0.45 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 128B         |     252.2 ns |   4.37 ns |   3.88 ns |         - |
-|                                                 |              |              |           |           |           |
-| TryComputeHash · cSHAKE256 · BouncyCastle       | 137B         |     327.1 ns |   1.07 ns |   0.95 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 137B         |     605.0 ns |   5.58 ns |   4.94 ns |         - |
-|                                                 |              |              |           |           |           |
-| TryComputeHash · cSHAKE256 · BouncyCastle       | 1KB          |   1,271.7 ns |  16.05 ns |  13.40 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 1KB          |   1,473.1 ns |  25.16 ns |  31.82 ns |         - |
-|                                                 |              |              |           |           |           |
-| TryComputeHash · cSHAKE256 · BouncyCastle       | 1025B        |   1,278.3 ns |  21.17 ns |  19.80 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 1025B        |   1,451.4 ns |   9.75 ns |   7.61 ns |         - |
-|                                                 |              |              |           |           |           |
-| TryComputeHash · cSHAKE256 · BouncyCastle       | 8KB          |   9,468.9 ns |  48.20 ns |  40.25 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 8KB          |  10,010.8 ns |  40.24 ns |  31.42 ns |         - |
-|                                                 |              |              |           |           |           |
-| TryComputeHash · cSHAKE256 · BouncyCastle       | 128KB        | 149,997.3 ns | 354.21 ns | 295.78 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 128KB        | 154,402.4 ns | 937.27 ns | 782.66 ns |         - |
+﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · cSHAKE256 · CryptoHives-Arm64  | 128B         |     160.9 ns |     0.98 ns |     0.76 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 128B         |     171.4 ns |     0.89 ns |     0.75 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle       | 128B         |     179.7 ns |     0.49 ns |     0.45 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Arm64  | 137B         |     305.4 ns |     0.26 ns |     0.20 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 137B         |     327.3 ns |     0.38 ns |     0.34 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle       | 137B         |     336.5 ns |     1.03 ns |     0.91 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Arm64  | 1KB          |   1,228.1 ns |     4.29 ns |     4.01 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle       | 1KB          |   1,275.7 ns |    12.12 ns |    10.74 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 1KB          |   1,302.6 ns |    21.02 ns |    19.66 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Arm64  | 1025B        |   1,222.1 ns |     1.40 ns |     1.09 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle       | 1025B        |   1,267.5 ns |     3.94 ns |     3.50 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 1025B        |   1,290.0 ns |     3.78 ns |     3.16 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Arm64  | 8KB          |   9,314.5 ns |    16.66 ns |    15.59 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle       | 8KB          |   9,502.6 ns |    39.18 ns |    34.73 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 8KB          |   9,725.9 ns |    15.54 ns |    12.98 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Arm64  | 128KB        | 146,894.1 ns |   272.24 ns |   227.34 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle       | 128KB        | 151,896.5 ns | 2,910.90 ns | 2,722.86 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar | 128KB        | 153,825.0 ns |   356.39 ns |   297.60 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/hash.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/hash.md
@@ -11,16 +11,16 @@ Implementations are compared against:
 - **BouncyCastle** — BouncyCastle C# library
 - **Native** — Platform-specific native libraries (e.g., blake3-dotnet)
 - **Managed** — CryptoHives managed implementation (scalar)
-- **SIMD** — CryptoHives SIMD variants (ArmSha256, Neon)
+- **SIMD** — CryptoHives SIMD variants (ArmSha256, Neon, Arm64)
 
 ## Highlights
 
 | Family | Leader | Key Insight |
 |--------|--------|-------------|
-| **SHA-2** | OS (ArmSha256) | Apple CommonCrypto leads: ~2× faster at 128 B, ~13% at 128 KiB; ArmSha256 managed path matches scalar Managed speed |
-| **SHA-3/Keccak** | BouncyCastle | BouncyCastle slightly faster than Managed (~6% at bulk sizes); **opposite pattern to x86** where scalar Managed leads |
+| **SHA-2** | OS (CommonCrypto) | Apple Silicon SHA hardware ~2.2× faster than ArmSha256 at 128 B; ArmSha256 is ~2.6× faster than Scalar at 128 B and ~7.3× faster at 128 KiB |
+| **SHA-3/Keccak** | CryptoHives Arm64 | Arm64 variant beats BouncyCastle at all sizes; Scalar on parity with BouncyCastle at bulk |
 | **BLAKE2b/2s** | BouncyCastle | BouncyCastle ~2× faster than Neon at 128 KiB; Neon ~1.75× faster than Managed |
-| **BLAKE3** | Native (Rust) | Rust ~5.4× faster than BouncyCastle at 128 KiB; Neon ~2.5× faster than BouncyCastle |
+| **BLAKE3** | Native (Rust) | Rust ~5.4× faster than BouncyCastle at 128 KiB; Neon ~2.6× faster than BouncyCastle |
 | **Streebog** | Managed | ~1.7× faster than OpenGost; ~2.1× faster than BouncyCastle |
 | **Kupyna** | Managed | ~1.5× faster than BouncyCastle at all sizes |
 | **KMAC** | Managed | ~1.9× faster than BouncyCastle at 128 B; competitive at bulk sizes |
@@ -31,12 +31,15 @@ Implementations are compared against:
 
 ## SHA-2 Family
 
-On Apple M4, `System.Security.Cryptography` is backed by Apple CommonCrypto which uses the Apple Silicon hardware SHA acceleration. The `ArmSha256` managed variant maps to the ARM Cryptography Extension `SHA256H`/`SHA256H2`/`SHA256SU0`/`SHA256SU1` instructions — but at these sizes the overhead difference mainly stems from the OS call path being highly optimized. The managed `ArmSha256` path provides essentially the same throughput as the scalar `Managed` path (within 1%), suggesting the JIT already eliminates most overhead once SHA-round dispatch is optimized.
+On Apple M4, `System.Security.Cryptography` is backed by Apple CommonCrypto which uses Apple Silicon hardware SHA acceleration. At 128 B, OS (83 ns) is ~2.2× faster than `ArmSha256` (182 ns). The `ArmSha256` managed variant maps directly to the ARM Cryptography Extension `SHA256H`/`SHA256H2`/`SHA256SU0`/`SHA256SU1` instructions and is **2.6× faster than the scalar `Managed` path** (182 ns vs 473 ns at 128 B) and **7.3× faster at 128 KiB** (44 μs vs 321 μs). The remaining gap to OS is due to Apple's proprietary SHA pipelining inside CommonCrypto, which is not accessible via the standard ARM intrinsics.
+
+CryptoHives-Scalar outperforms BouncyCastle by ~20–24% across all sizes — consistent with the x86 result.
 
 **Key observations:**
-- **OS**: Apple Silicon hardware SHA — ~2× faster at 128 B; ~13% faster at 128 KiB
-- **ArmSha256 / Managed**: Identical throughput; ArmSha256 does not currently provide additional speedup over the scalar path in this .NET version
-- **BouncyCastle**: ~3.3× slower than OS at 128 B; slower than Managed by ~9.4× at 128 KiB
+- **OS**: Apple Silicon hardware SHA — ~2.2× faster than ArmSha256 at 128 B; ~12% faster at 128 KiB
+- **ArmSha256**: Uses `SHA256H`/`SHA256H2` ARM Crypto Extension instructions; ~2.6× faster than Scalar at 128 B; ~7.3× faster at 128 KiB
+- **CryptoHives-Scalar**: ~20–24% faster than BouncyCastle across all sizes
+- **BouncyCastle**: ~7× slower than OS at 128 B (590 ns vs 83 ns); ~31% slower than Scalar at 128 KiB
 
 ### SHA-224
 [!INCLUDE[](sha224.md)]
@@ -60,12 +63,13 @@ On Apple M4, `System.Security.Cryptography` is backed by Apple CommonCrypto whic
 
 ## Keccak-derived Families
 
-On Apple M4, BouncyCastle is slightly faster than the CryptoHives managed Keccak core across all payload sizes — the reverse of the x86 Windows result. On x86, the scalar CryptoHives path is ~30% faster than OS SHA-3 due to loop-unrolling and constant elimination that matches well with x86 out-of-order execution. On Apple M4, BouncyCastle's JIT-optimized Keccak permutation is ~6% faster at bulk sizes. Both implementations use scalar arithmetic; neither has an ARM SIMD path yet.
+On Apple M4, the CryptoHives **Arm64** Keccak variant is the fastest managed implementation, beating BouncyCastle at all payload sizes (e.g., 147 μs vs 151 μs at 128 KiB for SHA3-256). The scalar `Managed` path is on parity with BouncyCastle at bulk sizes (~2% difference), while the Arm64 path stays ~2–3% ahead. This is the reverse of the x86 pattern — on x86, the scalar path is ~30% faster than OS SHA-3; here there is no OS SHA-3 reference and both managed paths operate at similar throughput.
 
 **Key observations:**
-- **BouncyCastle**: ~3% faster than Managed at 128 B for SHA3-256; ~6% faster at bulk (1 KiB–128 KiB)
+- **CryptoHives Arm64**: Fastest managed option — beats BouncyCastle at all sizes (~6% at 128 B, ~2.4% at 128 KiB for SHA3-256)
+- **CryptoHives Scalar**: On parity with BouncyCastle at bulk sizes; ~6% behind at 128 B
 - No OS SHA-3 comparison available (macOS CommonCrypto does not expose SHA-3 via .NET in current releases)
-- All Keccak variants (SHA-3, SHA-3/SHAKE, cSHAKE, TurboSHAKE, KT) share the same optimized core
+- All Keccak variants (SHA-3, SHAKE, cSHAKE, TurboSHAKE, KT) share the same optimized core
 
 ### SHA-3 Family
 
@@ -152,9 +156,11 @@ BouncyCastle leads the BLAKE2 benchmarks on Apple M4 — its JIT-compiled implem
 
 ## BLAKE3
 
-BLAKE3 is a modern hash function designed for extreme parallelism. At 128 KiB, the **Native (Rust)** variant via `blake3-dotnet` is **~5.4× faster than BouncyCastle** and **~2.6× faster than the NEON path**. The gap is smaller than on x86 (where the Rust build uses AVX-512 `hash_many` for ~12× advantage) because the ARM Rust build uses a single-threaded NEON path that is comparable in architecture to the CryptoHives Neon path — the key difference is that the Rust build also enables tree-hash parallelism via NEON-based chunk merging at 128 KiB, while the CryptoHives implementation processes chunks sequentially.
+BLAKE3 is a modern hash function designed for extreme parallelism. At 128 KiB, the **Native (Rust)** variant via `blake3-dotnet` is **~5.4× faster than BouncyCastle** and **~2.6× faster than the NEON path** (52.6 μs vs 283 μs). The gap is smaller than on x86 (where the Rust build uses AVX-512 `hash_many` for ~12× advantage) because the ARM Rust build uses a single-threaded NEON path comparable in architecture to the CryptoHives Neon path — the key difference is that the Rust build also enables tree-hash parallelism via NEON-based chunk merging at 128 KiB, while the CryptoHives implementation processes chunks sequentially.
 
-The CryptoHives `Neon` path uses `Vector128<uint>` for the BLAKE3 compression function (same G-function as ChaCha20), yielding ~2.5× speedup over BouncyCastle at 128 KiB. The scalar `Managed` path is ~1.4× faster than BouncyCastle at 128 B and ~1.3× at 128 KiB.
+The CryptoHives `Neon` path uses `Vector128<uint>` for the BLAKE3 compression function, yielding **~2.6× speedup over BouncyCastle at 128 KiB** (283 μs vs 729 μs). The scalar `Managed` path is ~1.4× faster than BouncyCastle at 128 B and ~1.3× at 128 KiB.
+
+> ⚠️ **Note**: The macOS benchmarks in this run were produced before the `Reset(bool)` allocation fix landed. The `Neon` and `Scalar` rows currently report 24 B allocated per call. This is a known stale artifact — the fix is confirmed zero-allocation on Windows. These benchmarks will be updated after the next macOS run.
 
 [!INCLUDE[](blake3.md)]
 
@@ -198,184 +204,3 @@ On Apple M4, BouncyCastle leads MD5 at small sizes (~20% faster than OS at 128 B
 
 ### SHA-1
 [!INCLUDE[](sha1.md)]
-
----
-
-## Regional Standards
-
-These algorithms serve **regulatory compliance requirements** in specific jurisdictions:
-
-| Algorithm | Region | Use Case |
-|-----------|--------|----------|
-| **SM3** | China | Required for Chinese government and financial systems (GB/T 32905-2016) |
-| **Streebog** | Russia | Russian federal standard GOST R 34.11-2012, required for government communications |
-| **Kupyna** | Ukraine | Ukrainian national standard DSTU 7564:2014, required for government systems |
-| **LSH** | South Korea | Korean national standard KS X 3262, approved by KCMVP |
-| **Whirlpool** | ISO/NESSIE | European cryptographic standard (ISO/IEC 10118-3) |
-| **RIPEMD-160** | Europe/Crypto | Used in Bitcoin address generation and some European standards |
-
-On Apple M4, the managed Streebog implementation is **~1.7× faster than OpenGost** and **~2.1× faster than BouncyCastle** — consistent with the x86 advantage. Kupyna is **~1.5× faster than BouncyCastle** (vs ~1.3–1.45× on x86). The Whirlpool implementation is outstanding at **~4.9× faster than BouncyCastle** — the most dominant advantage of any regional algorithm on this platform.
-
-### SM3
-[!INCLUDE[](sm3.md)]
-
-### Streebog-256
-[!INCLUDE[](streebog256.md)]
-
-### Streebog-512
-[!INCLUDE[](streebog512.md)]
-
-### Whirlpool
-[!INCLUDE[](whirlpool.md)]
-
-### RIPEMD-160
-[!INCLUDE[](ripemd160.md)]
-
-### Kupyna-256 (DSTU 7564)
-[!INCLUDE[](kupyna256.md)]
-
-### Kupyna-384 (DSTU 7564)
-[!INCLUDE[](kupyna384.md)]
-
-### Kupyna-512 (DSTU 7564)
-[!INCLUDE[](kupyna512.md)]
-
-### LSH-256-256 (KS X 3262)
-[!INCLUDE[](lsh256-256.md)]
-
-### LSH-512-256 (KS X 3262)
-[!INCLUDE[](lsh512-256.md)]
-
-### LSH-512-512 (KS X 3262)
-[!INCLUDE[](lsh512-512.md)]
-
----
-
-## XOF Mode
-
-XOF (Extendable Output Function) benchmarks measure the full absorb-then-squeeze cycle: the input is absorbed and an output of equal size is squeezed. The benchmark method is `AbsorbSqueeze`. All CryptoHives XOF implementations are **zero-allocation** regardless of output size. BouncyCastle's XOF implementations allocate an internal output buffer proportional to the squeezed length (e.g., ~150 KB for a 128 KiB squeeze), making them unsuitable for high-frequency streaming use.
-
-### SHAKE Family
-
-SHAKE128 and SHAKE256 (FIPS 202) are variable-output-length extensions of the SHA-3 permutation with security strengths of 128 and 256 bits respectively. SHAKE128 uses a 1344-bit rate (21 blocks × 64 bytes) while SHAKE256 uses a 1088-bit rate — making SHAKE128 ~14% faster for the same output size due to fewer Keccak permutation calls per byte output.
-
-On Apple M4, BouncyCastle leads both variants at all tested sizes. For SHAKE128: BC ~12% faster at 128 B; ~1.64× faster at 128 KiB. For SHAKE256: BC ~11% faster at 128 B; ~1.53× faster at 128 KiB. This follows the same pattern as the fixed-output SHAKE hash benchmarks (BouncyCastle's Keccak permutation marginally outperforms the CryptoHives scalar implementation on Apple Silicon).
-
-**Key observations:**
-- **BouncyCastle**: Fastest on Apple M4 but allocates output-proportional buffers (~150 KB at 128 KiB squeeze)
-- **Managed**: Zero-allocation; ~1.6× slower than BC at 128 KiB
-- SHAKE128 is ~12% faster than SHAKE256 at the same size due to wider rate
-
-#### SHAKE128
-[!INCLUDE[](xof-shake128.md)]
-
-#### SHAKE256
-[!INCLUDE[](xof-shake256.md)]
-
----
-
-### cSHAKE Family
-
-cSHAKE128 and cSHAKE256 (NIST SP 800-185) extend SHAKE with domain separation via a function-name string `N` and a customization string `S`, enabling distinct hash functions for different applications from the same permutation. When both strings are empty, cSHAKE degenerates exactly to SHAKE.
-
-Performance is essentially identical to the corresponding SHAKE variants — the customization strings add a one-time padding overhead during initialization, negligible in the benchmarked range. BouncyCastle leads by ~12% at 128 B and ~1.63× at 128 KiB; both implementations are zero-allocation at all sizes for the CryptoHives path.
-
-**Key observations:**
-- Performance matches SHAKE128/256 within measurement noise
-- **BouncyCastle**: Allocates ~150 KB per 128 KiB squeeze
-- **Managed**: Zero-allocation; preserves streaming use-case fitness
-
-#### cSHAKE128
-[!INCLUDE[](xof-cshake128.md)]
-
-#### cSHAKE256
-[!INCLUDE[](xof-cshake256.md)]
-
----
-
-### KMAC Family (XOF)
-
-KMAC128 XOF and KMAC256 XOF (NIST SP 800-185) are keyed variants of cSHAKE usable as variable-length PRFs. In XOF mode the output length is not encoded into the padding, enabling stream output of arbitrary length. KMAC128 XOF uses the cSHAKE128 rate (1344 bits); KMAC256 XOF uses the cSHAKE256 rate (1088 bits).
-
-At 128 B absorb + 128 B squeeze, Managed and BouncyCastle are nearly equal (BC ~2% faster) — this is a notable difference from the fixed-output KMAC benchmark where Managed was ~1.9× faster. The larger per-call overhead of the XOF API (absorb + pad + squeeze) dominates at small sizes, favouring neither implementation. At 128 KiB, BC leads by ~1.64×, consistent with the Keccak throughput pattern.
-
-**Key observations:**
-- Near parity at 128 B between Managed and BC (within ~2%)
-- **BouncyCastle**: Allocates ~130 B at small sizes, ~150 KB at 128 KiB squeeze
-- **Managed**: Zero-allocation at all sizes
-
-#### KMAC128
-[!INCLUDE[](xof-kmac128.md)]
-
-#### KMAC256
-[!INCLUDE[](xof-kmac256.md)]
-
----
-
-### KangarooTwelve Family (XOF)
-
-KangarooTwelve (KT128 / KT256) are tree-hashing XOFs based on the Keccak permutation with 12 rounds (vs 24 for full SHA-3). The reduced-round design yields ~2× throughput over SHAKE128 while maintaining 128-bit security. No external competitor implementations are available for comparison.
-
-On Apple M4, KT128 XOF delivers approximately the same throughput as SHAKE128 XOF at bulk sizes despite the halved round count, suggesting the M4 execution units are not bottlenecked by round count alone. KT256 follows the same architecture with the narrower cSHAKE256 rate and is marginally slower.
-
-**Key observations:**
-- **KT128** ~1.3× faster than SHAKE128 at 128 B; near parity at 128 KiB (permutation throughput parity)
-- **KT256** slightly slower than KT128 due to narrower rate (1088-bit vs 1344-bit)
-- No BouncyCastle or OS comparison available; zero-allocation
-
-#### KT128
-[!INCLUDE[](xof-kt128.md)]
-
-#### KT256
-[!INCLUDE[](xof-kt256.md)]
-
----
-
-### TurboSHAKE Family (XOF)
-
-TurboSHAKE128 and TurboSHAKE256 (IETF RFC 9562) use 12 Keccak rounds with a simplified padding scheme and expose a plain XOF interface with no tree-hashing overhead. They are the simplest and fastest Keccak-family XOFs available in this library.
-
-On Apple M4, TurboSHAKE128 XOF is the **fastest Keccak-based XOF** at all sizes: ~1.37× faster than SHAKE128 at bulk sizes and leads KT128 across all payload sizes. No external competitor implementations are available.
-
-**Key observations:**
-- Fastest Keccak XOF in this library on Apple M4
-- TurboSHAKE128: 1344-bit rate with 12 rounds
-- TurboSHAKE256: 1088-bit rate with 12 rounds; slightly slower
-- Zero-allocation; no OS or BouncyCastle comparison available
-
-#### TurboSHAKE128
-[!INCLUDE[](xof-turboshake128.md)]
-
-#### TurboSHAKE256
-[!INCLUDE[](xof-turboshake256.md)]
-
----
-
-### BLAKE3 (XOF)
-
-BLAKE3 XOF uses the same ChaCha-based compression function but extends the tree hashing mode to produce output of arbitrary length. The output is derived by repeatedly doubling the output chaining value from the root node. This differs from the fixed-output benchmark, which stops at the root hash.
-
-The **Native (Rust)** implementation via `blake3-dotnet` is dramatically faster — ~7× at 128 B and ~5.8× at 128 KiB — because the Rust output-reader uses parallel chunk generation for the extended output, exploiting multiple NEON lanes simultaneously. The CryptoHives `Neon` path squeezed output sequentially. **Managed** is 1.3× faster than BouncyCastle at 128 B and ~1.3× at 128 KiB.
-
-**Key observations:**
-- **Native**: ~7× faster than Managed at 128 B XOF; ~5.8× at 128 KiB
-- **Managed**: ~1.3× faster than BouncyCastle across all sizes; zero allocation
-- **BouncyCastle**: Slowest XOF option; allocates 56 B per call regardless of output size
-- BLAKE3 XOF output is deterministic given key and context — suitable for KDF and stream encryption
-
-[!INCLUDE[](xof-blake3.md)]
-
----
-
-### Ascon-XOF128
-
-Ascon-XOF128 (NIST Lightweight Cryptography standard 2023) is the XOF variant of the Ascon family using the same 320-bit permutation as Ascon-Hash256. It uses a 128-bit rate, requiring a full 12-round permutation call per 16 bytes of input or output — making it inherently slower than SHAKE/BLAKE XOFs for large outputs.
-
-On Apple M4, the CryptoHives Managed implementation is **~43% faster than BouncyCastle** across all sizes — consistent with the fixed-output Ascon-Hash256 advantage. Zero allocation on both paths.
-
-**Key observations:**
-- **Managed**: ~43% faster than BouncyCastle at all sizes; zero-allocation
-- Throughput ~3× slower than SHAKE128 at 128 KiB due to the narrow rate (128-bit vs 1344-bit)
-- Optimized for memory-constrained environments, not bulk throughput
-
-[!INCLUDE[](xof-asconxof128.md)]

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kalyna-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kalyna-cbc-128.md
@@ -1,25 +1,25 @@
-﻿| Description                                   | TestDataSize | Mean         | Error      | StdDev     | Allocated |
-|---------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |    10.647 μs |  0.0055 μs |  0.0051 μs |         - |
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |    11.408 μs |  0.0098 μs |  0.0092 μs |     872 B |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |     5.975 μs |  0.0042 μs |  0.0037 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |     9.549 μs |  0.0290 μs |  0.0271 μs |         - |
-|                                               |              |              |            |            |           |
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |    72.699 μs |  0.0466 μs |  0.0436 μs |     872 B |
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |    76.134 μs |  0.0295 μs |  0.0246 μs |         - |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |    33.716 μs |  0.0235 μs |  0.0196 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |    68.741 μs |  0.2542 μs |  0.2122 μs |         - |
-|                                               |              |              |            |            |           |
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |   562.699 μs |  0.4849 μs |  0.4299 μs |     872 B |
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |   601.110 μs |  0.4157 μs |  0.3685 μs |         - |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |   255.848 μs |  0.1039 μs |  0.0868 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |   542.563 μs |  2.6695 μs |  2.4971 μs |         - |
-|                                               |              |              |            |            |           |
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        | 8,970.836 μs | 10.4951 μs |  8.7639 μs |     872 B |
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        | 9,627.223 μs | 28.4509 μs | 26.6130 μs |         - |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        | 4,066.766 μs |  2.7149 μs |  2.1196 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        | 8,725.221 μs | 23.8144 μs | 22.2760 μs |         - |
+﻿| Description                                   | TestDataSize | Mean           | Error       | StdDev      | Allocated |
+|---------------------------------------------- |------------- |---------------:|------------:|------------:|----------:|
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |       798.7 ns |     2.73 ns |     2.42 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |     2,425.8 ns |     3.09 ns |     2.89 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |       396.9 ns |     1.65 ns |     1.38 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |     1,252.7 ns |     4.56 ns |     4.26 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |     5,642.5 ns |    17.20 ns |    16.09 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |    15,461.9 ns |    12.48 ns |    11.06 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |     2,886.6 ns |    12.01 ns |    11.23 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |     7,027.7 ns |    23.47 ns |    21.96 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |    44,408.3 ns |   191.24 ns |   169.53 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |   119,614.1 ns |    88.51 ns |    78.46 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |    22,890.9 ns |    66.92 ns |    62.60 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |    53,186.3 ns |   138.19 ns |   122.50 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        |   706,983.4 ns | 2,881.66 ns | 2,249.81 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        | 1,902,282.2 ns | 2,917.11 ns | 2,277.49 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        |   369,102.1 ns |   873.51 ns |   817.08 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        |   847,327.0 ns | 1,901.11 ns | 1,685.28 ns |     872 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kalyna-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kalyna-cbc-256.md
@@ -1,25 +1,25 @@
-﻿| Description                                   | TestDataSize | Mean          | Error      | StdDev     | Allocated |
-|---------------------------------------------- |------------- |--------------:|-----------:|-----------:|----------:|
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |     14.626 μs |  0.0066 μs |  0.0058 μs |         - |
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |     15.499 μs |  0.0101 μs |  0.0085 μs |    1112 B |
-|                                               |              |               |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |      8.032 μs |  0.0112 μs |  0.0105 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |     13.069 μs |  0.0179 μs |  0.0149 μs |         - |
-|                                               |              |               |            |            |           |
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |     99.783 μs |  0.0840 μs |  0.0702 μs |    1112 B |
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |    104.872 μs |  0.0364 μs |  0.0340 μs |         - |
-|                                               |              |               |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |     46.026 μs |  0.0245 μs |  0.0205 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |     93.874 μs |  0.1473 μs |  0.1378 μs |         - |
-|                                               |              |               |            |            |           |
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |    774.335 μs |  0.3431 μs |  0.3210 μs |    1112 B |
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |    827.234 μs |  0.5608 μs |  0.5246 μs |         - |
-|                                               |              |               |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |    350.339 μs |  0.2128 μs |  0.1886 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |    739.892 μs |  1.8743 μs |  1.5652 μs |         - |
-|                                               |              |               |            |            |           |
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        |  2,628.318 μs | 31.0346 μs | 59.7931 μs |    1112 B |
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        | 13,231.225 μs |  6.8742 μs |  6.0938 μs |         - |
-|                                               |              |               |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        |  5,569.737 μs |  3.4409 μs |  2.8733 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        | 11,931.521 μs | 19.3520 μs | 17.1551 μs |         - |
+﻿| Description                                   | TestDataSize | Mean           | Error       | StdDev      | Allocated |
+|---------------------------------------------- |------------- |---------------:|------------:|------------:|----------:|
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |     1,128.5 ns |     3.81 ns |     3.18 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |     3,303.0 ns |     2.29 ns |     2.03 ns |    1112 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |       554.4 ns |     2.69 ns |     2.10 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |     1,699.2 ns |     3.38 ns |     2.82 ns |    1112 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |     8,036.5 ns |    31.95 ns |    24.95 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |    21,269.0 ns |    16.57 ns |    12.93 ns |    1112 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |     4,010.7 ns |    17.98 ns |    15.01 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |     9,626.2 ns |    19.34 ns |    17.15 ns |    1112 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |    63,253.3 ns |   244.99 ns |   229.16 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |   164,958.9 ns |   155.34 ns |   145.31 ns |    1112 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |    31,585.1 ns |   164.62 ns |   145.93 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |    73,257.0 ns |   363.53 ns |   322.26 ns |    1112 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        | 1,005,918.9 ns | 3,380.08 ns | 3,161.73 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        | 2,628,385.5 ns | 1,761.63 ns | 1,375.36 ns |    1112 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        |   506,426.0 ns | 1,779.25 ns | 1,577.25 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        | 1,164,810.6 ns | 4,690.58 ns | 4,158.07 ns |    1112 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/keccak256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/keccak256.md
@@ -1,19 +1,25 @@
 ﻿| Description                                      | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 128B         |     175.6 ns |   0.19 ns |   0.17 ns |         - |
-| TryComputeHash · Keccak-256 · BouncyCastle       | 128B         |     179.4 ns |   0.75 ns |   0.67 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Arm64  | 128B         |     157.3 ns |   0.24 ns |   0.20 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 128B         |     166.9 ns |   0.15 ns |   0.12 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle       | 128B         |     178.3 ns |   0.29 ns |   0.22 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · BouncyCastle       | 137B         |     325.2 ns |   1.14 ns |   0.95 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 137B         |     541.5 ns |   9.19 ns |   8.60 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Arm64  | 137B         |     305.8 ns |   0.89 ns |   0.74 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle       | 137B         |     324.9 ns |   1.03 ns |   0.86 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 137B         |     331.1 ns |   6.38 ns |   6.83 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · BouncyCastle       | 1KB          |   1,275.3 ns |   5.47 ns |   4.85 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 1KB          |   1,378.2 ns |  10.59 ns |   8.84 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Arm64  | 1KB          |   1,232.5 ns |   2.49 ns |   2.33 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle       | 1KB          |   1,267.5 ns |   2.82 ns |   2.50 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 1KB          |   1,286.0 ns |   3.37 ns |   3.15 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · BouncyCastle       | 1025B        |   1,264.6 ns |   5.69 ns |   4.44 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 1025B        |   1,371.8 ns |   3.51 ns |   3.29 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Arm64  | 1025B        |   1,221.1 ns |   1.44 ns |   1.28 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle       | 1025B        |   1,268.5 ns |   4.55 ns |   4.04 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 1025B        |   1,286.1 ns |   3.21 ns |   2.84 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · BouncyCastle       | 8KB          |   9,513.4 ns |  26.32 ns |  21.98 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 8KB          |   9,944.7 ns |  59.76 ns |  52.97 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Arm64  | 8KB          |   9,269.5 ns |  10.51 ns |   9.31 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle       | 8KB          |   9,519.3 ns |  39.63 ns |  35.13 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 8KB          |   9,740.7 ns |  28.12 ns |  24.93 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · BouncyCastle       | 128KB        | 149,685.7 ns | 526.60 ns | 466.82 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 128KB        | 153,761.7 ns | 210.88 ns | 186.94 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Arm64  | 128KB        | 147,398.1 ns | 113.86 ns | 100.93 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle       | 128KB        | 150,396.5 ns | 549.22 ns | 458.62 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar | 128KB        | 153,848.1 ns | 245.89 ns | 217.97 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/keccak384.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/keccak384.md
@@ -1,19 +1,25 @@
 ﻿| Description                                      | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · Keccak-384 · BouncyCastle       | 128B         |     326.0 ns |   3.96 ns |   3.31 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 128B         |     447.2 ns |   3.54 ns |   2.77 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Arm64  | 128B         |     302.7 ns |   0.24 ns |   0.20 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 128B         |     320.5 ns |   0.65 ns |   0.54 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle       | 128B         |     327.2 ns |   2.57 ns |   2.28 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-384 · BouncyCastle       | 137B         |     331.5 ns |   1.77 ns |   1.48 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 137B         |     437.5 ns |   3.44 ns |   2.88 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Arm64  | 137B         |     307.3 ns |   0.39 ns |   0.33 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 137B         |     321.3 ns |   0.81 ns |   0.76 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle       | 137B         |     324.3 ns |   0.62 ns |   0.55 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-384 · BouncyCastle       | 1KB          |   1,556.5 ns |   5.00 ns |   4.43 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 1KB          |   1,624.6 ns |   2.53 ns |   2.24 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Arm64  | 1KB          |   1,528.8 ns |   2.72 ns |   2.12 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle       | 1KB          |   1,566.6 ns |   6.17 ns |   5.47 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 1KB          |   1,593.9 ns |   2.19 ns |   2.05 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-384 · BouncyCastle       | 1025B        |   1,559.3 ns |   8.01 ns |   7.50 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 1025B        |   1,625.1 ns |   1.52 ns |   1.19 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Arm64  | 1025B        |   1,530.2 ns |   1.04 ns |   0.92 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle       | 1025B        |   1,574.6 ns |   6.88 ns |   6.10 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 1025B        |   1,595.7 ns |   3.03 ns |   2.83 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-384 · BouncyCastle       | 8KB          |  12,160.5 ns | 113.10 ns | 105.80 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 8KB          |  12,550.3 ns |  16.53 ns |  15.46 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Arm64  | 8KB          |  12,051.4 ns |   7.42 ns |   6.58 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle       | 8KB          |  12,163.8 ns |  30.93 ns |  27.42 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 8KB          |  12,493.0 ns |  12.34 ns |  10.30 ns |         - |
 |                                                  |              |              |           |           |           |
-| TryComputeHash · Keccak-384 · BouncyCastle       | 128KB        | 193,521.9 ns | 472.27 ns | 441.76 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 128KB        | 199,780.6 ns | 479.93 ns | 448.92 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Arm64  | 128KB        | 192,623.2 ns | 165.46 ns | 129.18 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle       | 128KB        | 195,703.5 ns | 953.01 ns | 795.80 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar | 128KB        | 200,130.6 ns | 221.99 ns | 196.79 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/keccak512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/keccak512.md
@@ -1,19 +1,25 @@
-﻿| Description                                      | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · Keccak-512 · BouncyCastle       | 128B         |     327.5 ns |     5.48 ns |     4.86 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 128B         |     340.6 ns |     1.01 ns |     0.95 ns |         - |
-|                                                  |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · BouncyCastle       | 137B         |     326.2 ns |     0.71 ns |     0.56 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 137B         |     327.7 ns |     0.53 ns |     0.49 ns |         - |
-|                                                  |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · BouncyCastle       | 1KB          |   2,311.5 ns |     2.80 ns |     2.18 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 1KB          |   2,472.8 ns |     4.85 ns |     4.53 ns |         - |
-|                                                  |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · BouncyCastle       | 1025B        |   2,300.4 ns |     7.16 ns |     6.35 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 1025B        |   2,476.5 ns |     6.99 ns |     5.46 ns |         - |
-|                                                  |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · BouncyCastle       | 8KB          |  17,430.5 ns |    58.13 ns |    51.53 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 8KB          |  17,943.4 ns |    15.84 ns |    14.82 ns |         - |
-|                                                  |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · BouncyCastle       | 128KB        | 278,051.6 ns | 2,124.22 ns | 1,987.00 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 128KB        | 286,319.3 ns |   491.01 ns |   435.26 ns |         - |
+﻿| Description                                      | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
+| TryComputeHash · Keccak-512 · CryptoHives-Arm64  | 128B         |     307.1 ns |   0.32 ns |   0.25 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 128B         |     320.3 ns |   0.52 ns |   0.49 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle       | 128B         |     335.7 ns |   1.27 ns |   1.13 ns |         - |
+|                                                  |              |              |           |           |           |
+| TryComputeHash · Keccak-512 · CryptoHives-Arm64  | 137B         |     303.2 ns |   0.58 ns |   0.48 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 137B         |     319.1 ns |   1.03 ns |   0.96 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle       | 137B         |     326.7 ns |   1.12 ns |   1.05 ns |         - |
+|                                                  |              |              |           |           |           |
+| TryComputeHash · Keccak-512 · CryptoHives-Arm64  | 1KB          |   2,270.7 ns |   2.30 ns |   2.04 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle       | 1KB          |   2,340.3 ns |  18.47 ns |  17.28 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 1KB          |   2,368.3 ns |   3.71 ns |   3.29 ns |         - |
+|                                                  |              |              |           |           |           |
+| TryComputeHash · Keccak-512 · CryptoHives-Arm64  | 1025B        |   2,299.3 ns |   4.56 ns |   4.05 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle       | 1025B        |   2,318.3 ns |   9.56 ns |   8.94 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 1025B        |   2,369.7 ns |   6.94 ns |   6.50 ns |         - |
+|                                                  |              |              |           |           |           |
+| TryComputeHash · Keccak-512 · CryptoHives-Arm64  | 8KB          |  17,202.5 ns |  19.01 ns |  16.85 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle       | 8KB          |  17,422.1 ns |  70.30 ns |  62.32 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 8KB          |  17,950.7 ns |  33.82 ns |  29.98 ns |         - |
+|                                                  |              |              |           |           |           |
+| TryComputeHash · Keccak-512 · CryptoHives-Arm64  | 128KB        | 274,909.7 ns | 309.68 ns | 258.60 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle       | 128KB        | 277,699.9 ns | 898.75 ns | 750.50 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar | 128KB        | 286,797.2 ns | 362.25 ns | 321.13 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kt128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kt128.md
@@ -1,13 +1,19 @@
 ﻿| Description                                 | TestDataSize | Mean        | Error     | StdDev    | Allocated |
 |-------------------------------------------- |------------- |------------:|----------:|----------:|----------:|
-| TryComputeHash · KT128 · CryptoHives-Scalar | 128B         |    144.2 ns |   0.70 ns |   0.65 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar | 128B         |    102.6 ns |   1.72 ns |   1.61 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Arm64  | 128B         |    103.4 ns |   0.28 ns |   0.24 ns |         - |
 |                                             |              |             |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar | 137B         |    136.7 ns |   0.81 ns |   0.67 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar | 137B         |    100.2 ns |   0.78 ns |   0.65 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Arm64  | 137B         |    102.4 ns |   1.28 ns |   1.20 ns |         - |
 |                                             |              |             |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar | 1KB          |    740.2 ns |   1.24 ns |   1.10 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Arm64  | 1KB          |    601.8 ns |   8.52 ns |   7.97 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar | 1KB          |    636.6 ns |  10.00 ns |   9.36 ns |         - |
 |                                             |              |             |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar | 1025B        |    749.2 ns |   1.22 ns |   1.08 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Arm64  | 1025B        |    599.2 ns |   1.59 ns |   1.25 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar | 1025B        |    637.2 ns |   9.80 ns |   8.69 ns |         - |
 |                                             |              |             |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar | 8KB          |  5,162.9 ns |  29.82 ns |  26.43 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Arm64  | 8KB          |  4,588.6 ns |  66.42 ns |  58.88 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar | 8KB          |  4,771.9 ns |  21.87 ns |  18.26 ns |         - |
 |                                             |              |             |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar | 128KB        | 72,060.4 ns | 145.50 ns | 136.10 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Arm64  | 128KB        | 69,227.4 ns | 133.44 ns | 118.29 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar | 128KB        | 71,122.6 ns | 132.93 ns | 111.00 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kt256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/kt256.md
@@ -1,13 +1,19 @@
-﻿| Description                                 | TestDataSize | Mean        | Error       | StdDev      | Allocated |
-|-------------------------------------------- |------------- |------------:|------------:|------------:|----------:|
-| TryComputeHash · KT256 · CryptoHives-Scalar | 128B         |    140.2 ns |     0.22 ns |     0.17 ns |         - |
-|                                             |              |             |             |             |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar | 137B         |    333.6 ns |     0.70 ns |     0.65 ns |         - |
-|                                             |              |             |             |             |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar | 1KB          |    783.1 ns |     1.71 ns |     1.52 ns |         - |
-|                                             |              |             |             |             |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar | 1025B        |    790.4 ns |     0.63 ns |     0.56 ns |         - |
-|                                             |              |             |             |             |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar | 8KB          |  5,951.3 ns |    21.51 ns |    20.12 ns |         - |
-|                                             |              |             |             |             |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar | 128KB        | 90,190.6 ns | 1,291.53 ns | 1,208.10 ns |         - |
+﻿| Description                                 | TestDataSize | Mean         | Error      | StdDev     | Allocated |
+|-------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
+| TryComputeHash · KT256 · CryptoHives-Arm64  | 128B         |     96.93 ns |   0.338 ns |   0.283 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar | 128B         |    100.93 ns |   0.805 ns |   0.629 ns |         - |
+|                                             |              |              |            |            |           |
+| TryComputeHash · KT256 · CryptoHives-Arm64  | 137B         |    173.71 ns |   0.214 ns |   0.167 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar | 137B         |    186.66 ns |   0.908 ns |   0.805 ns |         - |
+|                                             |              |              |            |            |           |
+| TryComputeHash · KT256 · CryptoHives-Arm64  | 1KB          |    678.11 ns |   0.835 ns |   0.652 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar | 1KB          |    710.71 ns |   1.323 ns |   1.033 ns |         - |
+|                                             |              |              |            |            |           |
+| TryComputeHash · KT256 · CryptoHives-Arm64  | 1025B        |    677.40 ns |   1.879 ns |   1.569 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar | 1025B        |    709.34 ns |   0.678 ns |   0.566 ns |         - |
+|                                             |              |              |            |            |           |
+| TryComputeHash · KT256 · CryptoHives-Arm64  | 8KB          |  5,494.82 ns |  43.804 ns |  36.578 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar | 8KB          |  5,699.26 ns |  54.532 ns |  48.341 ns |         - |
+|                                             |              |              |            |            |           |
+| TryComputeHash · KT256 · CryptoHives-Arm64  | 128KB        | 83,881.20 ns | 182.055 ns | 142.137 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar | 128KB        | 87,553.90 ns | 278.551 ns | 217.474 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-224.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-224.md
@@ -1,19 +1,25 @@
-﻿| Description                                    | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|----------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · SHA3-224 · BouncyCastle       | 128B         |     182.6 ns |   1.01 ns |   0.84 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 128B         |     189.8 ns |   3.54 ns |   3.79 ns |         - |
-|                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 137B         |     175.4 ns |   0.65 ns |   0.61 ns |         - |
-| TryComputeHash · SHA3-224 · BouncyCastle       | 137B         |     185.1 ns |   1.56 ns |   1.22 ns |         - |
-|                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-224 · BouncyCastle       | 1KB          |   1,280.8 ns |  10.13 ns |   8.46 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 1KB          |   1,514.0 ns |  26.32 ns |  23.33 ns |         - |
-|                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-224 · BouncyCastle       | 1025B        |   1,276.8 ns |   4.86 ns |   4.31 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 1025B        |   1,496.7 ns |   8.95 ns |   7.48 ns |         - |
-|                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-224 · BouncyCastle       | 8KB          |   8,901.4 ns |  16.96 ns |  13.24 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 8KB          |   9,186.3 ns |  38.51 ns |  32.16 ns |         - |
-|                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-224 · BouncyCastle       | 128KB        | 142,676.7 ns | 793.26 ns | 662.40 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 128KB        | 146,232.5 ns | 639.22 ns | 499.06 ns |         - |
+﻿| Description                                    | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|----------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · SHA3-224 · CryptoHives-Arm64  | 128B         |     157.8 ns |     0.19 ns |     0.18 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 128B         |     167.7 ns |     0.21 ns |     0.18 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle       | 128B         |     178.9 ns |     0.73 ns |     0.61 ns |         - |
+|                                                |              |              |             |             |           |
+| TryComputeHash · SHA3-224 · CryptoHives-Arm64  | 137B         |     157.7 ns |     0.45 ns |     0.40 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 137B         |     167.6 ns |     1.27 ns |     1.06 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle       | 137B         |     178.7 ns |     0.25 ns |     0.20 ns |         - |
+|                                                |              |              |             |             |           |
+| TryComputeHash · SHA3-224 · CryptoHives-Arm64  | 1KB          |   1,213.2 ns |     1.94 ns |     1.51 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle       | 1KB          |   1,274.6 ns |     7.62 ns |     7.13 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 1KB          |   1,293.3 ns |     1.70 ns |     1.42 ns |         - |
+|                                                |              |              |             |             |           |
+| TryComputeHash · SHA3-224 · CryptoHives-Arm64  | 1025B        |   1,211.4 ns |     3.81 ns |     3.38 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle       | 1025B        |   1,272.0 ns |     3.98 ns |     3.73 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 1025B        |   1,292.2 ns |     4.57 ns |     3.81 ns |         - |
+|                                                |              |              |             |             |           |
+| TryComputeHash · SHA3-224 · CryptoHives-Arm64  | 8KB          |   8,563.2 ns |    14.18 ns |    13.26 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle       | 8KB          |   9,072.8 ns |     8.63 ns |     6.74 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 8KB          |   9,120.8 ns |    37.42 ns |    35.01 ns |         - |
+|                                                |              |              |             |             |           |
+| TryComputeHash · SHA3-224 · CryptoHives-Arm64  | 128KB        | 136,885.6 ns |   332.11 ns |   294.41 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle       | 128KB        | 142,734.5 ns | 1,287.69 ns | 1,204.51 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar | 128KB        | 146,222.5 ns |   351.63 ns |   328.92 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-256.md
@@ -1,19 +1,25 @@
 ﻿| Description                                    | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |----------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 128B         |     175.3 ns |   0.87 ns |   0.73 ns |         - |
-| TryComputeHash · SHA3-256 · BouncyCastle       | 128B         |     179.6 ns |   1.19 ns |   0.99 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Arm64  | 128B         |     157.3 ns |   0.11 ns |   0.10 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 128B         |     167.4 ns |   0.19 ns |   0.17 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle       | 128B         |     178.6 ns |   0.57 ns |   0.53 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-256 · BouncyCastle       | 137B         |     329.8 ns |   4.06 ns |   3.39 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 137B         |     544.1 ns |   6.15 ns |   5.75 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Arm64  | 137B         |     304.5 ns |   0.64 ns |   0.60 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 137B         |     324.5 ns |   0.17 ns |   0.15 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle       | 137B         |     329.1 ns |   0.20 ns |   0.15 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-256 · BouncyCastle       | 1KB          |   1,276.7 ns |   4.85 ns |   4.30 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 1KB          |   1,382.2 ns |   9.21 ns |   8.16 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Arm64  | 1KB          |   1,224.1 ns |   2.01 ns |   1.78 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle       | 1KB          |   1,271.9 ns |   4.65 ns |   4.12 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 1KB          |   1,286.0 ns |   1.96 ns |   1.64 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-256 · BouncyCastle       | 1025B        |   1,278.1 ns |   8.29 ns |   6.93 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 1025B        |   1,376.3 ns |   5.04 ns |   4.47 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Arm64  | 1025B        |   1,225.7 ns |   1.80 ns |   1.50 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle       | 1025B        |   1,272.6 ns |   2.98 ns |   2.65 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 1025B        |   1,286.7 ns |   3.64 ns |   3.41 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-256 · BouncyCastle       | 8KB          |   9,575.2 ns |  65.20 ns |  60.99 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 8KB          |   9,935.0 ns |  27.08 ns |  21.14 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Arm64  | 8KB          |   9,293.1 ns |  11.72 ns |  10.96 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle       | 8KB          |   9,493.1 ns |  19.27 ns |  16.09 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 8KB          |   9,729.3 ns |  29.39 ns |  27.49 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHA3-256 · BouncyCastle       | 128KB        | 149,969.4 ns | 331.02 ns | 293.44 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 128KB        | 153,762.1 ns | 199.17 ns | 166.31 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Arm64  | 128KB        | 146,939.1 ns | 169.90 ns | 150.61 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle       | 128KB        | 150,547.7 ns | 964.49 ns | 855.00 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar | 128KB        | 154,209.1 ns | 210.44 ns | 186.55 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-384.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-384.md
@@ -1,19 +1,25 @@
 ﻿| Description                                    | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |----------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA3-384 · BouncyCastle       | 128B         |     325.2 ns |     0.61 ns |     0.51 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 128B         |     446.5 ns |     2.85 ns |     2.53 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Arm64  | 128B         |     303.3 ns |     0.27 ns |     0.25 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 128B         |     321.2 ns |     0.34 ns |     0.30 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle       | 128B         |     326.5 ns |     0.60 ns |     0.50 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · BouncyCastle       | 137B         |     326.6 ns |     2.20 ns |     1.95 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 137B         |     436.6 ns |     3.23 ns |     2.69 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Arm64  | 137B         |     303.4 ns |     0.70 ns |     0.62 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 137B         |     321.8 ns |     0.34 ns |     0.32 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle       | 137B         |     327.7 ns |     1.06 ns |     0.99 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · BouncyCastle       | 1KB          |   1,589.1 ns |    31.44 ns |    38.62 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 1KB          |   1,629.0 ns |     7.26 ns |     6.07 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Arm64  | 1KB          |   1,532.9 ns |     1.04 ns |     0.97 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle       | 1KB          |   1,569.7 ns |     7.00 ns |     6.21 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 1KB          |   1,597.7 ns |     1.64 ns |     1.37 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · BouncyCastle       | 1025B        |   1,611.9 ns |    31.10 ns |    29.09 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 1025B        |   1,638.5 ns |    11.50 ns |     9.60 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Arm64  | 1025B        |   1,524.1 ns |     2.66 ns |     2.36 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle       | 1025B        |   1,571.5 ns |     6.69 ns |     5.93 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 1025B        |   1,597.9 ns |     2.79 ns |     2.61 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · BouncyCastle       | 8KB          |  12,390.6 ns |   179.78 ns |   140.36 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 8KB          |  12,801.6 ns |   245.29 ns |   272.64 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Arm64  | 8KB          |  11,983.8 ns |    66.25 ns |    58.73 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle       | 8KB          |  12,096.0 ns |    53.81 ns |    50.34 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 8KB          |  12,514.0 ns |    56.46 ns |    52.81 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · BouncyCastle       | 128KB        | 194,480.9 ns | 1,584.04 ns | 1,481.71 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 128KB        | 202,294.2 ns | 2,587.47 ns | 2,160.65 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Arm64  | 128KB        | 190,722.7 ns |   122.61 ns |   102.38 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle       | 128KB        | 197,501.0 ns | 2,827.13 ns | 2,506.18 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar | 128KB        | 200,429.5 ns |   654.87 ns |   546.85 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-512.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/sha3-512.md
@@ -1,19 +1,25 @@
 ﻿| Description                                    | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |----------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA3-512 · BouncyCastle       | 128B         |     331.5 ns |     6.38 ns |     4.98 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 128B         |     341.4 ns |     1.85 ns |     1.44 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Arm64  | 128B         |     304.9 ns |     0.32 ns |     0.28 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 128B         |     321.4 ns |     1.00 ns |     0.78 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle       | 128B         |     331.9 ns |     3.85 ns |     3.60 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 137B         |     331.0 ns |     5.93 ns |     5.26 ns |         - |
-| TryComputeHash · SHA3-512 · BouncyCastle       | 137B         |     331.1 ns |     4.63 ns |     4.10 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Arm64  | 137B         |     306.7 ns |     3.94 ns |     3.50 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 137B         |     320.9 ns |     0.62 ns |     0.55 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle       | 137B         |     331.0 ns |     3.34 ns |     3.13 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · BouncyCastle       | 1KB          |   2,326.5 ns |    22.79 ns |    19.03 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 1KB          |   2,508.3 ns |    48.89 ns |    43.34 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Arm64  | 1KB          |   2,302.5 ns |    33.31 ns |    31.15 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle       | 1KB          |   2,336.8 ns |    26.80 ns |    25.07 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 1KB          |   2,370.5 ns |     6.91 ns |     5.39 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · BouncyCastle       | 1025B        |   2,341.5 ns |    26.46 ns |    22.09 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 1025B        |   2,483.5 ns |    24.23 ns |    18.91 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Arm64  | 1025B        |   2,276.4 ns |    10.08 ns |     8.42 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle       | 1025B        |   2,335.9 ns |    22.64 ns |    21.18 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 1025B        |   2,372.9 ns |     4.39 ns |     3.67 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · BouncyCastle       | 8KB          |  17,967.6 ns |    79.09 ns |    66.04 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 8KB          |  18,038.5 ns |    47.53 ns |    42.14 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Arm64  | 8KB          |  17,393.5 ns |   178.69 ns |   167.15 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle       | 8KB          |  17,529.9 ns |   177.85 ns |   166.36 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 8KB          |  18,075.7 ns |   116.74 ns |   109.19 ns |         - |
 |                                                |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · BouncyCastle       | 128KB        | 281,162.9 ns | 2,124.03 ns | 1,773.66 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 128KB        | 286,932.4 ns |   371.66 ns |   329.46 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Arm64  | 128KB        | 276,375.8 ns | 2,372.12 ns | 1,980.83 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle       | 128KB        | 281,097.9 ns | 1,865.41 ns | 1,744.90 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar | 128KB        | 291,445.9 ns | 3,671.93 ns | 3,434.73 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/shake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/shake128.md
@@ -1,19 +1,25 @@
 ﻿| Description                                    | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |----------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · SHAKE128 · BouncyCastle       | 128B         |     179.7 ns |   1.19 ns |   1.12 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 128B         |     260.2 ns |   3.44 ns |   2.87 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Arm64  | 128B         |     158.5 ns |   0.60 ns |   0.50 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 128B         |     171.4 ns |   2.35 ns |   2.20 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle       | 128B         |     181.0 ns |   1.00 ns |   0.84 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHAKE128 · BouncyCastle       | 137B         |     179.7 ns |   1.03 ns |   0.91 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 137B         |     244.0 ns |   1.07 ns |   1.00 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Arm64  | 137B         |     158.6 ns |   0.71 ns |   0.60 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 137B         |     171.7 ns |   1.94 ns |   1.82 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle       | 137B         |     180.5 ns |   0.58 ns |   0.45 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHAKE128 · BouncyCastle       | 1KB          |   1,117.6 ns |   4.77 ns |   4.23 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 1KB          |   1,407.8 ns |   7.42 ns |   6.57 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Arm64  | 1KB          |   1,072.8 ns |  12.08 ns |  11.30 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle       | 1KB          |   1,138.1 ns |  20.45 ns |  19.13 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 1KB          |   1,149.4 ns |  11.92 ns |  11.15 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHAKE128 · BouncyCastle       | 1025B        |   1,115.5 ns |   3.09 ns |   2.58 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 1025B        |   1,404.2 ns |   6.25 ns |   5.85 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Arm64  | 1025B        |   1,067.6 ns |   0.55 ns |   0.48 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 1025B        |   1,136.5 ns |   7.37 ns |   6.54 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle       | 1025B        |   1,148.3 ns |  13.98 ns |  13.08 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHAKE128 · BouncyCastle       | 8KB          |   7,683.0 ns |  34.79 ns |  30.84 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 8KB          |   7,976.4 ns |  26.07 ns |  24.38 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Arm64  | 8KB          |   7,456.4 ns |  74.10 ns |  69.31 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle       | 8KB          |   7,795.7 ns |  98.13 ns |  91.79 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 8KB          |   7,942.2 ns | 102.64 ns |  96.01 ns |         - |
 |                                                |              |              |           |           |           |
-| TryComputeHash · SHAKE128 · BouncyCastle       | 128KB        | 122,490.6 ns | 216.49 ns | 169.02 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 128KB        | 125,088.4 ns | 311.63 ns | 291.50 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Arm64  | 128KB        | 118,130.5 ns | 114.91 ns | 107.49 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle       | 128KB        | 123,132.5 ns | 356.45 ns | 333.42 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar | 128KB        | 125,449.4 ns | 626.37 ns | 523.05 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/shake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/shake256.md
@@ -1,19 +1,25 @@
-﻿| Description                                    | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|----------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHAKE256 · BouncyCastle       | 128B         |     177.8 ns |     1.13 ns |     1.00 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 128B         |     249.7 ns |     3.81 ns |     3.56 ns |         - |
-|                                                |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · BouncyCastle       | 137B         |     326.8 ns |     1.21 ns |     1.13 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 137B         |     608.2 ns |     4.86 ns |     4.54 ns |         - |
-|                                                |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · BouncyCastle       | 1KB          |   1,265.8 ns |     6.64 ns |     5.88 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 1KB          |   1,440.2 ns |     6.76 ns |     5.99 ns |         - |
-|                                                |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · BouncyCastle       | 1025B        |   1,265.1 ns |     4.61 ns |     4.09 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 1025B        |   1,436.1 ns |     5.11 ns |     4.78 ns |         - |
-|                                                |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · BouncyCastle       | 8KB          |   9,445.8 ns |    37.22 ns |    32.99 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 8KB          |   9,977.7 ns |     9.19 ns |     7.67 ns |         - |
-|                                                |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · BouncyCastle       | 128KB        | 150,434.6 ns | 1,378.54 ns | 1,289.49 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 128KB        | 154,855.2 ns | 1,075.21 ns |   953.15 ns |         - |
+﻿| Description                                    | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|----------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
+| TryComputeHash · SHAKE256 · CryptoHives-Arm64  | 128B         |     156.8 ns |   0.12 ns |   0.10 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 128B         |     170.3 ns |   0.22 ns |   0.19 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle       | 128B         |     179.6 ns |   0.86 ns |   0.67 ns |         - |
+|                                                |              |              |           |           |           |
+| TryComputeHash · SHAKE256 · CryptoHives-Arm64  | 137B         |     314.6 ns |   6.04 ns |   6.20 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle       | 137B         |     331.7 ns |   5.69 ns |   6.32 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 137B         |     333.6 ns |   6.53 ns |   8.26 ns |         - |
+|                                                |              |              |           |           |           |
+| TryComputeHash · SHAKE256 · CryptoHives-Arm64  | 1KB          |   1,224.8 ns |   9.86 ns |   8.24 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 1KB          |   1,288.6 ns |   2.16 ns |   1.69 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle       | 1KB          |   1,301.6 ns |   4.47 ns |   3.49 ns |         - |
+|                                                |              |              |           |           |           |
+| TryComputeHash · SHAKE256 · CryptoHives-Arm64  | 1025B        |   1,218.6 ns |   1.32 ns |   1.24 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 1025B        |   1,288.0 ns |   2.84 ns |   2.65 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle       | 1025B        |   1,300.9 ns |   2.76 ns |   2.45 ns |         - |
+|                                                |              |              |           |           |           |
+| TryComputeHash · SHAKE256 · CryptoHives-Arm64  | 8KB          |   9,286.8 ns |  11.57 ns |  10.25 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle       | 8KB          |   9,492.8 ns |  32.86 ns |  30.74 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 8KB          |   9,728.2 ns |  17.76 ns |  15.74 ns |         - |
+|                                                |              |              |           |           |           |
+| TryComputeHash · SHAKE256 · CryptoHives-Arm64  | 128KB        | 146,779.2 ns | 238.13 ns | 211.10 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle       | 128KB        | 149,803.9 ns | 924.86 ns | 772.30 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar | 128KB        | 153,747.4 ns | 209.09 ns | 195.59 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/turboshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/turboshake128.md
@@ -1,25 +1,37 @@
-﻿| Description                                            | TestDataSize | Mean        | Error    | StdDev   | Allocated |
-|------------------------------------------------------- |------------- |------------:|---------:|---------:|----------:|
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 128B         |    184.3 ns |  1.96 ns |  1.74 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 137B         |    170.2 ns |  2.07 ns |  1.93 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 1KB          |    901.2 ns |  8.26 ns |  7.73 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 1025B        |    893.2 ns |  9.47 ns |  8.39 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 8KB          |  4,291.8 ns |  6.14 ns |  5.75 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 128KB        | 67,376.0 ns | 75.85 ns | 70.95 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 128B         |    224.3 ns |  4.20 ns |  4.31 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 137B         |    209.5 ns |  4.20 ns |  4.50 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 1KB          |    939.0 ns |  7.38 ns |  6.91 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 1025B        |    934.6 ns |  8.82 ns |  7.82 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 8KB          |  4,379.4 ns |  9.94 ns |  8.82 ns |         - |
-|                                                        |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 128KB        | 67,236.0 ns | 70.95 ns | 62.89 ns |         - |
+﻿| Description                                            | TestDataSize | Mean         | Error        | StdDev       | Allocated |
+|------------------------------------------------------- |------------- |-------------:|-------------:|-------------:|----------:|
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Arm64  | 128B         |     92.64 ns |     1.626 ns |     1.441 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 128B         |     95.25 ns |     0.141 ns |     0.110 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Arm64  | 137B         |     91.31 ns |     0.488 ns |     0.433 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 137B         |     95.43 ns |     0.880 ns |     0.735 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Arm64  | 1KB          |    590.08 ns |     7.656 ns |     6.393 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 1KB          |    615.26 ns |     8.589 ns |     7.172 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Arm64  | 1025B        |    586.61 ns |     0.762 ns |     0.676 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 1025B        |    619.10 ns |    10.408 ns |    13.162 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Arm64  | 8KB          |  4,044.47 ns |    48.493 ns |    42.987 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 8KB          |  4,237.82 ns |    33.918 ns |    30.068 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Arm64  | 128KB        | 65,424.95 ns | 1,269.427 ns | 1,461.874 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar | 128KB        | 67,091.23 ns |   282.341 ns |   235.767 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Arm64  | 128B         |     91.42 ns |     0.308 ns |     0.240 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 128B         |     95.87 ns |     0.474 ns |     0.443 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Arm64  | 137B         |     91.21 ns |     0.377 ns |     0.315 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 137B         |     95.75 ns |     0.720 ns |     0.638 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Arm64  | 1KB          |    584.87 ns |     0.677 ns |     0.528 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 1KB          |    612.88 ns |     1.490 ns |     1.244 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Arm64  | 1025B        |    585.00 ns |     0.987 ns |     0.825 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 1025B        |    614.80 ns |     0.999 ns |     0.886 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Arm64  | 8KB          |  4,105.47 ns |     3.710 ns |     3.098 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 8KB          |  4,215.29 ns |     8.172 ns |     6.824 ns |         - |
+|                                                        |              |              |              |              |           |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Arm64  | 128KB        | 64,162.79 ns |   187.619 ns |   146.481 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar | 128KB        | 67,503.29 ns |   438.546 ns |   366.206 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/turboshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/turboshake256.md
@@ -1,13 +1,19 @@
-﻿| Description                                         | TestDataSize | Mean        | Error    | StdDev   | Allocated |
-|---------------------------------------------------- |------------- |------------:|---------:|---------:|----------:|
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 128B         |    175.0 ns |  3.47 ns |  5.69 ns |         - |
-|                                                     |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 137B         |    464.3 ns |  9.11 ns |  8.52 ns |         - |
-|                                                     |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 1KB          |    887.2 ns |  5.15 ns |  4.82 ns |         - |
-|                                                     |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 1025B        |    847.0 ns |  9.08 ns |  7.09 ns |         - |
-|                                                     |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 8KB          |  5,379.8 ns | 27.45 ns | 25.68 ns |         - |
-|                                                     |              |             |          |          |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 128KB        | 81,742.6 ns | 60.43 ns | 53.57 ns |         - |
+﻿| Description                                         | TestDataSize | Mean         | Error      | StdDev     | Allocated |
+|---------------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Arm64  | 128B         |     89.83 ns |   0.108 ns |   0.084 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 128B         |     94.40 ns |   0.179 ns |   0.159 ns |         - |
+|                                                     |              |              |            |            |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Arm64  | 137B         |    171.44 ns |   0.951 ns |   0.742 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 137B         |    178.63 ns |   0.420 ns |   0.328 ns |         - |
+|                                                     |              |              |            |            |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Arm64  | 1KB          |    669.07 ns |   1.584 ns |   1.237 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 1KB          |    696.55 ns |   1.939 ns |   1.719 ns |         - |
+|                                                     |              |              |            |            |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Arm64  | 1025B        |    670.40 ns |   1.788 ns |   1.493 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 1025B        |    692.86 ns |   0.863 ns |   0.721 ns |         - |
+|                                                     |              |              |            |            |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Arm64  | 8KB          |  5,036.00 ns |  14.722 ns |  13.051 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 8KB          |  5,205.14 ns |  19.761 ns |  18.485 ns |         - |
+|                                                     |              |              |            |            |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Arm64  | 128KB        | 80,726.10 ns | 743.523 ns | 620.875 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar | 128KB        | 82,358.96 ns | 377.127 ns | 294.436 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-blake3.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-blake3.md
@@ -1,17 +1,17 @@
 ﻿| Description                                 | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |-------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128B         |   1.641 μs | 0.0033 μs | 0.0030 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128B         |   8.997 μs | 0.0475 μs | 0.0444 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128B         |  11.582 μs | 0.0401 μs | 0.0356 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128B         |   1.643 μs | 0.0056 μs | 0.0053 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128B         |   8.963 μs | 0.0476 μs | 0.0445 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128B         |  11.587 μs | 0.0369 μs | 0.0327 μs |      56 B |
 |                                             |              |            |           |           |           |
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 1KB          |   2.266 μs | 0.0045 μs | 0.0042 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 1KB          |  12.502 μs | 0.0375 μs | 0.0314 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 1KB          |  16.572 μs | 0.0842 μs | 0.0746 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 1KB          |   2.273 μs | 0.0104 μs | 0.0097 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 1KB          |  12.444 μs | 0.0446 μs | 0.0417 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 1KB          |  16.572 μs | 0.0622 μs | 0.0582 μs |      56 B |
 |                                             |              |            |           |           |           |
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 8KB          |   7.285 μs | 0.0071 μs | 0.0063 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 8KB          |  40.677 μs | 0.2871 μs | 0.2545 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 8KB          |  53.862 μs | 0.6764 μs | 0.5648 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 8KB          |   7.312 μs | 0.0153 μs | 0.0143 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 8KB          |  40.892 μs | 0.3356 μs | 0.3140 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 8KB          |  53.690 μs | 0.1873 μs | 0.1752 μs |      56 B |
 |                                             |              |            |           |           |           |
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128KB        |  93.105 μs | 0.3192 μs | 0.2492 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128KB        | 525.042 μs | 6.4389 μs | 5.3768 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128KB        | 686.699 μs | 3.1645 μs | 2.6425 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128KB        |  93.569 μs | 0.3721 μs | 0.3480 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128KB        | 525.172 μs | 2.7830 μs | 2.6032 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128KB        | 686.210 μs | 2.5021 μs | 2.3405 μs |      56 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-cshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-cshake128.md
@@ -1,13 +1,17 @@
-﻿| Description                                    | TestDataSize | Mean       | Error     | StdDev    | Median     | Allocated |
-|----------------------------------------------- |------------- |-----------:|----------:|----------:|-----------:|----------:|
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128B         |   2.082 μs | 0.0181 μs | 0.0151 μs |   2.082 μs |         - |
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128B         |   2.358 μs | 0.0459 μs | 0.0596 μs |   2.324 μs |         - |
-|                                                |              |            |           |           |            |           |
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 1KB          |   3.264 μs | 0.0083 μs | 0.0069 μs |   3.265 μs |    1152 B |
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 1KB          |   3.876 μs | 0.0042 μs | 0.0039 μs |   3.876 μs |         - |
-|                                                |              |            |           |           |            |           |
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 8KB          |  10.073 μs | 0.0170 μs | 0.0151 μs |  10.068 μs |    9216 B |
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 8KB          |  15.632 μs | 0.1368 μs | 0.1213 μs |  15.635 μs |         - |
-|                                                |              |            |           |           |            |           |
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128KB        | 133.216 μs | 1.3104 μs | 1.0943 μs | 132.869 μs |  149760 B |
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128KB        | 216.171 μs | 0.2724 μs | 0.2127 μs | 216.183 μs |         - |
+﻿| Description                                    | TestDataSize | Mean       | Error     | StdDev    | Allocated |
+|----------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Arm64  | 128B         |   1.982 μs | 0.0014 μs | 0.0013 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128B         |   2.078 μs | 0.0069 μs | 0.0065 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128B         |   2.133 μs | 0.0058 μs | 0.0052 μs |         - |
+|                                                |              |            |           |           |           |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Arm64  | 1KB          |   2.848 μs | 0.0026 μs | 0.0021 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 1KB          |   3.060 μs | 0.0032 μs | 0.0030 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 1KB          |   3.150 μs | 0.0060 μs | 0.0053 μs |    1152 B |
+|                                                |              |            |           |           |           |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Arm64  | 8KB          |   8.856 μs | 0.0146 μs | 0.0122 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 8KB          |   9.566 μs | 0.0147 μs | 0.0130 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 8KB          |  10.301 μs | 0.0352 μs | 0.0294 μs |    9216 B |
+|                                                |              |            |           |           |           |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Arm64  | 128KB        | 113.493 μs | 0.0670 μs | 0.0523 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128KB        | 123.085 μs | 0.3629 μs | 0.2833 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128KB        | 132.800 μs | 0.3830 μs | 0.3198 μs |  149760 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-cshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-cshake256.md
@@ -1,13 +1,17 @@
 ﻿| Description                                    | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |----------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128B         |   2.511 μs | 0.0128 μs | 0.0114 μs |         - |
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128B         |   2.797 μs | 0.0239 μs | 0.0212 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Arm64  | 128B         |   2.424 μs | 0.0066 μs | 0.0051 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128B         |   2.540 μs | 0.0137 μs | 0.0114 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128B         |   2.606 μs | 0.0043 μs | 0.0036 μs |         - |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 1KB          |   3.684 μs | 0.0114 μs | 0.0101 μs |    1120 B |
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 1KB          |   4.480 μs | 0.0055 μs | 0.0049 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Arm64  | 1KB          |   3.432 μs | 0.0076 μs | 0.0067 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 1KB          |   3.692 μs | 0.0158 μs | 0.0140 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 1KB          |   3.739 μs | 0.0081 μs | 0.0063 μs |    1120 B |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 8KB          |  12.306 μs | 0.0216 μs | 0.0192 μs |    9600 B |
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 8KB          |  17.684 μs | 0.0243 μs | 0.0227 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Arm64  | 8KB          |  10.933 μs | 0.0064 μs | 0.0054 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 8KB          |  11.858 μs | 0.0157 μs | 0.0139 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 8KB          |  12.575 μs | 0.0566 μs | 0.0442 μs |    9600 B |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128KB        | 161.864 μs | 1.7823 μs | 1.4883 μs |  154080 B |
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128KB        | 242.995 μs | 0.2432 μs | 0.2275 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Arm64  | 128KB        | 139.921 μs | 0.6292 μs | 0.5254 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128KB        | 151.094 μs | 0.2513 μs | 0.1962 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128KB        | 162.368 μs | 0.2855 μs | 0.2531 μs |  154080 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-kt128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-kt128.md
@@ -1,9 +1,13 @@
-﻿| Description                                | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128B         |   1.366 μs | 0.0020 μs | 0.0018 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 1KB          |   2.482 μs | 0.0052 μs | 0.0049 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 8KB          |  10.997 μs | 0.0119 μs | 0.0099 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128KB        | 157.875 μs | 0.1381 μs | 0.1292 μs |         - |
+﻿| Description                                | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · KT128 · CryptoHives-Arm64  | 128B         |  1.107 μs | 0.0010 μs | 0.0008 μs |         - |
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128B         |  1.159 μs | 0.0037 μs | 0.0029 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT128 · CryptoHives-Arm64  | 1KB          |  1.555 μs | 0.0082 μs | 0.0069 μs |         - |
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 1KB          |  1.649 μs | 0.0033 μs | 0.0028 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT128 · CryptoHives-Arm64  | 8KB          |  4.702 μs | 0.0039 μs | 0.0031 μs |         - |
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 8KB          |  4.974 μs | 0.0086 μs | 0.0067 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT128 · CryptoHives-Arm64  | 128KB        | 59.436 μs | 0.1779 μs | 0.1485 μs |         - |
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128KB        | 63.357 μs | 1.0746 μs | 1.0052 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-kt256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-kt256.md
@@ -1,9 +1,13 @@
-﻿| Description                                | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128B         |   1.598 μs | 0.0022 μs | 0.0020 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 1KB          |   2.778 μs | 0.0115 μs | 0.0089 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 8KB          |  12.194 μs | 0.1996 μs | 0.1867 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128KB        | 172.041 μs | 1.1054 μs | 0.8630 μs |         - |
+﻿| Description                                | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · KT256 · CryptoHives-Arm64  | 128B         |  1.365 μs | 0.0066 μs | 0.0052 μs |         - |
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128B         |  1.403 μs | 0.0010 μs | 0.0009 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT256 · CryptoHives-Arm64  | 1KB          |  1.883 μs | 0.0031 μs | 0.0024 μs |         - |
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 1KB          |  1.964 μs | 0.0014 μs | 0.0011 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT256 · CryptoHives-Arm64  | 8KB          |  5.881 μs | 0.0940 μs | 0.0880 μs |         - |
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 8KB          |  6.123 μs | 0.0099 μs | 0.0088 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT256 · CryptoHives-Arm64  | 128KB        | 72.510 μs | 0.1350 μs | 0.1054 μs |         - |
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128KB        | 77.320 μs | 0.5075 μs | 0.4238 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-shake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-shake128.md
@@ -1,13 +1,17 @@
 ﻿| Description                                   | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |---------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128B         |   2.065 μs | 0.0051 μs | 0.0043 μs |         - |
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128B         |   2.326 μs | 0.0073 μs | 0.0065 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Arm64  | 128B         |   1.986 μs | 0.0022 μs | 0.0021 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128B         |   2.077 μs | 0.0034 μs | 0.0030 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128B         |   2.115 μs | 0.0051 μs | 0.0043 μs |         - |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 1KB          |   3.092 μs | 0.0108 μs | 0.0101 μs |    1152 B |
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 1KB          |   3.883 μs | 0.0075 μs | 0.0067 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Arm64  | 1KB          |   2.853 μs | 0.0010 μs | 0.0008 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 1KB          |   3.032 μs | 0.0034 μs | 0.0032 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 1KB          |   3.095 μs | 0.0071 μs | 0.0067 μs |    1152 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 8KB          |  10.055 μs | 0.0162 μs | 0.0143 μs |    9216 B |
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 8KB          |  15.487 μs | 0.0248 μs | 0.0207 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Arm64  | 8KB          |   8.868 μs | 0.0067 μs | 0.0063 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 8KB          |   9.669 μs | 0.0739 μs | 0.0691 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 8KB          |  10.236 μs | 0.1461 μs | 0.1367 μs |    9216 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128KB        | 132.467 μs | 0.4133 μs | 0.3664 μs |  149760 B |
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128KB        | 216.277 μs | 0.3966 μs | 0.3710 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Arm64  | 128KB        | 113.853 μs | 0.1921 μs | 0.1796 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128KB        | 121.735 μs | 0.1942 μs | 0.1622 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128KB        | 133.084 μs | 0.4793 μs | 0.3742 μs |  149760 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-shake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-shake256.md
@@ -1,13 +1,17 @@
 ﻿| Description                                   | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |---------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128B         |   2.525 μs | 0.0185 μs | 0.0173 μs |         - |
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128B         |   2.784 μs | 0.0062 μs | 0.0048 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Arm64  | 128B         |   2.423 μs | 0.0025 μs | 0.0023 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128B         |   2.528 μs | 0.0167 μs | 0.0156 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128B         |   2.577 μs | 0.0072 μs | 0.0063 μs |         - |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 1KB          |   3.768 μs | 0.0263 μs | 0.0246 μs |    1120 B |
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 1KB          |   4.477 μs | 0.0072 μs | 0.0064 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Arm64  | 1KB          |   3.427 μs | 0.0027 μs | 0.0024 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 1KB          |   3.648 μs | 0.0039 μs | 0.0035 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 1KB          |   3.754 μs | 0.0082 μs | 0.0073 μs |    1120 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 8KB          |  12.436 μs | 0.0734 μs | 0.0613 μs |    9600 B |
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 8KB          |  17.888 μs | 0.2295 μs | 0.2254 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Arm64  | 8KB          |  10.933 μs | 0.0063 μs | 0.0053 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 8KB          |  11.730 μs | 0.0188 μs | 0.0176 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 8KB          |  12.515 μs | 0.0292 μs | 0.0273 μs |    9600 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128KB        | 161.436 μs | 2.6453 μs | 2.5981 μs |  154080 B |
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128KB        | 244.918 μs | 1.7002 μs | 1.5072 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Arm64  | 128KB        | 139.331 μs | 0.1048 μs | 0.0929 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128KB        | 149.582 μs | 0.2771 μs | 0.2314 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128KB        | 161.799 μs | 0.2561 μs | 0.2271 μs |  154080 B |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-turboshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-turboshake128.md
@@ -1,9 +1,13 @@
-﻿| Description                                        | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|--------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128B         |   1.355 μs | 0.0020 μs | 0.0019 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 1KB          |   2.469 μs | 0.0040 μs | 0.0037 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 8KB          |  10.964 μs | 0.0058 μs | 0.0054 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128KB        | 157.365 μs | 0.1392 μs | 0.1302 μs |         - |
+﻿| Description                                        | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|--------------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Arm64  | 128B         |  1.077 μs | 0.0026 μs | 0.0022 μs |         - |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128B         |  1.142 μs | 0.0031 μs | 0.0028 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Arm64  | 1KB          |  1.530 μs | 0.0068 μs | 0.0057 μs |         - |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 1KB          |  1.626 μs | 0.0088 μs | 0.0078 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Arm64  | 8KB          |  4.675 μs | 0.0041 μs | 0.0032 μs |         - |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 8KB          |  4.947 μs | 0.0240 μs | 0.0224 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Arm64  | 128KB        | 59.443 μs | 0.1956 μs | 0.1633 μs |         - |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128KB        | 62.704 μs | 0.2105 μs | 0.1757 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-turboshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/macos-arm64-apple-m4/xof-turboshake256.md
@@ -1,9 +1,13 @@
-﻿| Description                                        | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|--------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128B         |   1.587 μs | 0.0032 μs | 0.0028 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 1KB          |   2.775 μs | 0.0018 μs | 0.0016 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 8KB          |  12.075 μs | 0.0032 μs | 0.0029 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128KB        | 171.019 μs | 0.1887 μs | 0.1673 μs |         - |
+﻿| Description                                        | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|--------------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Arm64  | 128B         |  1.331 μs | 0.0072 μs | 0.0060 μs |         - |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128B         |  1.397 μs | 0.0053 μs | 0.0042 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Arm64  | 1KB          |  1.860 μs | 0.0088 μs | 0.0083 μs |         - |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 1KB          |  1.955 μs | 0.0083 μs | 0.0078 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Arm64  | 8KB          |  5.803 μs | 0.0247 μs | 0.0231 μs |         - |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 8KB          |  6.107 μs | 0.0047 μs | 0.0041 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Arm64  | 128KB        | 72.501 μs | 0.0344 μs | 0.0322 μs |         - |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128KB        | 76.983 μs | 0.0673 μs | 0.0562 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-cbc-128.md
@@ -1,41 +1,41 @@
-﻿| Description                                | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 128B         |      43.17 ns |     0.181 ns |     0.161 ns |         - |
-| Decrypt · AES-128-CBC (OS)                 | 128B         |     243.43 ns |     1.785 ns |     1.582 ns |     128 B |
-| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 128B         |     440.90 ns |     1.557 ns |     1.456 ns |         - |
-| Decrypt · AES-128-CBC (BouncyCastle)       | 128B         |     687.82 ns |     3.306 ns |     3.093 ns |     832 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 128B         |     177.58 ns |     3.294 ns |     3.081 ns |         - |
-| Encrypt · AES-128-CBC (OS)                 | 128B         |     290.90 ns |     5.064 ns |     5.629 ns |     128 B |
-| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 128B         |     452.48 ns |     5.147 ns |     4.563 ns |         - |
-| Encrypt · AES-128-CBC (BouncyCastle)       | 128B         |     628.09 ns |     5.175 ns |     4.587 ns |     832 B |
-|                                            |              |               |              |              |           |
-| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 1KB          |     228.41 ns |     0.542 ns |     0.507 ns |         - |
-| Decrypt · AES-128-CBC (OS)                 | 1KB          |     301.76 ns |     2.199 ns |     2.057 ns |     128 B |
-| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 1KB          |   3,101.18 ns |    21.408 ns |    20.025 ns |         - |
-| Decrypt · AES-128-CBC (BouncyCastle)       | 1KB          |   3,873.68 ns |    33.008 ns |    30.876 ns |     832 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-128-CBC (OS)                 | 1KB          |     702.95 ns |     2.720 ns |     2.545 ns |     128 B |
-| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 1KB          |   1,176.11 ns |     3.232 ns |     2.865 ns |         - |
-| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 1KB          |   3,138.37 ns |    11.263 ns |     9.984 ns |         - |
-| Encrypt · AES-128-CBC (BouncyCastle)       | 1KB          |   3,709.17 ns |    23.366 ns |    21.856 ns |     832 B |
-|                                            |              |               |              |              |           |
-| Decrypt · AES-128-CBC (OS)                 | 8KB          |     732.49 ns |     4.807 ns |     4.261 ns |     128 B |
-| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 8KB          |   1,555.19 ns |     8.042 ns |     7.522 ns |         - |
-| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 8KB          |  24,417.64 ns |   155.710 ns |   145.651 ns |         - |
-| Decrypt · AES-128-CBC (BouncyCastle)       | 8KB          |  29,020.13 ns |   182.137 ns |   161.460 ns |     832 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-128-CBC (OS)                 | 8KB          |   4,248.04 ns |    30.043 ns |    26.632 ns |     128 B |
-| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 8KB          |   9,449.34 ns |    55.769 ns |    49.438 ns |         - |
-| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 8KB          |  24,657.81 ns |    73.621 ns |    65.263 ns |         - |
-| Encrypt · AES-128-CBC (BouncyCastle)       | 8KB          |  28,512.77 ns |   209.950 ns |   186.115 ns |     832 B |
-|                                            |              |               |              |              |           |
-| Decrypt · AES-128-CBC (OS)                 | 128KB        |   8,261.76 ns |    28.680 ns |    26.827 ns |     128 B |
-| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 128KB        |  24,533.06 ns |   125.368 ns |   117.269 ns |         - |
-| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 128KB        | 390,174.43 ns | 2,100.277 ns | 1,964.601 ns |         - |
-| Decrypt · AES-128-CBC (BouncyCastle)       | 128KB        | 459,847.82 ns | 2,134.402 ns | 1,892.092 ns |     832 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-128-CBC (OS)                 | 128KB        |  65,167.59 ns |   443.417 ns |   370.273 ns |     128 B |
-| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 128KB        | 147,034.93 ns |   227.566 ns |   177.669 ns |         - |
-| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 128KB        | 395,207.30 ns | 1,834.482 ns | 1,626.220 ns |         - |
-| Encrypt · AES-128-CBC (BouncyCastle)       | 128KB        | 450,755.05 ns | 2,709.060 ns | 2,534.056 ns |     832 B |
+﻿| Description                                | TestDataSize | Mean          | Error        | StdDev        | Allocated |
+|------------------------------------------- |------------- |--------------:|-------------:|--------------:|----------:|
+| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 128B         |      46.29 ns |     0.865 ns |      0.809 ns |         - |
+| Decrypt · AES-128-CBC (OS)                 | 128B         |     267.96 ns |     5.322 ns |      5.465 ns |     128 B |
+| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 128B         |     472.49 ns |     9.205 ns |      8.610 ns |         - |
+| Decrypt · AES-128-CBC (BouncyCastle)       | 128B         |     746.98 ns |    14.534 ns |     15.551 ns |     832 B |
+|                                            |              |               |              |               |           |
+| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 128B         |     179.76 ns |     3.476 ns |      2.903 ns |         - |
+| Encrypt · AES-128-CBC (OS)                 | 128B         |     297.25 ns |     2.923 ns |      2.440 ns |     128 B |
+| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 128B         |     544.00 ns |     9.066 ns |      8.481 ns |         - |
+| Encrypt · AES-128-CBC (BouncyCastle)       | 128B         |     676.90 ns |    10.596 ns |      9.911 ns |     832 B |
+|                                            |              |               |              |               |           |
+| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 1KB          |     218.10 ns |     3.329 ns |      3.114 ns |         - |
+| Decrypt · AES-128-CBC (OS)                 | 1KB          |     318.93 ns |     4.463 ns |      3.956 ns |     128 B |
+| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 1KB          |   3,327.49 ns |    64.734 ns |     57.385 ns |         - |
+| Decrypt · AES-128-CBC (BouncyCastle)       | 1KB          |   4,153.21 ns |    80.542 ns |    110.246 ns |     832 B |
+|                                            |              |               |              |               |           |
+| Encrypt · AES-128-CBC (OS)                 | 1KB          |     756.04 ns |    14.571 ns |     13.629 ns |     128 B |
+| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 1KB          |   1,227.17 ns |    23.998 ns |     32.849 ns |         - |
+| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 1KB          |   3,316.62 ns |    45.072 ns |     42.160 ns |         - |
+| Encrypt · AES-128-CBC (BouncyCastle)       | 1KB          |   3,969.28 ns |    74.556 ns |     76.563 ns |     832 B |
+|                                            |              |               |              |               |           |
+| Decrypt · AES-128-CBC (OS)                 | 8KB          |     787.69 ns |    15.408 ns |     15.133 ns |     128 B |
+| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 8KB          |   1,631.84 ns |    26.699 ns |     24.975 ns |         - |
+| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 8KB          |  25,913.09 ns |   370.545 ns |    346.608 ns |         - |
+| Decrypt · AES-128-CBC (BouncyCastle)       | 8KB          |  31,100.76 ns |   620.806 ns |    690.025 ns |     832 B |
+|                                            |              |               |              |               |           |
+| Encrypt · AES-128-CBC (OS)                 | 8KB          |   4,259.19 ns |    83.325 ns |    102.331 ns |     128 B |
+| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 8KB          |   9,469.91 ns |   130.696 ns |    115.858 ns |         - |
+| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 8KB          |  28,629.61 ns |   856.548 ns |  2,485.001 ns |         - |
+| Encrypt · AES-128-CBC (BouncyCastle)       | 8KB          |  30,377.40 ns |   586.129 ns |    548.265 ns |     832 B |
+|                                            |              |               |              |               |           |
+| Decrypt · AES-128-CBC (OS)                 | 128KB        |   8,831.08 ns |   151.807 ns |    134.573 ns |     128 B |
+| Decrypt · AES-128-CBC (CryptoHives-AES-NI) | 128KB        |  26,059.87 ns |   516.010 ns |    552.125 ns |         - |
+| Decrypt · AES-128-CBC (CryptoHives-Scalar) | 128KB        | 417,289.85 ns | 7,896.018 ns |  7,385.940 ns |         - |
+| Decrypt · AES-128-CBC (BouncyCastle)       | 128KB        | 494,379.46 ns | 9,452.536 ns | 10,885.554 ns |     832 B |
+|                                            |              |               |              |               |           |
+| Encrypt · AES-128-CBC (OS)                 | 128KB        |  64,719.45 ns | 1,059.299 ns |    939.041 ns |     128 B |
+| Encrypt · AES-128-CBC (CryptoHives-AES-NI) | 128KB        | 154,095.26 ns | 3,050.188 ns |  4,071.913 ns |         - |
+| Encrypt · AES-128-CBC (BouncyCastle)       | 128KB        | 480,607.72 ns | 6,161.056 ns |  5,763.056 ns |     832 B |
+| Encrypt · AES-128-CBC (CryptoHives-Scalar) | 128KB        | 491,958.31 ns | 8,633.671 ns |  9,942.549 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-cbc-256.md
@@ -1,41 +1,41 @@
-﻿| Description                                | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 128B         |      56.25 ns |     0.338 ns |     0.316 ns |         - |
-| Decrypt · AES-256-CBC (OS)                 | 128B         |     248.27 ns |     1.848 ns |     1.729 ns |     128 B |
-| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 128B         |     559.26 ns |     3.515 ns |     3.288 ns |         - |
-| Decrypt · AES-256-CBC (BouncyCastle)       | 128B         |     881.16 ns |    13.362 ns |    12.499 ns |    1024 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 128B         |     200.24 ns |     0.843 ns |     0.747 ns |         - |
-| Encrypt · AES-256-CBC (OS)                 | 128B         |     307.94 ns |     1.811 ns |     1.694 ns |     128 B |
-| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 128B         |     563.04 ns |     4.012 ns |     3.753 ns |         - |
-| Encrypt · AES-256-CBC (BouncyCastle)       | 128B         |     783.77 ns |     6.225 ns |     5.823 ns |    1024 B |
-|                                            |              |               |              |              |           |
-| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 1KB          |     293.29 ns |     0.583 ns |     0.545 ns |         - |
-| Decrypt · AES-256-CBC (OS)                 | 1KB          |     326.17 ns |     1.114 ns |     0.988 ns |     128 B |
-| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 1KB          |   3,938.90 ns |    14.716 ns |    13.766 ns |         - |
-| Decrypt · AES-256-CBC (BouncyCastle)       | 1KB          |   4,774.60 ns |    12.701 ns |    10.606 ns |    1024 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-256-CBC (OS)                 | 1KB          |     894.49 ns |     3.834 ns |     3.586 ns |     128 B |
-| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 1KB          |   1,385.28 ns |     5.744 ns |     5.373 ns |         - |
-| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 1KB          |   3,986.95 ns |    24.802 ns |    23.200 ns |         - |
-| Encrypt · AES-256-CBC (BouncyCastle)       | 1KB          |   4,714.87 ns |    23.306 ns |    21.800 ns |    1024 B |
-|                                            |              |               |              |              |           |
-| Decrypt · AES-256-CBC (OS)                 | 8KB          |     937.29 ns |     2.520 ns |     2.234 ns |     128 B |
-| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 8KB          |   2,183.52 ns |     5.979 ns |     5.593 ns |         - |
-| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 8KB          |  30,976.15 ns |   165.309 ns |   154.630 ns |         - |
-| Decrypt · AES-256-CBC (BouncyCastle)       | 8KB          |  35,917.27 ns |   128.397 ns |   120.103 ns |    1024 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-256-CBC (OS)                 | 8KB          |   5,841.92 ns |    24.041 ns |    21.311 ns |     128 B |
-| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 8KB          |  10,781.37 ns |    59.217 ns |    52.495 ns |         - |
-| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 8KB          |  31,377.28 ns |   225.441 ns |   199.848 ns |         - |
-| Encrypt · AES-256-CBC (BouncyCastle)       | 8KB          |  36,311.11 ns |   216.880 ns |   202.870 ns |    1024 B |
-|                                            |              |               |              |              |           |
-| Decrypt · AES-256-CBC (OS)                 | 128KB        |  11,218.70 ns |    23.120 ns |    21.627 ns |     128 B |
-| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 128KB        |  34,456.57 ns |    52.498 ns |    40.987 ns |         - |
-| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 128KB        | 499,034.39 ns | 2,373.491 ns | 2,220.165 ns |         - |
-| Decrypt · AES-256-CBC (BouncyCastle)       | 128KB        | 568,959.83 ns | 2,913.285 ns | 2,725.089 ns |    1024 B |
-|                                            |              |               |              |              |           |
-| Encrypt · AES-256-CBC (OS)                 | 128KB        |  90,573.99 ns |   364.180 ns |   322.836 ns |     128 B |
-| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 128KB        | 171,486.16 ns |   332.831 ns |   277.929 ns |         - |
-| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 128KB        | 505,301.05 ns | 2,744.895 ns | 2,567.576 ns |         - |
-| Encrypt · AES-256-CBC (BouncyCastle)       | 128KB        | 575,718.61 ns | 4,352.420 ns | 4,071.257 ns |    1024 B |
+﻿| Description                                | TestDataSize | Mean          | Error         | StdDev        | Median        | Allocated |
+|------------------------------------------- |------------- |--------------:|--------------:|--------------:|--------------:|----------:|
+| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 128B         |      60.13 ns |      0.842 ns |      0.703 ns |      60.36 ns |         - |
+| Decrypt · AES-256-CBC (OS)                 | 128B         |     286.39 ns |      5.573 ns |      7.992 ns |     285.44 ns |     128 B |
+| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 128B         |     613.96 ns |     11.111 ns |     11.411 ns |     614.87 ns |         - |
+| Decrypt · AES-256-CBC (BouncyCastle)       | 128B         |     988.14 ns |     19.769 ns |     46.984 ns |     972.03 ns |    1024 B |
+|                                            |              |               |               |               |               |           |
+| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 128B         |     213.88 ns |      4.113 ns |      4.040 ns |     213.53 ns |         - |
+| Encrypt · AES-256-CBC (OS)                 | 128B         |     360.80 ns |      7.045 ns |     20.212 ns |     353.51 ns |     128 B |
+| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 128B         |     608.13 ns |     11.523 ns |     12.808 ns |     607.21 ns |         - |
+| Encrypt · AES-256-CBC (BouncyCastle)       | 128B         |     902.38 ns |     17.950 ns |     47.601 ns |     886.57 ns |    1024 B |
+|                                            |              |               |               |               |               |           |
+| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 1KB          |     309.93 ns |      6.200 ns |      9.280 ns |     309.50 ns |         - |
+| Decrypt · AES-256-CBC (OS)                 | 1KB          |     357.34 ns |      6.547 ns |      5.112 ns |     355.88 ns |     128 B |
+| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 1KB          |   4,241.34 ns |     61.796 ns |     60.692 ns |   4,232.60 ns |         - |
+| Decrypt · AES-256-CBC (BouncyCastle)       | 1KB          |   5,144.83 ns |    100.978 ns |     84.321 ns |   5,128.68 ns |    1024 B |
+|                                            |              |               |               |               |               |           |
+| Encrypt · AES-256-CBC (OS)                 | 1KB          |     938.54 ns |     15.059 ns |     14.790 ns |     933.62 ns |     128 B |
+| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 1KB          |   1,455.39 ns |     28.455 ns |     38.950 ns |   1,464.82 ns |         - |
+| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 1KB          |   4,565.57 ns |    168.485 ns |    480.698 ns |   4,356.88 ns |         - |
+| Encrypt · AES-256-CBC (BouncyCastle)       | 1KB          |   5,079.85 ns |     97.531 ns |    126.817 ns |   5,064.02 ns |    1024 B |
+|                                            |              |               |               |               |               |           |
+| Decrypt · AES-256-CBC (OS)                 | 8KB          |     985.52 ns |     15.230 ns |     12.717 ns |     986.67 ns |     128 B |
+| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 8KB          |   2,369.06 ns |     46.685 ns |    107.267 ns |   2,338.56 ns |         - |
+| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 8KB          |  33,194.96 ns |    478.317 ns |    373.438 ns |  33,244.41 ns |         - |
+| Decrypt · AES-256-CBC (BouncyCastle)       | 8KB          |  41,461.30 ns |  1,191.603 ns |  3,360.938 ns |  40,848.87 ns |    1024 B |
+|                                            |              |               |               |               |               |           |
+| Encrypt · AES-256-CBC (OS)                 | 8KB          |   5,840.01 ns |     88.780 ns |     78.701 ns |   5,828.20 ns |     128 B |
+| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 8KB          |  11,159.26 ns |    217.158 ns |    232.357 ns |  11,014.81 ns |         - |
+| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 8KB          |  33,833.43 ns |    666.347 ns |    912.103 ns |  33,654.73 ns |         - |
+| Encrypt · AES-256-CBC (BouncyCastle)       | 8KB          |  38,529.05 ns |    732.790 ns |    752.522 ns |  38,366.07 ns |    1024 B |
+|                                            |              |               |               |               |               |           |
+| Decrypt · AES-256-CBC (OS)                 | 128KB        |  11,859.28 ns |    236.544 ns |    253.100 ns |  11,776.66 ns |     128 B |
+| Decrypt · AES-256-CBC (CryptoHives-AES-NI) | 128KB        |  35,613.34 ns |    247.756 ns |    231.751 ns |  35,664.48 ns |         - |
+| Decrypt · AES-256-CBC (CryptoHives-Scalar) | 128KB        | 535,220.51 ns | 10,621.034 ns | 10,431.275 ns | 533,173.10 ns |         - |
+| Decrypt · AES-256-CBC (BouncyCastle)       | 128KB        | 602,660.32 ns | 11,308.283 ns | 12,569.127 ns | 601,370.80 ns |    1024 B |
+|                                            |              |               |               |               |               |           |
+| Encrypt · AES-256-CBC (OS)                 | 128KB        |  90,424.66 ns |  1,315.210 ns |  1,165.899 ns |  90,202.11 ns |     128 B |
+| Encrypt · AES-256-CBC (CryptoHives-AES-NI) | 128KB        | 175,511.06 ns |  2,019.578 ns |  1,790.303 ns | 175,025.89 ns |         - |
+| Encrypt · AES-256-CBC (CryptoHives-Scalar) | 128KB        | 538,863.93 ns |  9,357.779 ns | 10,012.719 ns | 536,745.31 ns |         - |
+| Encrypt · AES-256-CBC (BouncyCastle)       | 128KB        | 612,879.74 ns | 11,075.703 ns | 10,360.220 ns | 613,046.44 ns |    1024 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-ccm-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-ccm-128.md
@@ -1,33 +1,33 @@
-﻿| Description                                | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 128B         |     399.1 ns |     0.54 ns |     0.51 ns |         - |
-| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 128B         |     988.4 ns |     4.42 ns |     4.13 ns |         - |
-| Decrypt · AES-128-CCM (BouncyCastle)       | 128B         |   1,599.4 ns |    11.14 ns |     9.88 ns |    2424 B |
-|                                            |              |              |             |             |           |
-| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 128B         |     350.7 ns |     0.49 ns |     0.43 ns |         - |
-| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 128B         |     956.3 ns |     4.17 ns |     3.90 ns |         - |
-| Encrypt · AES-128-CCM (BouncyCastle)       | 128B         |   1,561.5 ns |    13.94 ns |    12.36 ns |    2464 B |
-|                                            |              |              |             |             |           |
-| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 1KB          |   2,281.6 ns |     3.96 ns |     3.70 ns |         - |
-| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 1KB          |   6,251.7 ns |    12.71 ns |    11.27 ns |         - |
-| Decrypt · AES-128-CCM (BouncyCastle)       | 1KB          |   7,998.5 ns |    42.92 ns |    40.14 ns |    2424 B |
-|                                            |              |              |             |             |           |
-| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 1KB          |   2,239.2 ns |     3.13 ns |     2.93 ns |         - |
-| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 1KB          |   6,207.7 ns |    11.41 ns |     9.53 ns |         - |
-| Encrypt · AES-128-CCM (BouncyCastle)       | 1KB          |   7,994.5 ns |    30.19 ns |    28.24 ns |    2464 B |
-|                                            |              |              |             |             |           |
-| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 8KB          |  17,480.9 ns |    33.36 ns |    31.20 ns |         - |
-| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 8KB          |  48,275.4 ns |   154.19 ns |   144.23 ns |         - |
-| Decrypt · AES-128-CCM (BouncyCastle)       | 8KB          |  58,976.9 ns |   253.61 ns |   237.23 ns |    2424 B |
-|                                            |              |              |             |             |           |
-| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 8KB          |  17,385.0 ns |    21.97 ns |    20.55 ns |         - |
-| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 8KB          |  48,211.8 ns |   233.97 ns |   218.86 ns |         - |
-| Encrypt · AES-128-CCM (BouncyCastle)       | 8KB          |  58,909.2 ns |   125.34 ns |   111.11 ns |    2464 B |
-|                                            |              |              |             |             |           |
-| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 128KB        | 277,037.5 ns |   518.83 ns |   485.32 ns |         - |
-| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 128KB        | 768,752.6 ns | 2,447.15 ns | 2,289.07 ns |         - |
-| Decrypt · AES-128-CCM (BouncyCastle)       | 128KB        | 933,584.1 ns | 3,067.61 ns | 2,869.44 ns |    2424 B |
-|                                            |              |              |             |             |           |
-| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 128KB        | 276,953.8 ns |   341.10 ns |   319.07 ns |         - |
-| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 128KB        | 770,092.3 ns | 1,219.94 ns | 1,081.44 ns |         - |
-| Encrypt · AES-128-CCM (BouncyCastle)       | 128KB        | 934,335.8 ns | 2,759.48 ns | 2,446.21 ns |    2464 B |
+﻿| Description                                | TestDataSize | Mean         | Error        | StdDev       | Allocated |
+|------------------------------------------- |------------- |-------------:|-------------:|-------------:|----------:|
+| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 128B         |     418.3 ns |      7.98 ns |      7.47 ns |         - |
+| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 128B         |   1,070.0 ns |     21.21 ns |     26.05 ns |         - |
+| Decrypt · AES-128-CCM (BouncyCastle)       | 128B         |   1,716.2 ns |     19.62 ns |     17.39 ns |    2424 B |
+|                                            |              |              |              |              |           |
+| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 128B         |     364.5 ns |      6.20 ns |      5.80 ns |         - |
+| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 128B         |   1,003.4 ns |     13.55 ns |     10.58 ns |         - |
+| Encrypt · AES-128-CCM (BouncyCastle)       | 128B         |   1,757.5 ns |     29.06 ns |     25.76 ns |    2464 B |
+|                                            |              |              |              |              |           |
+| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 1KB          |   2,336.5 ns |     17.23 ns |     16.11 ns |         - |
+| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 1KB          |   6,615.6 ns |     79.02 ns |     73.91 ns |         - |
+| Decrypt · AES-128-CCM (BouncyCastle)       | 1KB          |   8,636.4 ns |    168.74 ns |    225.26 ns |    2424 B |
+|                                            |              |              |              |              |           |
+| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 1KB          |   2,311.9 ns |     17.76 ns |     14.83 ns |         - |
+| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 1KB          |   6,596.1 ns |    125.07 ns |    116.99 ns |         - |
+| Encrypt · AES-128-CCM (BouncyCastle)       | 1KB          |   8,374.1 ns |     82.37 ns |     64.31 ns |    2464 B |
+|                                            |              |              |              |              |           |
+| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 8KB          |  17,996.4 ns |    358.47 ns |    317.78 ns |         - |
+| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 8KB          |  52,370.2 ns |  1,043.40 ns |  1,319.57 ns |         - |
+| Decrypt · AES-128-CCM (BouncyCastle)       | 8KB          |  62,866.2 ns |  1,246.30 ns |  1,620.55 ns |    2424 B |
+|                                            |              |              |              |              |           |
+| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 8KB          |  17,691.0 ns |    105.30 ns |     87.93 ns |         - |
+| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 8KB          |  52,439.0 ns |    975.09 ns |  1,366.94 ns |         - |
+| Encrypt · AES-128-CCM (BouncyCastle)       | 8KB          |  62,662.2 ns |  1,224.23 ns |  1,409.82 ns |    2464 B |
+|                                            |              |              |              |              |           |
+| Decrypt · AES-128-CCM (CryptoHives-AES-NI) | 128KB        | 286,031.8 ns |  5,501.22 ns |  5,649.35 ns |         - |
+| Decrypt · AES-128-CCM (CryptoHives-Scalar) | 128KB        | 817,828.2 ns | 14,740.85 ns | 13,067.38 ns |         - |
+| Decrypt · AES-128-CCM (BouncyCastle)       | 128KB        | 986,481.5 ns | 15,046.89 ns | 13,338.68 ns |    2424 B |
+|                                            |              |              |              |              |           |
+| Encrypt · AES-128-CCM (CryptoHives-AES-NI) | 128KB        | 281,794.7 ns |  2,710.52 ns |  2,263.41 ns |         - |
+| Encrypt · AES-128-CCM (CryptoHives-Scalar) | 128KB        | 819,973.2 ns | 15,710.71 ns | 16,133.74 ns |         - |
+| Encrypt · AES-128-CCM (BouncyCastle)       | 128KB        | 998,539.2 ns | 18,955.60 ns | 17,731.08 ns |    2464 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-ccm-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-ccm-256.md
@@ -1,33 +1,33 @@
-﻿| Description                                | TestDataSize | Mean           | Error       | StdDev      | Allocated |
-|------------------------------------------- |------------- |---------------:|------------:|------------:|----------:|
-| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 128B         |       446.6 ns |     0.69 ns |     0.65 ns |         - |
-| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 128B         |     1,256.2 ns |     4.73 ns |     4.42 ns |         - |
-| Decrypt · AES-256-CCM (BouncyCastle)       | 128B         |     1,942.7 ns |     8.74 ns |     8.18 ns |    2808 B |
-|                                            |              |                |             |             |           |
-| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 128B         |       412.9 ns |     0.57 ns |     0.53 ns |         - |
-| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 128B         |     1,214.2 ns |     4.22 ns |     3.94 ns |         - |
-| Encrypt · AES-256-CCM (BouncyCastle)       | 128B         |     1,903.9 ns |     6.58 ns |     6.15 ns |    2848 B |
-|                                            |              |                |             |             |           |
-| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 1KB          |     2,730.3 ns |     4.44 ns |     4.16 ns |         - |
-| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 1KB          |     7,981.7 ns |    27.43 ns |    24.32 ns |         - |
-| Decrypt · AES-256-CCM (BouncyCastle)       | 1KB          |    10,070.9 ns |    46.31 ns |    43.32 ns |    2808 B |
-|                                            |              |                |             |             |           |
-| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 1KB          |     2,694.5 ns |     3.04 ns |     2.70 ns |         - |
-| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 1KB          |     7,942.8 ns |    28.15 ns |    26.33 ns |         - |
-| Encrypt · AES-256-CCM (BouncyCastle)       | 1KB          |    10,012.1 ns |    39.86 ns |    37.29 ns |    2848 B |
-|                                            |              |                |             |             |           |
-| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 8KB          |    21,046.4 ns |    25.56 ns |    23.91 ns |         - |
-| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 8KB          |    61,670.3 ns |   237.07 ns |   210.16 ns |         - |
-| Decrypt · AES-256-CCM (BouncyCastle)       | 8KB          |    74,571.4 ns |   388.74 ns |   363.63 ns |    2808 B |
-|                                            |              |                |             |             |           |
-| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 8KB          |    20,973.4 ns |    25.71 ns |    24.05 ns |         - |
-| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 8KB          |    61,837.6 ns |   196.67 ns |   183.96 ns |         - |
-| Encrypt · AES-256-CCM (BouncyCastle)       | 8KB          |    74,922.0 ns |   312.18 ns |   292.01 ns |    2848 B |
-|                                            |              |                |             |             |           |
-| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 128KB        |   334,196.8 ns |   238.04 ns |   222.66 ns |         - |
-| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 128KB        |   985,478.8 ns | 5,687.86 ns | 5,320.43 ns |         - |
-| Decrypt · AES-256-CCM (BouncyCastle)       | 128KB        | 1,181,242.9 ns | 4,068.32 ns | 3,805.51 ns |    2808 B |
-|                                            |              |                |             |             |           |
-| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 128KB        |   334,282.6 ns |   366.60 ns |   342.91 ns |         - |
-| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 128KB        |   985,928.2 ns | 4,992.46 ns | 4,168.93 ns |         - |
-| Encrypt · AES-256-CCM (BouncyCastle)       | 128KB        | 1,182,530.1 ns | 4,696.97 ns | 4,393.55 ns |    2848 B |
+﻿| Description                                | TestDataSize | Mean           | Error        | StdDev       | Allocated |
+|------------------------------------------- |------------- |---------------:|-------------:|-------------:|----------:|
+| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 128B         |       457.8 ns |      1.62 ns |      1.35 ns |         - |
+| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 128B         |     1,326.0 ns |     16.03 ns |     15.00 ns |         - |
+| Decrypt · AES-256-CCM (BouncyCastle)       | 128B         |     2,085.4 ns |     28.00 ns |     26.19 ns |    2808 B |
+|                                            |              |                |              |              |           |
+| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 128B         |       419.2 ns |      1.67 ns |      1.39 ns |         - |
+| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 128B         |     1,272.7 ns |     13.48 ns |     12.61 ns |         - |
+| Encrypt · AES-256-CCM (BouncyCastle)       | 128B         |     2,060.1 ns |     34.88 ns |     37.32 ns |    2848 B |
+|                                            |              |                |              |              |           |
+| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 1KB          |     2,758.7 ns |      7.40 ns |      6.56 ns |         - |
+| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 1KB          |     8,425.9 ns |    119.63 ns |    111.90 ns |         - |
+| Decrypt · AES-256-CCM (BouncyCastle)       | 1KB          |    10,805.5 ns |    210.83 ns |    197.21 ns |    2808 B |
+|                                            |              |                |              |              |           |
+| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 1KB          |     2,759.6 ns |     50.95 ns |     47.66 ns |         - |
+| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 1KB          |     8,477.6 ns |    158.16 ns |    169.23 ns |         - |
+| Encrypt · AES-256-CCM (BouncyCastle)       | 1KB          |    10,716.7 ns |    209.81 ns |    224.50 ns |    2848 B |
+|                                            |              |                |              |              |           |
+| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 8KB          |    21,699.4 ns |    341.95 ns |    319.86 ns |         - |
+| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 8KB          |    65,523.0 ns |    797.05 ns |    745.56 ns |         - |
+| Decrypt · AES-256-CCM (BouncyCastle)       | 8KB          |    78,214.3 ns |  1,043.83 ns |    976.40 ns |    2808 B |
+|                                            |              |                |              |              |           |
+| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 8KB          |    21,165.0 ns |     72.50 ns |     60.54 ns |         - |
+| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 8KB          |    66,228.0 ns |  1,312.98 ns |  1,563.01 ns |         - |
+| Encrypt · AES-256-CCM (BouncyCastle)       | 8KB          |    78,365.6 ns |    569.20 ns |    532.43 ns |    2848 B |
+|                                            |              |                |              |              |           |
+| Decrypt · AES-256-CCM (CryptoHives-AES-NI) | 128KB        |   337,879.7 ns |    790.20 ns |    700.49 ns |         - |
+| Decrypt · AES-256-CCM (CryptoHives-Scalar) | 128KB        | 1,043,715.0 ns | 13,713.19 ns | 12,827.33 ns |         - |
+| Decrypt · AES-256-CCM (BouncyCastle)       | 128KB        | 1,241,674.1 ns | 11,207.65 ns | 10,483.65 ns |    2808 B |
+|                                            |              |                |              |              |           |
+| Encrypt · AES-256-CCM (CryptoHives-AES-NI) | 128KB        |   340,670.5 ns |  3,941.35 ns |  3,291.20 ns |         - |
+| Encrypt · AES-256-CCM (CryptoHives-Scalar) | 128KB        | 1,041,979.9 ns | 17,594.69 ns | 16,458.09 ns |         - |
+| Encrypt · AES-256-CCM (BouncyCastle)       | 128KB        | 1,238,243.7 ns | 13,973.30 ns | 13,070.63 ns |    2848 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-gcm-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-gcm-128.md
@@ -1,97 +1,97 @@
-﻿| Description                                           | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|------------------------------------------------------ |------------- |--------------:|-------------:|-------------:|----------:|
-| Decrypt · AES-128-GCM (OS)                            | 17B          |     115.36 ns |     0.451 ns |     0.422 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |     117.80 ns |     0.241 ns |     0.226 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |     118.99 ns |     0.239 ns |     0.224 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 17B          |     336.41 ns |     1.631 ns |     1.526 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 17B          |     556.45 ns |     4.420 ns |     4.134 ns |    1624 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |      62.22 ns |     0.155 ns |     0.145 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |      62.54 ns |     0.156 ns |     0.146 ns |         - |
-| Encrypt · AES-128-GCM (OS)                            | 17B          |     119.99 ns |     0.397 ns |     0.371 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 17B          |     309.73 ns |     0.588 ns |     0.491 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 17B          |     492.14 ns |     1.594 ns |     1.413 ns |    1608 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |      97.88 ns |     0.373 ns |     0.349 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |     101.55 ns |     0.129 ns |     0.114 ns |         - |
-| Decrypt · AES-128-GCM (OS)                            | 65B          |     117.21 ns |     0.270 ns |     0.226 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 65B          |     581.35 ns |     3.181 ns |     2.820 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 65B          |     748.74 ns |     3.771 ns |     3.343 ns |    1624 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |      68.18 ns |     0.143 ns |     0.127 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |      68.54 ns |     0.206 ns |     0.192 ns |         - |
-| Encrypt · AES-128-GCM (OS)                            | 65B          |     124.98 ns |     0.245 ns |     0.191 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 65B          |     547.58 ns |     1.888 ns |     1.766 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 65B          |     663.33 ns |     4.148 ns |     3.880 ns |    1608 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      92.49 ns |     0.297 ns |     0.278 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      94.73 ns |     0.188 ns |     0.166 ns |         - |
-| Decrypt · AES-128-GCM (OS)                            | 128B         |     116.50 ns |     0.545 ns |     0.510 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 128B         |     816.23 ns |     3.511 ns |     3.284 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 128B         |     894.51 ns |     2.394 ns |     2.123 ns |    1624 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      57.54 ns |     0.130 ns |     0.122 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      59.64 ns |     0.210 ns |     0.196 ns |         - |
-| Encrypt · AES-128-GCM (OS)                            | 128B         |     119.54 ns |     0.562 ns |     0.526 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 128B         |     787.47 ns |     3.046 ns |     2.849 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 128B         |     791.11 ns |     3.725 ns |     3.302 ns |    1608 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |     119.14 ns |     0.366 ns |     0.343 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |     122.59 ns |     0.285 ns |     0.253 ns |         - |
-| Decrypt · AES-128-GCM (OS)                            | 152B         |     133.18 ns |     0.399 ns |     0.373 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 152B         |     978.85 ns |     3.268 ns |     3.057 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 152B         |     988.49 ns |     5.152 ns |     4.302 ns |    1624 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |      82.61 ns |     0.194 ns |     0.182 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |      84.61 ns |     0.261 ns |     0.244 ns |         - |
-| Encrypt · AES-128-GCM (OS)                            | 152B         |     133.21 ns |     0.662 ns |     0.620 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 152B         |     908.51 ns |     5.545 ns |     5.186 ns |    1608 B |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 152B         |     951.71 ns |     4.256 ns |     3.981 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |     107.84 ns |     0.464 ns |     0.434 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |     119.73 ns |     0.636 ns |     0.595 ns |         - |
-| Decrypt · AES-128-GCM (OS)                            | 256B         |     124.29 ns |     0.310 ns |     0.290 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 256B         |   1,260.40 ns |     7.431 ns |     6.951 ns |    1624 B |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 256B         |   1,455.75 ns |     4.351 ns |     4.070 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |      72.79 ns |     0.293 ns |     0.274 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |      77.83 ns |     0.333 ns |     0.295 ns |         - |
-| Encrypt · AES-128-GCM (OS)                            | 256B         |     120.78 ns |     0.544 ns |     0.509 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 256B         |   1,183.38 ns |     8.789 ns |     8.221 ns |    1608 B |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 256B         |   1,427.31 ns |     4.823 ns |     4.512 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-128-GCM (OS)                            | 1KB          |     176.88 ns |     0.971 ns |     0.860 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     193.79 ns |     1.057 ns |     0.989 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     240.54 ns |     1.045 ns |     0.978 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 1KB          |   3,650.03 ns |    10.071 ns |     8.928 ns |    1624 B |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 1KB          |   5,301.19 ns |    18.975 ns |    17.749 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     169.88 ns |     0.397 ns |     0.371 ns |         - |
-| Encrypt · AES-128-GCM (OS)                            | 1KB          |     171.20 ns |     0.627 ns |     0.556 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     195.02 ns |     0.546 ns |     0.511 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 1KB          |   3,528.52 ns |    19.218 ns |    17.977 ns |    1608 B |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 1KB          |   5,282.98 ns |    19.701 ns |    16.451 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-128-GCM (OS)                            | 8KB          |     697.38 ns |     2.528 ns |     2.364 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,008.21 ns |     3.247 ns |     2.878 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,365.39 ns |     4.269 ns |     3.993 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 8KB          |  25,400.87 ns |    92.402 ns |    86.433 ns |    1624 B |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 8KB          |  41,106.89 ns |   172.087 ns |   160.970 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (OS)                            | 8KB          |     660.88 ns |     3.272 ns |     3.061 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,093.28 ns |     2.196 ns |     1.946 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,297.97 ns |     3.210 ns |     3.002 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 8KB          |  25,487.30 ns |    67.742 ns |    56.568 ns |    1608 B |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 8KB          |  41,140.75 ns |   260.029 ns |   243.231 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-128-GCM (OS)                            | 128KB        |  10,847.21 ns |    13.060 ns |    11.577 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  15,620.14 ns |    67.150 ns |    59.527 ns |         - |
-| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  20,623.03 ns |   101.666 ns |    95.098 ns |         - |
-| Decrypt · AES-128-GCM (BouncyCastle)                  | 128KB        | 401,817.23 ns |   939.908 ns |   833.204 ns |    1624 B |
-| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 128KB        | 671,240.85 ns | 1,063.373 ns |   994.680 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-128-GCM (OS)                            | 128KB        |   9,606.26 ns |    35.176 ns |    32.903 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  16,753.47 ns |    61.975 ns |    57.972 ns |         - |
-| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  20,240.08 ns |    76.682 ns |    67.977 ns |         - |
-| Encrypt · AES-128-GCM (BouncyCastle)                  | 128KB        | 400,510.74 ns | 1,054.740 ns |   986.605 ns |    1608 B |
-| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 128KB        | 656,694.11 ns | 2,870.029 ns | 2,544.206 ns |         - |
+﻿| Description                                           | TestDataSize | Mean          | Error         | StdDev        | Allocated |
+|------------------------------------------------------ |------------- |--------------:|--------------:|--------------:|----------:|
+| Decrypt · AES-128-GCM (OS)                            | 17B          |     120.90 ns |      1.311 ns |      1.227 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |     125.18 ns |      2.521 ns |      2.698 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |     127.55 ns |      1.090 ns |      1.019 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 17B          |     355.45 ns |      2.956 ns |      2.468 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 17B          |     621.57 ns |      7.004 ns |      6.552 ns |    1624 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |      65.77 ns |      0.272 ns |      0.255 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |      66.36 ns |      0.159 ns |      0.133 ns |         - |
+| Encrypt · AES-128-GCM (OS)                            | 17B          |     128.19 ns |      1.205 ns |      1.127 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 17B          |     331.85 ns |      3.129 ns |      2.927 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 17B          |     558.93 ns |      9.317 ns |      8.715 ns |    1608 B |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |     102.41 ns |      1.589 ns |      1.486 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |     105.78 ns |      1.125 ns |      0.998 ns |         - |
+| Decrypt · AES-128-GCM (OS)                            | 65B          |     125.79 ns |      2.545 ns |      3.219 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 65B          |     628.58 ns |     11.961 ns |     10.604 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 65B          |     849.11 ns |     16.198 ns |     21.624 ns |    1624 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |      70.57 ns |      0.438 ns |      0.366 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |      70.74 ns |      0.323 ns |      0.270 ns |         - |
+| Encrypt · AES-128-GCM (OS)                            | 65B          |     131.19 ns |      0.615 ns |      0.575 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 65B          |     579.04 ns |      4.327 ns |      3.378 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 65B          |     715.78 ns |     11.904 ns |     10.553 ns |    1608 B |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      97.95 ns |      1.917 ns |      1.793 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |     100.12 ns |      0.658 ns |      0.550 ns |         - |
+| Decrypt · AES-128-GCM (OS)                            | 128B         |     122.31 ns |      0.702 ns |      0.586 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 128B         |     859.02 ns |     10.048 ns |      9.399 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 128B         |     957.60 ns |     11.804 ns |     11.042 ns |    1624 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      59.45 ns |      0.404 ns |      0.378 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      61.89 ns |      0.637 ns |      0.564 ns |         - |
+| Encrypt · AES-128-GCM (OS)                            | 128B         |     125.36 ns |      1.561 ns |      1.460 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 128B         |     824.55 ns |     14.780 ns |     13.825 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 128B         |     864.72 ns |     13.318 ns |     12.458 ns |    1608 B |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |     127.24 ns |      1.637 ns |      1.531 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |     129.91 ns |      1.466 ns |      1.371 ns |         - |
+| Decrypt · AES-128-GCM (OS)                            | 152B         |     142.53 ns |      1.945 ns |      1.724 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 152B         |   1,043.02 ns |     18.180 ns |     17.006 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 152B         |   1,100.54 ns |     14.216 ns |     13.297 ns |    1624 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |      86.29 ns |      1.724 ns |      1.693 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |      89.17 ns |      1.556 ns |      1.528 ns |         - |
+| Encrypt · AES-128-GCM (OS)                            | 152B         |     139.99 ns |      1.302 ns |      1.218 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 152B         |   1,010.19 ns |     20.000 ns |     18.708 ns |    1608 B |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 152B         |   1,023.17 ns |     20.331 ns |     22.598 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |     115.11 ns |      1.273 ns |      1.191 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |     133.64 ns |      2.699 ns |      3.510 ns |         - |
+| Decrypt · AES-128-GCM (OS)                            | 256B         |     139.17 ns |      2.787 ns |      2.862 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 256B         |   1,434.62 ns |     28.322 ns |     36.827 ns |    1624 B |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 256B         |   1,544.24 ns |     19.158 ns |     17.920 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |      76.63 ns |      1.201 ns |      1.124 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |      81.24 ns |      0.799 ns |      0.747 ns |         - |
+| Encrypt · AES-128-GCM (OS)                            | 256B         |     133.52 ns |      2.645 ns |      3.959 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 256B         |   1,297.97 ns |     23.544 ns |     22.023 ns |    1608 B |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 256B         |   1,515.08 ns |     17.327 ns |     16.208 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-128-GCM (OS)                            | 1KB          |     189.01 ns |      3.375 ns |      3.157 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     207.78 ns |      4.134 ns |      4.922 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     265.17 ns |      4.488 ns |      4.198 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 1KB          |   3,844.68 ns |     46.142 ns |     36.025 ns |    1624 B |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 1KB          |   5,760.38 ns |    109.675 ns |    107.715 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     179.05 ns |      3.480 ns |      3.418 ns |         - |
+| Encrypt · AES-128-GCM (OS)                            | 1KB          |     184.82 ns |      2.815 ns |      2.495 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     207.94 ns |      4.151 ns |      4.076 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 1KB          |   3,712.32 ns |     34.814 ns |     30.862 ns |    1608 B |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 1KB          |   5,997.45 ns |     65.878 ns |     61.622 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-128-GCM (OS)                            | 8KB          |     717.21 ns |     14.099 ns |     13.189 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,073.78 ns |     15.036 ns |     13.329 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,467.09 ns |     28.733 ns |     28.219 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 8KB          |  26,887.71 ns |    260.587 ns |    243.753 ns |    1624 B |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 8KB          |  43,639.69 ns |    494.512 ns |    462.566 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (OS)                            | 8KB          |     691.59 ns |     10.838 ns |     10.138 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,152.68 ns |     14.763 ns |     13.810 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,361.15 ns |     13.827 ns |     12.934 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 8KB          |  26,510.39 ns |    220.545 ns |    206.298 ns |    1608 B |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 8KB          |  43,119.14 ns |    207.101 ns |    183.590 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-128-GCM (OS)                            | 128KB        |  11,360.11 ns |    138.436 ns |    115.600 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  16,465.23 ns |    255.352 ns |    238.856 ns |         - |
+| Decrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  21,794.01 ns |    369.365 ns |    345.505 ns |         - |
+| Decrypt · AES-128-GCM (BouncyCastle)                  | 128KB        | 419,142.68 ns |  6,298.970 ns |  5,259.925 ns |    1624 B |
+| Decrypt · AES-128-GCM (CryptoHives-Scalar)            | 128KB        | 700,467.03 ns | 13,642.634 ns | 13,398.891 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-128-GCM (OS)                            | 128KB        |  10,145.57 ns |    148.883 ns |    139.265 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  17,575.66 ns |    182.644 ns |    161.909 ns |         - |
+| Encrypt · AES-128-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  21,014.08 ns |    232.972 ns |    217.922 ns |         - |
+| Encrypt · AES-128-GCM (BouncyCastle)                  | 128KB        | 418,362.57 ns |  2,760.521 ns |  2,582.193 ns |    1608 B |
+| Encrypt · AES-128-GCM (CryptoHives-Scalar)            | 128KB        | 688,774.13 ns |  8,493.157 ns |  7,944.504 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-gcm-192.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-gcm-192.md
@@ -1,97 +1,97 @@
-﻿| Description                                           | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|------------------------------------------------------ |------------- |--------------:|-------------:|-------------:|----------:|
-| Decrypt · AES-192-GCM (OS)                            | 17B          |     119.67 ns |     0.376 ns |     0.352 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |     121.49 ns |     0.224 ns |     0.210 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |     122.11 ns |     0.211 ns |     0.197 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 17B          |     358.48 ns |     1.811 ns |     1.694 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 17B          |     599.53 ns |     2.944 ns |     2.754 ns |    1728 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |      65.84 ns |     0.103 ns |     0.096 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |      66.07 ns |     0.250 ns |     0.234 ns |         - |
-| Encrypt · AES-192-GCM (OS)                            | 17B          |     123.65 ns |     0.319 ns |     0.283 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 17B          |     328.72 ns |     1.369 ns |     1.280 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 17B          |     539.65 ns |     2.822 ns |     2.639 ns |    1712 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |     102.57 ns |     0.333 ns |     0.311 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |     107.48 ns |     0.314 ns |     0.293 ns |         - |
-| Decrypt · AES-192-GCM (OS)                            | 65B          |     122.79 ns |     0.380 ns |     0.337 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 65B          |     615.44 ns |     2.428 ns |     2.271 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 65B          |     796.90 ns |     2.880 ns |     2.694 ns |    1728 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |      72.81 ns |     0.161 ns |     0.151 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |      73.21 ns |     0.183 ns |     0.171 ns |         - |
-| Encrypt · AES-192-GCM (OS)                            | 65B          |     126.98 ns |     0.344 ns |     0.322 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 65B          |     587.28 ns |     1.288 ns |     1.205 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 65B          |     705.92 ns |     2.831 ns |     2.648 ns |    1712 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      96.57 ns |     0.354 ns |     0.332 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |     100.27 ns |     0.337 ns |     0.315 ns |         - |
-| Decrypt · AES-192-GCM (OS)                            | 128B         |     121.43 ns |     0.501 ns |     0.469 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 128B         |     965.69 ns |     6.360 ns |     5.949 ns |    1728 B |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 128B         |   1,579.78 ns |    31.297 ns |    34.786 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      59.91 ns |     0.199 ns |     0.186 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      62.61 ns |     0.155 ns |     0.145 ns |         - |
-| Encrypt · AES-192-GCM (OS)                            | 128B         |     119.13 ns |     0.286 ns |     0.224 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 128B         |     875.34 ns |     2.935 ns |     2.602 ns |    1712 B |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 128B         |     883.59 ns |     1.438 ns |     1.201 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |     126.81 ns |     0.240 ns |     0.213 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |     127.10 ns |     0.661 ns |     0.586 ns |         - |
-| Decrypt · AES-192-GCM (OS)                            | 152B         |     137.44 ns |     0.516 ns |     0.483 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 152B         |   1,052.88 ns |     4.091 ns |     3.827 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 152B         |   1,104.68 ns |     4.454 ns |     4.166 ns |    1728 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |      87.32 ns |     0.158 ns |     0.148 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |      89.45 ns |     0.172 ns |     0.161 ns |         - |
-| Encrypt · AES-192-GCM (OS)                            | 152B         |     135.72 ns |     0.542 ns |     0.507 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 152B         |   1,003.91 ns |     5.388 ns |     5.040 ns |    1712 B |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 152B         |   1,023.66 ns |     3.858 ns |     3.609 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |     113.66 ns |     0.289 ns |     0.256 ns |         - |
-| Decrypt · AES-192-GCM (OS)                            | 256B         |     129.24 ns |     0.157 ns |     0.131 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |     131.80 ns |     1.213 ns |     1.076 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 256B         |   1,417.31 ns |     4.532 ns |     4.239 ns |    1728 B |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 256B         |   1,571.12 ns |     6.925 ns |     6.477 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |      77.91 ns |     0.243 ns |     0.227 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |      81.82 ns |     0.299 ns |     0.280 ns |         - |
-| Encrypt · AES-192-GCM (OS)                            | 256B         |     122.95 ns |     0.245 ns |     0.217 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 256B         |   1,327.54 ns |     7.432 ns |     6.952 ns |    1712 B |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 256B         |   1,554.01 ns |     2.578 ns |     2.285 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     201.13 ns |     0.683 ns |     0.639 ns |         - |
-| Decrypt · AES-192-GCM (OS)                            | 1KB          |     204.98 ns |     0.383 ns |     0.358 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     252.16 ns |     0.978 ns |     0.915 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 1KB          |   4,141.49 ns |    16.911 ns |    15.819 ns |    1728 B |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 1KB          |   5,743.99 ns |    20.118 ns |    18.818 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (OS)                            | 1KB          |     174.93 ns |     0.682 ns |     0.638 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     186.38 ns |     0.651 ns |     0.577 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     204.88 ns |     0.492 ns |     0.460 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 1KB          |   4,060.13 ns |    22.901 ns |    21.422 ns |    1712 B |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 1KB          |   5,712.17 ns |    17.085 ns |    15.981 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-192-GCM (OS)                            | 8KB          |     776.84 ns |     2.816 ns |     2.634 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,055.90 ns |     5.346 ns |     5.000 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,458.85 ns |     3.377 ns |     2.993 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 8KB          |  29,455.32 ns |    56.637 ns |    50.207 ns |    1728 B |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 8KB          |  45,045.79 ns |   223.156 ns |   208.740 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (OS)                            | 8KB          |     684.09 ns |     3.133 ns |     2.930 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,184.52 ns |     2.791 ns |     2.474 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,364.40 ns |     4.701 ns |     4.397 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 8KB          |  29,380.01 ns |    50.207 ns |    46.964 ns |    1712 B |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 8KB          |  44,544.59 ns |   195.274 ns |   182.659 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-192-GCM (OS)                            | 128KB        |  11,598.76 ns |    39.805 ns |    37.234 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  16,379.91 ns |    87.162 ns |    81.532 ns |         - |
-| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  21,987.06 ns |    69.737 ns |    65.232 ns |         - |
-| Decrypt · AES-192-GCM (BouncyCastle)                  | 128KB        | 464,656.26 ns | 1,575.756 ns | 1,473.963 ns |    1728 B |
-| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 128KB        | 711,492.12 ns | 2,554.506 ns | 2,389.486 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-192-GCM (OS)                            | 128KB        |  10,069.99 ns |    53.713 ns |    47.615 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  18,417.35 ns |    46.386 ns |    38.734 ns |         - |
-| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  21,138.81 ns |    73.152 ns |    68.426 ns |         - |
-| Encrypt · AES-192-GCM (BouncyCastle)                  | 128KB        | 464,245.22 ns | 1,350.243 ns | 1,263.018 ns |    1712 B |
-| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 128KB        | 711,611.54 ns | 4,121.843 ns | 3,855.575 ns |         - |
+﻿| Description                                           | TestDataSize | Mean          | Error         | StdDev        | Allocated |
+|------------------------------------------------------ |------------- |--------------:|--------------:|--------------:|----------:|
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |     120.95 ns |      2.376 ns |      2.440 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |     121.20 ns |      2.337 ns |      2.691 ns |         - |
+| Decrypt · AES-192-GCM (OS)                            | 17B          |     128.08 ns |      2.241 ns |      2.096 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 17B          |     394.28 ns |      6.815 ns |     10.201 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 17B          |     702.23 ns |      9.815 ns |      8.196 ns |    1728 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |      68.20 ns |      0.888 ns |      0.787 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |      68.80 ns |      1.387 ns |      1.484 ns |         - |
+| Encrypt · AES-192-GCM (OS)                            | 17B          |     131.08 ns |      2.484 ns |      2.761 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 17B          |     356.48 ns |      7.103 ns |      9.482 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 17B          |     611.84 ns |     12.070 ns |     16.521 ns |    1712 B |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |     116.34 ns |      1.575 ns |      1.474 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |     116.85 ns |      1.872 ns |      1.751 ns |         - |
+| Decrypt · AES-192-GCM (OS)                            | 65B          |     127.40 ns |      2.249 ns |      2.104 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 65B          |     653.40 ns |     11.668 ns |     13.436 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 65B          |     886.73 ns |     14.037 ns |     12.444 ns |    1728 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |      75.60 ns |      1.040 ns |      0.922 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |      75.93 ns |      1.465 ns |      1.439 ns |         - |
+| Encrypt · AES-192-GCM (OS)                            | 65B          |     135.72 ns |      2.624 ns |      2.577 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 65B          |     626.51 ns |     12.140 ns |     13.493 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 65B          |     787.63 ns |     14.040 ns |     13.133 ns |    1712 B |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      99.91 ns |      0.766 ns |      0.640 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |     100.74 ns |      1.169 ns |      1.094 ns |         - |
+| Decrypt · AES-192-GCM (OS)                            | 128B         |     125.60 ns |      2.384 ns |      2.341 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 128B         |     930.73 ns |     18.588 ns |     19.889 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 128B         |   1,058.67 ns |     20.582 ns |     22.022 ns |    1728 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      62.86 ns |      1.210 ns |      1.242 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      65.03 ns |      0.649 ns |      0.507 ns |         - |
+| Encrypt · AES-192-GCM (OS)                            | 128B         |     128.21 ns |      2.546 ns |      2.382 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 128B         |     899.09 ns |     17.020 ns |     15.087 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 128B         |     963.87 ns |     18.765 ns |     20.078 ns |    1712 B |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |     128.83 ns |      2.185 ns |      2.043 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |     132.76 ns |      1.137 ns |      0.949 ns |         - |
+| Decrypt · AES-192-GCM (OS)                            | 152B         |     147.03 ns |      2.654 ns |      2.482 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 152B         |   1,126.01 ns |     21.387 ns |     21.005 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 152B         |   1,212.28 ns |     23.505 ns |     28.866 ns |    1728 B |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |      90.91 ns |      1.354 ns |      1.201 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |      94.31 ns |      1.883 ns |      1.934 ns |         - |
+| Encrypt · AES-192-GCM (OS)                            | 152B         |     144.20 ns |      1.395 ns |      1.165 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 152B         |   1,086.55 ns |     11.756 ns |     10.997 ns |    1712 B |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 152B         |   1,095.62 ns |     21.205 ns |     23.570 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |     118.67 ns |      1.961 ns |      1.834 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |     130.96 ns |      2.350 ns |      2.198 ns |         - |
+| Decrypt · AES-192-GCM (OS)                            | 256B         |     141.15 ns |      2.006 ns |      1.876 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 256B         |   1,534.63 ns |     17.770 ns |     16.622 ns |    1728 B |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 256B         |   1,644.79 ns |     14.288 ns |     11.931 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |      81.44 ns |      0.825 ns |      0.771 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |      86.54 ns |      0.858 ns |      0.802 ns |         - |
+| Encrypt · AES-192-GCM (OS)                            | 256B         |     135.02 ns |      1.086 ns |      0.963 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 256B         |   1,421.64 ns |     14.556 ns |     13.616 ns |    1712 B |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 256B         |   1,626.45 ns |     15.925 ns |     14.117 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-192-GCM (OS)                            | 1KB          |     201.82 ns |      4.008 ns |      3.936 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     212.83 ns |      3.818 ns |      3.571 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     266.36 ns |      4.397 ns |      4.113 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 1KB          |   4,436.19 ns |     82.200 ns |     80.731 ns |    1728 B |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 1KB          |   6,047.13 ns |     71.144 ns |     63.067 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (OS)                            | 1KB          |     188.19 ns |      3.676 ns |      3.259 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     192.80 ns |      1.629 ns |      1.524 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     214.18 ns |      1.730 ns |      1.618 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 1KB          |   4,351.48 ns |     82.849 ns |     85.079 ns |    1712 B |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 1KB          |   6,027.21 ns |     91.044 ns |     85.163 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-192-GCM (OS)                            | 8KB          |     838.64 ns |     15.821 ns |     14.799 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,123.26 ns |     17.752 ns |     15.737 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,540.66 ns |     30.440 ns |     29.896 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 8KB          |  31,999.31 ns |    638.334 ns |    974.804 ns |    1728 B |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 8KB          |  47,227.81 ns |    819.517 ns |    766.577 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (OS)                            | 8KB          |     719.69 ns |     13.878 ns |     17.044 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,260.63 ns |     25.204 ns |     24.754 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,429.44 ns |     28.210 ns |     30.185 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 8KB          |  30,999.88 ns |    474.427 ns |    420.567 ns |    1712 B |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 8KB          |  47,098.46 ns |    926.024 ns |  1,029.273 ns |         - |
+|                                                       |              |               |               |               |           |
+| Decrypt · AES-192-GCM (OS)                            | 128KB        |  13,320.57 ns |    256.902 ns |    324.898 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  18,278.08 ns |    351.159 ns |    480.671 ns |         - |
+| Decrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  24,358.78 ns |    469.228 ns |    438.917 ns |         - |
+| Decrypt · AES-192-GCM (BouncyCastle)                  | 128KB        | 518,511.76 ns | 10,350.799 ns | 12,321.890 ns |    1728 B |
+| Decrypt · AES-192-GCM (CryptoHives-Scalar)            | 128KB        | 795,957.06 ns | 15,815.995 ns | 15,533.422 ns |         - |
+|                                                       |              |               |               |               |           |
+| Encrypt · AES-192-GCM (OS)                            | 128KB        |  10,718.06 ns |    199.055 ns |    186.196 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  19,381.53 ns |    360.848 ns |    354.401 ns |         - |
+| Encrypt · AES-192-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  22,394.91 ns |    432.143 ns |    404.227 ns |         - |
+| Encrypt · AES-192-GCM (BouncyCastle)                  | 128KB        | 488,858.11 ns |  8,982.683 ns |  8,402.408 ns |    1712 B |
+| Encrypt · AES-192-GCM (CryptoHives-Scalar)            | 128KB        | 753,256.12 ns | 13,557.271 ns | 12,681.480 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-gcm-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aes-gcm-256.md
@@ -1,97 +1,97 @@
-﻿| Description                                           | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|------------------------------------------------------ |------------- |--------------:|-------------:|-------------:|----------:|
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |     122.05 ns |     0.211 ns |     0.187 ns |         - |
-| Decrypt · AES-256-GCM (OS)                            | 17B          |     122.48 ns |     0.308 ns |     0.273 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |     160.23 ns |     0.148 ns |     0.131 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 17B          |     376.12 ns |     1.795 ns |     1.679 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 17B          |     645.23 ns |     4.986 ns |     4.664 ns |    1832 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |      69.23 ns |     0.150 ns |     0.140 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |      69.23 ns |     0.119 ns |     0.112 ns |         - |
-| Encrypt · AES-256-GCM (OS)                            | 17B          |     128.30 ns |     0.216 ns |     0.191 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 17B          |     360.08 ns |     1.333 ns |     1.247 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 17B          |     595.20 ns |     2.812 ns |     2.630 ns |    1816 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |     116.69 ns |     0.245 ns |     0.229 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |     118.49 ns |     0.352 ns |     0.329 ns |         - |
-| Decrypt · AES-256-GCM (OS)                            | 65B          |     134.00 ns |     0.353 ns |     0.313 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 65B          |     657.06 ns |     3.393 ns |     3.174 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 65B          |     867.23 ns |     4.225 ns |     3.952 ns |    1832 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |      76.63 ns |     0.156 ns |     0.130 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |      76.65 ns |     0.235 ns |     0.220 ns |         - |
-| Encrypt · AES-256-GCM (OS)                            | 65B          |     133.33 ns |     0.555 ns |     0.519 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 65B          |     637.93 ns |     1.670 ns |     1.562 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 65B          |     788.39 ns |    14.276 ns |    13.354 ns |    1816 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |     105.56 ns |     0.447 ns |     0.418 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |     106.15 ns |     0.222 ns |     0.197 ns |         - |
-| Decrypt · AES-256-GCM (OS)                            | 128B         |     123.44 ns |     0.561 ns |     0.525 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 128B         |     940.22 ns |     3.068 ns |     2.870 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 128B         |   1,054.45 ns |     4.264 ns |     3.561 ns |    1832 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      62.49 ns |     0.059 ns |     0.049 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      64.53 ns |     0.200 ns |     0.187 ns |         - |
-| Encrypt · AES-256-GCM (OS)                            | 128B         |     124.39 ns |     0.272 ns |     0.255 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 128B         |     922.62 ns |     3.278 ns |     2.906 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 128B         |     973.00 ns |     6.086 ns |     5.693 ns |    1816 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-256-GCM (OS)                            | 152B         |     140.15 ns |     0.462 ns |     0.432 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |     142.09 ns |     0.302 ns |     0.253 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |     142.53 ns |     0.445 ns |     0.416 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 152B         |   1,127.70 ns |     5.327 ns |     4.722 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 152B         |   1,233.06 ns |     3.676 ns |     3.439 ns |    1832 B |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |      92.11 ns |     0.203 ns |     0.189 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |      95.67 ns |     0.227 ns |     0.212 ns |         - |
-| Encrypt · AES-256-GCM (OS)                            | 152B         |     144.04 ns |     0.373 ns |     0.330 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 152B         |   1,095.90 ns |     4.841 ns |     4.528 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 152B         |   1,114.16 ns |     5.102 ns |     4.523 ns |    1816 B |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |     122.39 ns |     0.663 ns |     0.621 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |     127.93 ns |     0.375 ns |     0.351 ns |         - |
-| Decrypt · AES-256-GCM (OS)                            | 256B         |     136.50 ns |     0.249 ns |     0.220 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 256B         |   1,585.44 ns |    10.158 ns |     9.502 ns |    1832 B |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 256B         |   1,693.38 ns |    10.323 ns |     9.656 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |      83.19 ns |     0.140 ns |     0.131 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |      88.14 ns |     0.230 ns |     0.204 ns |         - |
-| Encrypt · AES-256-GCM (OS)                            | 256B         |     125.27 ns |     0.303 ns |     0.284 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 256B         |   1,483.49 ns |     7.845 ns |     7.338 ns |    1816 B |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 256B         |   1,652.90 ns |     9.410 ns |     8.803 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-256-GCM (OS)                            | 1KB          |     213.04 ns |     0.376 ns |     0.334 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     214.28 ns |     0.338 ns |     0.299 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     265.04 ns |     0.583 ns |     0.517 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 1KB          |   4,682.35 ns |    17.021 ns |    15.089 ns |    1832 B |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 1KB          |   6,174.70 ns |    17.272 ns |    16.156 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (OS)                            | 1KB          |     181.92 ns |     0.606 ns |     0.567 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     200.22 ns |     0.435 ns |     0.386 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     221.72 ns |     0.614 ns |     0.545 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 1KB          |   4,576.39 ns |    17.458 ns |    16.331 ns |    1816 B |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 1KB          |   6,152.93 ns |    45.113 ns |    42.199 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-256-GCM (OS)                            | 8KB          |     942.26 ns |     2.067 ns |     1.933 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,134.22 ns |     2.542 ns |     2.253 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,557.05 ns |     4.576 ns |     4.281 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 8KB          |  33,442.91 ns |   103.238 ns |    91.517 ns |    1832 B |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 8KB          |  48,079.90 ns |   224.575 ns |   210.068 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (OS)                            | 8KB          |     727.51 ns |     2.786 ns |     2.606 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,301.33 ns |     4.258 ns |     3.775 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,472.20 ns |     2.903 ns |     2.715 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 8KB          |  33,246.75 ns |   146.025 ns |   136.591 ns |    1816 B |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 8KB          |  47,977.81 ns |   141.797 ns |   125.699 ns |         - |
-|                                                       |              |               |              |              |           |
-| Decrypt · AES-256-GCM (OS)                            | 128KB        |  14,285.30 ns |    27.413 ns |    25.642 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  17,360.33 ns |   146.891 ns |   137.402 ns |         - |
-| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  23,289.15 ns |    80.120 ns |    74.944 ns |         - |
-| Decrypt · AES-256-GCM (BouncyCastle)                  | 128KB        | 533,993.69 ns | 1,012.869 ns |   947.438 ns |    1832 B |
-| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 128KB        | 768,052.74 ns | 3,574.137 ns | 3,343.250 ns |         - |
-|                                                       |              |               |              |              |           |
-| Encrypt · AES-256-GCM (OS)                            | 128KB        |  10,574.83 ns |    44.383 ns |    41.516 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  20,219.61 ns |    59.127 ns |    55.307 ns |         - |
-| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  22,953.02 ns |    85.087 ns |    79.590 ns |         - |
-| Encrypt · AES-256-GCM (BouncyCastle)                  | 128KB        | 527,109.62 ns | 2,193.061 ns | 2,051.390 ns |    1816 B |
-| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 128KB        | 763,765.67 ns | 4,693.947 ns | 4,390.721 ns |         - |
+﻿| Description                                           | TestDataSize | Mean          | Error        | StdDev       | Median        | Allocated |
+|------------------------------------------------------ |------------- |--------------:|-------------:|-------------:|--------------:|----------:|
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |     119.51 ns |     0.224 ns |     0.175 ns |     119.56 ns |         - |
+| Decrypt · AES-256-GCM (OS)                            | 17B          |     122.81 ns |     0.716 ns |     0.670 ns |     122.96 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |     123.42 ns |     0.348 ns |     0.272 ns |     123.50 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 17B          |     399.34 ns |     1.820 ns |     1.520 ns |     399.69 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 17B          |     648.08 ns |     3.634 ns |     3.222 ns |     648.10 ns |    1832 B |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 17B          |      73.05 ns |     1.406 ns |     1.246 ns |      72.76 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 17B          |      74.65 ns |     1.063 ns |     0.994 ns |      74.61 ns |         - |
+| Encrypt · AES-256-GCM (OS)                            | 17B          |     134.76 ns |     1.491 ns |     1.322 ns |     134.62 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 17B          |     376.62 ns |     4.891 ns |     4.336 ns |     377.74 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 17B          |     671.07 ns |    13.065 ns |    16.988 ns |     666.14 ns |    1816 B |
+|                                                       |              |               |              |              |               |           |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |     105.05 ns |     0.436 ns |     0.387 ns |     104.93 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |     114.99 ns |     0.429 ns |     0.358 ns |     114.91 ns |         - |
+| Decrypt · AES-256-GCM (OS)                            | 65B          |     125.96 ns |     0.214 ns |     0.167 ns |     125.99 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 65B          |     658.76 ns |     2.993 ns |     2.800 ns |     658.13 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 65B          |     878.20 ns |     3.302 ns |     2.757 ns |     878.53 ns |    1832 B |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 65B          |      82.01 ns |     1.595 ns |     1.492 ns |      82.58 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 65B          |      82.35 ns |     1.231 ns |     1.151 ns |      82.50 ns |         - |
+| Encrypt · AES-256-GCM (OS)                            | 65B          |     147.17 ns |     2.865 ns |     2.680 ns |     146.91 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 65B          |     688.80 ns |     7.599 ns |     6.345 ns |     690.10 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 65B          |     894.76 ns |    16.789 ns |    17.241 ns |     892.04 ns |    1816 B |
+|                                                       |              |               |              |              |               |           |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |     100.27 ns |     0.528 ns |     0.468 ns |     100.27 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |     102.61 ns |     0.601 ns |     0.502 ns |     102.54 ns |         - |
+| Decrypt · AES-256-GCM (OS)                            | 128B         |     124.28 ns |     0.762 ns |     0.712 ns |     124.27 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 128B         |     939.96 ns |     6.396 ns |     5.670 ns |     938.55 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 128B         |   1,125.26 ns |     6.726 ns |     5.963 ns |   1,122.42 ns |    1832 B |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128B         |      67.36 ns |     0.742 ns |     0.658 ns |      67.32 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128B         |      70.95 ns |     1.353 ns |     1.329 ns |      70.89 ns |         - |
+| Encrypt · AES-256-GCM (OS)                            | 128B         |     131.63 ns |     2.301 ns |     2.152 ns |     131.85 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 128B         |     995.86 ns |    19.752 ns |    18.476 ns |     993.39 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 128B         |   1,142.21 ns |    22.291 ns |    32.674 ns |   1,142.15 ns |    1816 B |
+|                                                       |              |               |              |              |               |           |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |     131.70 ns |     0.626 ns |     0.555 ns |     131.52 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |     136.84 ns |     0.506 ns |     0.449 ns |     136.74 ns |         - |
+| Decrypt · AES-256-GCM (OS)                            | 152B         |     142.64 ns |     0.754 ns |     0.630 ns |     142.37 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 152B         |   1,133.05 ns |     8.100 ns |     7.181 ns |   1,131.42 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 152B         |   1,224.91 ns |     6.377 ns |     5.325 ns |   1,223.50 ns |    1832 B |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 152B         |      96.19 ns |     1.301 ns |     1.153 ns |      96.47 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 152B         |      99.66 ns |     1.684 ns |     1.575 ns |      99.42 ns |         - |
+| Encrypt · AES-256-GCM (OS)                            | 152B         |     154.75 ns |     3.120 ns |     6.784 ns |     152.27 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 152B         |   1,182.02 ns |    23.463 ns |    23.044 ns |   1,178.16 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 152B         |   1,245.16 ns |    24.561 ns |    31.062 ns |   1,244.54 ns |    1816 B |
+|                                                       |              |               |              |              |               |           |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |     112.94 ns |     0.580 ns |     0.514 ns |     112.85 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |     125.34 ns |     0.628 ns |     0.556 ns |     125.24 ns |         - |
+| Decrypt · AES-256-GCM (OS)                            | 256B         |     135.24 ns |     0.482 ns |     0.427 ns |     135.12 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 256B         |   1,595.44 ns |    10.341 ns |     9.673 ns |   1,592.48 ns |    1832 B |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 256B         |   1,683.39 ns |     4.173 ns |     3.700 ns |   1,683.44 ns |         - |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 256B         |      83.44 ns |     0.471 ns |     0.417 ns |      83.26 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 256B         |      89.18 ns |     1.804 ns |     2.078 ns |      87.94 ns |         - |
+| Encrypt · AES-256-GCM (OS)                            | 256B         |     131.18 ns |     0.640 ns |     0.567 ns |     131.10 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 256B         |   1,494.89 ns |     5.223 ns |     4.361 ns |   1,493.71 ns |    1816 B |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 256B         |   1,665.83 ns |     8.158 ns |     7.231 ns |   1,666.48 ns |         - |
+|                                                       |              |               |              |              |               |           |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     210.62 ns |     0.955 ns |     0.893 ns |     210.50 ns |         - |
+| Decrypt · AES-256-GCM (OS)                            | 1KB          |     213.15 ns |     0.918 ns |     0.859 ns |     212.75 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     262.20 ns |     2.220 ns |     1.968 ns |     261.32 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 1KB          |   4,739.77 ns |    29.435 ns |    26.093 ns |   4,729.53 ns |    1832 B |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 1KB          |   6,180.07 ns |    33.297 ns |    29.517 ns |   6,181.93 ns |         - |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (OS)                            | 1KB          |     182.44 ns |     0.753 ns |     0.629 ns |     182.43 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 1KB          |     201.65 ns |     0.554 ns |     0.519 ns |     201.45 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 1KB          |     221.88 ns |     1.099 ns |     0.918 ns |     221.63 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 1KB          |   4,600.68 ns |    21.483 ns |    17.940 ns |   4,601.12 ns |    1816 B |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 1KB          |   6,179.35 ns |    34.963 ns |    30.994 ns |   6,180.43 ns |         - |
+|                                                       |              |               |              |              |               |           |
+| Decrypt · AES-256-GCM (OS)                            | 8KB          |     924.39 ns |     3.027 ns |     2.831 ns |     924.64 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,120.00 ns |     5.492 ns |     4.868 ns |   1,118.15 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,535.68 ns |     5.197 ns |     4.340 ns |   1,534.88 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 8KB          |  33,519.39 ns |   174.608 ns |   145.806 ns |  33,507.47 ns |    1832 B |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 8KB          |  48,118.70 ns |   199.467 ns |   186.582 ns |  48,086.23 ns |         - |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (OS)                            | 8KB          |     707.69 ns |     3.287 ns |     2.744 ns |     706.98 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 8KB          |   1,308.38 ns |     8.097 ns |     7.178 ns |   1,304.73 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 8KB          |   1,480.58 ns |     4.287 ns |     4.010 ns |   1,479.76 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 8KB          |  33,433.35 ns |   184.879 ns |   172.936 ns |  33,434.55 ns |    1816 B |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 8KB          |  48,511.14 ns |   316.603 ns |   296.150 ns |  48,379.07 ns |         - |
+|                                                       |              |               |              |              |               |           |
+| Decrypt · AES-256-GCM (OS)                            | 128KB        |  14,293.85 ns |    46.789 ns |    41.478 ns |  14,283.89 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  18,394.46 ns |   321.096 ns |   300.354 ns |  18,274.94 ns |         - |
+| Decrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  23,343.89 ns |    61.481 ns |    51.339 ns |  23,341.68 ns |         - |
+| Decrypt · AES-256-GCM (BouncyCastle)                  | 128KB        | 532,577.98 ns | 2,702.047 ns | 2,527.497 ns | 532,125.98 ns |    1832 B |
+| Decrypt · AES-256-GCM (CryptoHives-Scalar)            | 128KB        | 766,620.70 ns | 4,201.580 ns | 3,508.510 ns | 765,550.59 ns |         - |
+|                                                       |              |               |              |              |               |           |
+| Encrypt · AES-256-GCM (OS)                            | 128KB        |  10,633.04 ns |    72.316 ns |    64.106 ns |  10,632.63 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMulV256) | 128KB        |  20,228.13 ns |    41.758 ns |    37.017 ns |  20,231.02 ns |         - |
+| Encrypt · AES-256-GCM (CryptoHives-AES-NI+PClMul)     | 128KB        |  22,975.18 ns |    58.283 ns |    51.667 ns |  22,965.65 ns |         - |
+| Encrypt · AES-256-GCM (BouncyCastle)                  | 128KB        | 529,994.82 ns | 2,467.205 ns | 1,926.231 ns | 529,640.97 ns |    1816 B |
+| Encrypt · AES-256-GCM (CryptoHives-Scalar)            | 128KB        | 766,479.08 ns | 4,636.697 ns | 4,337.169 ns | 765,515.38 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aria-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aria-cbc-128.md
@@ -1,25 +1,25 @@
-﻿| Description                                 | TestDataSize | Mean         | Error      | StdDev     | Allocated |
-|-------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2.424 μs |  0.0065 μs |  0.0058 μs |    1288 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |     2.426 μs |  0.0089 μs |  0.0084 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2.334 μs |  0.0100 μs |  0.0094 μs |    1288 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |     2.438 μs |  0.0058 μs |  0.0052 μs |         - |
-|                                             |              |              |            |            |           |
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    15.032 μs |  0.0367 μs |  0.0325 μs |    3528 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |    17.548 μs |  0.0907 μs |  0.0849 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    15.108 μs |  0.0511 μs |  0.0478 μs |    3528 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |    17.744 μs |  0.0466 μs |  0.0436 μs |         - |
-|                                             |              |              |            |            |           |
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   116.269 μs |  0.3350 μs |  0.3133 μs |   21448 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |   137.312 μs |  0.3094 μs |  0.2894 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   126.286 μs |  1.4071 μs |  1.3162 μs |   21448 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |   138.259 μs |  0.8980 μs |  0.8400 μs |         - |
-|                                             |              |              |            |            |           |
-| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,845.168 μs |  3.0399 μs |  2.8435 μs |  328648 B |
-| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        | 2,197.193 μs |  6.3168 μs |  5.9087 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,869.519 μs |  6.8654 μs |  5.7330 μs |  328648 B |
-| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        | 2,206.402 μs | 12.2004 μs | 11.4123 μs |         - |
+﻿| Description                                 | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|-------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |     1.422 μs | 0.0086 μs | 0.0080 μs |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2.444 μs | 0.0101 μs | 0.0094 μs |    1288 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128B         |     1.421 μs | 0.0075 μs | 0.0070 μs |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128B         |     2.341 μs | 0.0131 μs | 0.0122 μs |    1288 B |
+|                                             |              |              |           |           |           |
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |    10.154 μs | 0.0579 μs | 0.0513 μs |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    15.058 μs | 0.0889 μs | 0.0831 μs |    3528 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 1KB          |    10.184 μs | 0.0564 μs | 0.0500 μs |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 1KB          |    15.249 μs | 0.0883 μs | 0.0782 μs |    3528 B |
+|                                             |              |              |           |           |           |
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |    79.852 μs | 0.4395 μs | 0.3896 μs |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   115.970 μs | 0.2453 μs | 0.2049 μs |   21448 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 8KB          |    80.031 μs | 0.2939 μs | 0.2605 μs |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 8KB          |   117.629 μs | 0.5000 μs | 0.3904 μs |   21448 B |
+|                                             |              |              |           |           |           |
+| Decrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        | 1,276.930 μs | 7.1693 μs | 6.3554 μs |         - |
+| Decrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,850.668 μs | 6.4922 μs | 6.0728 μs |  328648 B |
+|                                             |              |              |           |           |           |
+| Encrypt · ARIA-128-CBC (CryptoHives-Scalar) | 128KB        | 1,282.683 μs | 9.6670 μs | 8.5695 μs |         - |
+| Encrypt · ARIA-128-CBC (BouncyCastle)       | 128KB        | 1,873.519 μs | 5.8244 μs | 5.4482 μs |  328648 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aria-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/aria-cbc-256.md
@@ -1,25 +1,25 @@
-﻿| Description                                 | TestDataSize | Mean         | Error      | StdDev     | Allocated |
-|-------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     3.139 μs |  0.0097 μs |  0.0086 μs |    1496 B |
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |     3.265 μs |  0.0046 μs |  0.0041 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     3.019 μs |  0.0066 μs |  0.0059 μs |    1496 B |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |     3.245 μs |  0.0095 μs |  0.0089 μs |         - |
-|                                             |              |              |            |            |           |
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |    19.770 μs |  0.0639 μs |  0.0598 μs |    3736 B |
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |    23.202 μs |  0.1088 μs |  0.1018 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |    19.788 μs |  0.0563 μs |  0.0499 μs |    3736 B |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |    23.242 μs |  0.0999 μs |  0.0934 μs |         - |
-|                                             |              |              |            |            |           |
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |   153.419 μs |  0.5030 μs |  0.4705 μs |   21656 B |
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |   183.142 μs |  0.2246 μs |  0.1876 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |   154.947 μs |  0.3621 μs |  0.3388 μs |   21656 B |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |   183.539 μs |  1.0040 μs |  0.9391 μs |         - |
-|                                             |              |              |            |            |           |
-| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 2,431.475 μs |  6.3892 μs |  5.9764 μs |  328856 B |
-| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 2,929.538 μs | 13.8826 μs | 12.9858 μs |         - |
-|                                             |              |              |            |            |           |
-| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 2,463.406 μs |  5.1349 μs |  4.5519 μs |  328856 B |
-| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 2,927.544 μs |  7.8173 μs |  7.3123 μs |         - |
+﻿| Description                                 | TestDataSize | Mean         | Error      | StdDev    | Allocated |
+|-------------------------------------------- |------------- |-------------:|-----------:|----------:|----------:|
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |     1.851 μs |  0.0078 μs | 0.0066 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     3.171 μs |  0.0140 μs | 0.0124 μs |    1496 B |
+|                                             |              |              |            |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128B         |     1.855 μs |  0.0073 μs | 0.0065 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128B         |     3.031 μs |  0.0107 μs | 0.0095 μs |    1496 B |
+|                                             |              |              |            |           |           |
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |    13.305 μs |  0.0489 μs | 0.0433 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |    19.823 μs |  0.0688 μs | 0.0644 μs |    3736 B |
+|                                             |              |              |            |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 1KB          |    13.305 μs |  0.0729 μs | 0.0646 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 1KB          |    19.883 μs |  0.0850 μs | 0.0795 μs |    3736 B |
+|                                             |              |              |            |           |           |
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |   105.022 μs |  0.5500 μs | 0.5145 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |   152.947 μs |  0.5263 μs | 0.4666 μs |   21656 B |
+|                                             |              |              |            |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 8KB          |   104.956 μs |  0.6108 μs | 0.4769 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 8KB          |   154.912 μs |  0.5991 μs | 0.5311 μs |   21656 B |
+|                                             |              |              |            |           |           |
+| Decrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 1,676.004 μs |  9.2202 μs | 8.6246 μs |         - |
+| Decrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 2,438.043 μs | 10.9866 μs | 9.7393 μs |  328856 B |
+|                                             |              |              |            |           |           |
+| Encrypt · ARIA-256-CBC (CryptoHives-Scalar) | 128KB        | 1,679.356 μs | 10.4183 μs | 9.7453 μs |         - |
+| Encrypt · ARIA-256-CBC (BouncyCastle)       | 128KB        | 2,468.656 μs | 10.0598 μs | 8.9178 μs |  328856 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/asconhash256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/asconhash256.md
@@ -1,19 +1,19 @@
 ﻿| Description                                         | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |---------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 128B         |     561.8 ns |     1.54 ns |     1.37 ns |         - |
-| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 128B         |     762.5 ns |     1.94 ns |     1.62 ns |         - |
+| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 128B         |     564.7 ns |     3.13 ns |     2.61 ns |         - |
+| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 128B         |     764.3 ns |     6.30 ns |     5.90 ns |         - |
 |                                                     |              |              |             |             |           |
-| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 137B         |     594.5 ns |     1.26 ns |     1.05 ns |         - |
-| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 137B         |     799.3 ns |     2.48 ns |     2.20 ns |         - |
+| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 137B         |     596.8 ns |     2.21 ns |     2.07 ns |         - |
+| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 137B         |     802.6 ns |     3.35 ns |     3.13 ns |         - |
 |                                                     |              |              |             |             |           |
-| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 1KB          |   3,647.3 ns |     9.87 ns |     9.23 ns |         - |
-| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 1KB          |   4,955.0 ns |    18.84 ns |    14.71 ns |         - |
+| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 1KB          |   3,658.2 ns |    16.48 ns |    13.76 ns |         - |
+| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 1KB          |   4,951.2 ns |    16.97 ns |    15.04 ns |         - |
 |                                                     |              |              |             |             |           |
-| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 1025B        |   3,647.2 ns |     7.27 ns |     6.45 ns |         - |
-| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 1025B        |   4,942.7 ns |     9.00 ns |     8.42 ns |         - |
+| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 1025B        |   3,662.0 ns |    11.72 ns |    10.39 ns |         - |
+| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 1025B        |   4,969.6 ns |    23.35 ns |    20.70 ns |         - |
 |                                                     |              |              |             |             |           |
-| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 8KB          |  28,262.6 ns |    28.41 ns |    25.19 ns |         - |
-| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 8KB          |  38,419.0 ns |    83.80 ns |    74.29 ns |         - |
+| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 8KB          |  28,395.7 ns |    88.53 ns |    82.81 ns |         - |
+| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 8KB          |  38,488.8 ns |   161.04 ns |   134.47 ns |         - |
 |                                                     |              |              |             |             |           |
-| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 128KB        | 451,848.0 ns | 1,492.13 ns | 1,395.74 ns |         - |
-| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 128KB        | 612,689.4 ns | 2,077.04 ns | 1,841.24 ns |         - |
+| TryComputeHash · Ascon-Hash256 · CryptoHives-Scalar | 128KB        | 470,123.1 ns | 1,795.60 ns | 1,401.89 ns |         - |
+| TryComputeHash · Ascon-Hash256 · BouncyCastle       | 128KB        | 615,321.1 ns | 4,345.47 ns | 3,852.15 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/asconxof128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/asconxof128.md
@@ -1,19 +1,19 @@
 ﻿| Description                                        | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |--------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 128B         |     584.0 ns |    11.23 ns |    14.61 ns |         - |
-| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 128B         |     761.9 ns |     2.43 ns |     2.03 ns |         - |
+| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 128B         |     574.7 ns |     1.80 ns |     1.51 ns |         - |
+| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 128B         |     762.7 ns |     5.09 ns |     4.52 ns |         - |
 |                                                    |              |              |             |             |           |
-| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 137B         |     601.7 ns |     3.57 ns |     3.34 ns |         - |
-| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 137B         |     805.2 ns |     7.03 ns |     6.23 ns |         - |
+| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 137B         |     598.9 ns |     2.75 ns |     2.57 ns |         - |
+| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 137B         |     810.7 ns |     2.62 ns |     2.33 ns |         - |
 |                                                    |              |              |             |             |           |
-| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 1KB          |   3,667.6 ns |    13.05 ns |    11.57 ns |         - |
-| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 1KB          |   5,174.2 ns |    77.77 ns |    68.94 ns |         - |
+| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 1KB          |   3,666.2 ns |    12.96 ns |    10.82 ns |         - |
+| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 1KB          |   4,925.3 ns |    24.94 ns |    23.32 ns |         - |
 |                                                    |              |              |             |             |           |
-| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 1025B        |   3,674.7 ns |    21.74 ns |    20.33 ns |         - |
-| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 1025B        |   4,936.1 ns |    17.59 ns |    13.74 ns |         - |
+| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 1025B        |   3,669.2 ns |    13.18 ns |    11.68 ns |         - |
+| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 1025B        |   4,903.2 ns |    15.95 ns |    14.13 ns |         - |
 |                                                    |              |              |             |             |           |
-| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 8KB          |  28,470.4 ns |   160.34 ns |   142.14 ns |         - |
-| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 8KB          |  38,261.2 ns |   179.13 ns |   167.56 ns |         - |
+| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 8KB          |  28,420.5 ns |   145.69 ns |   129.15 ns |         - |
+| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 8KB          |  38,031.2 ns |   147.00 ns |   122.75 ns |         - |
 |                                                    |              |              |             |             |           |
-| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 128KB        | 452,295.0 ns | 1,546.53 ns | 1,370.96 ns |         - |
-| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 128KB        | 611,390.1 ns | 3,643.14 ns | 3,042.18 ns |         - |
+| TryComputeHash · Ascon-XOF128 · CryptoHives-Scalar | 128KB        | 453,575.7 ns | 1,541.47 ns | 1,287.20 ns |         - |
+| TryComputeHash · Ascon-XOF128 · BouncyCastle       | 128KB        | 610,509.3 ns | 4,523.18 ns | 4,009.68 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b256.md
@@ -1,37 +1,37 @@
-﻿| Description                                       | TestDataSize | Mean          | Error        | StdDev       | Allocated |
-|-------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 128B         |      82.86 ns |     0.165 ns |     0.146 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128B         |      98.03 ns |     0.211 ns |     0.197 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128B         |     101.46 ns |     0.320 ns |     0.300 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128B         |     127.83 ns |     0.298 ns |     0.264 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 128B         |     486.74 ns |     2.101 ns |     1.965 ns |    1120 B |
-|                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 137B         |     165.31 ns |     0.513 ns |     0.455 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 137B         |     179.25 ns |     1.020 ns |     0.904 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 137B         |     185.48 ns |     0.193 ns |     0.181 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 137B         |     250.42 ns |     0.504 ns |     0.447 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 137B         |     891.58 ns |     2.092 ns |     1.854 ns |    1136 B |
-|                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 1KB          |     619.83 ns |     1.204 ns |     0.940 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1KB          |     644.60 ns |     1.500 ns |     1.329 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1KB          |     704.40 ns |     2.488 ns |     1.942 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1KB          |     974.22 ns |     1.992 ns |     1.766 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 1KB          |   2,989.31 ns |     8.220 ns |     7.689 ns |    2016 B |
-|                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 1025B        |     703.04 ns |     1.077 ns |     0.899 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1025B        |     719.75 ns |     4.123 ns |     3.443 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1025B        |     791.51 ns |     1.522 ns |     1.424 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1025B        |   1,096.33 ns |     1.821 ns |     1.615 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 1025B        |   3,403.46 ns |     4.860 ns |     4.546 ns |    2024 B |
-|                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 8KB          |   4,916.54 ns |    21.059 ns |    16.442 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 8KB          |   5,005.50 ns |    13.704 ns |    11.443 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 8KB          |   5,519.51 ns |    18.966 ns |    15.838 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 8KB          |   7,746.93 ns |    16.948 ns |    15.853 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 8KB          |  23,031.77 ns |    59.889 ns |    56.021 ns |    9184 B |
-|                                                   |              |               |              |              |           |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 128KB        |  78,766.37 ns |   290.232 ns |   257.283 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128KB        |  79,892.70 ns |   277.249 ns |   231.516 ns |         - |
-| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128KB        |  88,306.89 ns |   307.366 ns |   287.510 ns |         - |
-| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128KB        | 124,232.82 ns |   252.967 ns |   236.626 ns |         - |
-| TryComputeHash · BLAKE2b-256 · Konscious          | 128KB        | 392,217.20 ns | 1,600.369 ns | 1,496.987 ns |  132078 B |
+﻿| Description                                       | TestDataSize | Mean          | Error        | StdDev     | Allocated |
+|-------------------------------------------------- |------------- |--------------:|-------------:|-----------:|----------:|
+| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 128B         |      84.13 ns |     0.231 ns |   0.216 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128B         |      95.14 ns |     0.235 ns |   0.220 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128B         |      98.38 ns |     0.237 ns |   0.222 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128B         |     125.63 ns |     0.368 ns |   0.326 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 128B         |     477.98 ns |     2.509 ns |   2.095 ns |    1120 B |
+|                                                   |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 137B         |     167.69 ns |     0.887 ns |   0.786 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 137B         |     176.19 ns |     0.513 ns |   0.480 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 137B         |     187.81 ns |     0.925 ns |   0.865 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 137B         |     250.36 ns |     0.820 ns |   0.640 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 137B         |     893.34 ns |     2.880 ns |   2.694 ns |    1136 B |
+|                                                   |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 1KB          |     624.09 ns |     1.834 ns |   1.531 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1KB          |     648.11 ns |     1.603 ns |   1.421 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1KB          |     711.96 ns |     1.558 ns |   1.458 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1KB          |     974.45 ns |     1.498 ns |   1.328 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 1KB          |   3,001.37 ns |    12.792 ns |  11.966 ns |    2016 B |
+|                                                   |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 1025B        |     705.76 ns |     1.482 ns |   1.386 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 1025B        |     725.73 ns |     2.113 ns |   1.764 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 1025B        |     792.97 ns |     1.867 ns |   1.746 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 1025B        |   1,099.43 ns |     5.725 ns |   5.075 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 1025B        |   3,418.95 ns |    13.789 ns |  12.898 ns |    2024 B |
+|                                                   |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 8KB          |   4,951.41 ns |    12.769 ns |  11.945 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 8KB          |   5,045.12 ns |    14.065 ns |  12.468 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 8KB          |   5,566.68 ns |    13.028 ns |  12.186 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 8KB          |   7,761.69 ns |    17.765 ns |  15.748 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 8KB          |  23,117.83 ns |    77.921 ns |  72.887 ns |    9184 B |
+|                                                   |              |               |              |            |           |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-AVX2   | 128KB        |  79,256.51 ns |   237.781 ns | 210.787 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Blake2Fast         | 128KB        |  80,655.84 ns |   470.832 ns | 417.381 ns |         - |
+| TryComputeHash · BLAKE2b-256 · BouncyCastle       | 128KB        |  88,701.72 ns |    98.943 ns |  87.711 ns |         - |
+| TryComputeHash · BLAKE2b-256 · CryptoHives-Scalar | 128KB        | 122,577.99 ns |   358.781 ns | 318.050 ns |         - |
+| TryComputeHash · BLAKE2b-256 · Konscious          | 128KB        | 393,151.26 ns | 1,067.332 ns | 998.383 ns |  132078 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2b512.md
@@ -1,37 +1,37 @@
-﻿| Description                                       | TestDataSize | Mean          | Error        | StdDev     | Allocated |
-|-------------------------------------------------- |------------- |--------------:|-------------:|-----------:|----------:|
-| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 128B         |      83.19 ns |     0.145 ns |   0.135 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128B         |      94.77 ns |     0.278 ns |   0.232 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128B         |     102.11 ns |     0.142 ns |   0.133 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128B         |     128.64 ns |     0.473 ns |   0.442 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 128B         |     501.21 ns |     2.040 ns |   1.908 ns |    1216 B |
-|                                                   |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 137B         |     165.40 ns |     0.581 ns |   0.453 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 137B         |     177.46 ns |     0.312 ns |   0.260 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 137B         |     188.81 ns |     0.234 ns |   0.196 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 137B         |     251.70 ns |     0.494 ns |   0.462 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 137B         |     912.09 ns |     1.225 ns |   1.086 ns |    1232 B |
-|                                                   |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 1KB          |     617.63 ns |     1.103 ns |   0.921 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1KB          |     642.58 ns |     1.838 ns |   1.535 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1KB          |     710.36 ns |     1.393 ns |   1.163 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1KB          |     975.68 ns |     1.857 ns |   1.646 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 1KB          |   3,016.54 ns |     5.874 ns |   5.494 ns |    2112 B |
-|                                                   |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 1025B        |     701.63 ns |     1.473 ns |   1.305 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1025B        |     730.00 ns |     0.831 ns |   0.649 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1025B        |     795.13 ns |     0.951 ns |   0.889 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1025B        |   1,097.94 ns |     2.042 ns |   1.910 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 1025B        |   3,424.88 ns |     7.997 ns |   7.480 ns |    2120 B |
-|                                                   |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 8KB          |   4,916.37 ns |    10.572 ns |   9.889 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 8KB          |   5,011.30 ns |    20.282 ns |  16.937 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 8KB          |   5,555.10 ns |    28.167 ns |  24.969 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 8KB          |   7,693.36 ns |    12.223 ns |  10.207 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 8KB          |  23,063.66 ns |    39.532 ns |  33.011 ns |    9280 B |
-|                                                   |              |               |              |            |           |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 128KB        |  78,622.44 ns |   468.224 ns | 415.069 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128KB        |  79,957.61 ns |   166.103 ns | 138.704 ns |         - |
-| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128KB        |  88,458.92 ns |   226.296 ns | 211.677 ns |         - |
-| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128KB        | 124,193.95 ns |   226.620 ns | 211.980 ns |         - |
-| TryComputeHash · BLAKE2b-512 · Konscious          | 128KB        | 391,159.01 ns | 1,020.559 ns | 954.631 ns |  132174 B |
+﻿| Description                                       | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|-------------------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 128B         |      83.55 ns |     0.246 ns |     0.205 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128B         |      96.08 ns |     0.258 ns |     0.229 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128B         |     102.50 ns |     0.277 ns |     0.259 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128B         |     127.03 ns |     0.332 ns |     0.278 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 128B         |     500.22 ns |     1.819 ns |     1.613 ns |    1216 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 137B         |     168.30 ns |     0.420 ns |     0.393 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 137B         |     176.58 ns |     0.364 ns |     0.304 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 137B         |     188.88 ns |     1.610 ns |     1.506 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 137B         |     250.73 ns |     1.781 ns |     1.487 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 137B         |     910.21 ns |     2.522 ns |     2.106 ns |    1232 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 1KB          |     623.14 ns |     1.473 ns |     1.378 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1KB          |     648.10 ns |     1.258 ns |     1.050 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1KB          |     713.05 ns |     1.679 ns |     1.571 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1KB          |     975.43 ns |     2.749 ns |     2.571 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 1KB          |   3,039.86 ns |    18.663 ns |    16.544 ns |    2112 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 1025B        |     709.10 ns |     1.395 ns |     1.305 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 1025B        |     726.74 ns |     1.937 ns |     1.811 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 1025B        |     803.67 ns |     1.483 ns |     1.388 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 1025B        |   1,100.42 ns |     4.588 ns |     4.292 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 1025B        |   3,450.92 ns |    16.711 ns |    15.631 ns |    2120 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 8KB          |   4,960.94 ns |     8.272 ns |     6.908 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 8KB          |   5,043.40 ns |    12.442 ns |    11.030 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 8KB          |   5,560.84 ns |    15.159 ns |    13.438 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 8KB          |   7,774.46 ns |    28.585 ns |    26.739 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 8KB          |  23,108.56 ns |    64.988 ns |    57.610 ns |    9280 B |
+|                                                   |              |               |              |              |           |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-AVX2   | 128KB        |  79,307.44 ns |   148.809 ns |   139.196 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Blake2Fast         | 128KB        |  80,579.10 ns |   231.713 ns |   205.408 ns |         - |
+| TryComputeHash · BLAKE2b-512 · BouncyCastle       | 128KB        |  88,814.68 ns |   211.523 ns |   197.859 ns |         - |
+| TryComputeHash · BLAKE2b-512 · CryptoHives-Scalar | 128KB        | 124,896.52 ns |   354.125 ns |   313.923 ns |         - |
+| TryComputeHash · BLAKE2b-512 · Konscious          | 128KB        | 393,971.05 ns | 1,732.514 ns | 1,535.829 ns |  132174 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s128.md
@@ -1,43 +1,43 @@
 ﻿| Description                                       | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |-------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 128B         |     153.7 ns |   0.36 ns |   0.34 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 128B         |     154.3 ns |   0.16 ns |   0.15 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128B         |     154.6 ns |   0.61 ns |   0.54 ns |         - |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128B         |     156.4 ns |   0.30 ns |   0.26 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 128B         |     157.8 ns |   0.19 ns |   0.18 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128B         |     159.7 ns |   1.71 ns |   1.51 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128B         |     154.2 ns |   0.35 ns |   0.31 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 128B         |     154.3 ns |   0.30 ns |   0.26 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 128B         |     154.5 ns |   0.26 ns |   0.25 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128B         |     156.3 ns |   1.14 ns |   1.01 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 128B         |     157.9 ns |   0.20 ns |   0.19 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128B         |     158.3 ns |   0.79 ns |   0.74 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 137B         |     225.3 ns |   0.37 ns |   0.31 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 137B         |     232.2 ns |   0.38 ns |   0.34 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 137B         |     233.3 ns |   0.93 ns |   0.83 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 137B         |     234.3 ns |   0.29 ns |   0.27 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 137B         |     239.4 ns |   0.21 ns |   0.19 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 137B         |     240.9 ns |   1.02 ns |   0.95 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 137B         |     226.7 ns |   0.39 ns |   0.34 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 137B         |     232.5 ns |   0.50 ns |   0.44 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 137B         |     232.7 ns |   2.02 ns |   1.79 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 137B         |     234.8 ns |   0.26 ns |   0.23 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 137B         |     240.9 ns |   0.29 ns |   0.27 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 137B         |     243.3 ns |   0.57 ns |   0.50 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1KB          |   1,133.9 ns |   4.35 ns |   4.07 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1KB          |   1,180.9 ns |   2.30 ns |   2.15 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 1KB          |   1,201.5 ns |   3.62 ns |   3.21 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 1KB          |   1,217.9 ns |   3.01 ns |   2.82 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1KB          |   1,232.1 ns |  24.04 ns |  35.24 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 1KB          |   1,240.2 ns |   1.47 ns |   1.37 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1KB          |   1,140.3 ns |   2.48 ns |   2.32 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1KB          |   1,198.9 ns |   3.96 ns |   3.71 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 1KB          |   1,204.9 ns |   3.53 ns |   2.94 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 1KB          |   1,217.5 ns |   1.85 ns |   1.64 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1KB          |   1,232.8 ns |   2.11 ns |   1.76 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 1KB          |   1,238.4 ns |   1.74 ns |   1.63 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1025B        |   1,204.6 ns |   3.37 ns |   3.15 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1025B        |   1,268.5 ns |   2.79 ns |   2.47 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 1025B        |   1,284.1 ns |   3.21 ns |   2.84 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1025B        |   1,292.4 ns |   3.64 ns |   3.22 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 1025B        |   1,293.2 ns |   1.48 ns |   1.15 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 1025B        |   1,320.8 ns |   1.88 ns |   1.76 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 1025B        |   1,209.7 ns |   4.48 ns |   4.19 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 1025B        |   1,270.8 ns |   2.65 ns |   2.35 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 1025B        |   1,285.5 ns |   6.16 ns |   5.76 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 1025B        |   1,298.5 ns |   2.02 ns |   1.89 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 1025B        |   1,304.3 ns |   3.94 ns |   3.68 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 1025B        |   1,322.8 ns |   2.30 ns |   2.15 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 8KB          |   8,933.0 ns |  28.70 ns |  23.97 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 8KB          |   9,500.9 ns |  28.12 ns |  26.31 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 8KB          |   9,621.7 ns |  15.59 ns |  13.02 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 8KB          |   9,625.0 ns |  52.34 ns |  43.70 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 8KB          |   9,687.1 ns |  15.12 ns |  13.40 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 8KB          |   9,893.4 ns |  17.26 ns |  16.14 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 8KB          |   8,997.8 ns |  34.02 ns |  28.41 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 8KB          |   9,545.7 ns |  41.42 ns |  36.72 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 8KB          |   9,625.6 ns |  26.36 ns |  24.66 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 8KB          |   9,664.6 ns |  41.97 ns |  39.26 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 8KB          |   9,723.9 ns |  30.40 ns |  26.95 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 8KB          |   9,906.8 ns |  11.56 ns |  10.81 ns |         - |
 |                                                   |              |              |           |           |           |
-| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128KB        | 142,762.6 ns | 527.86 ns | 467.93 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128KB        | 150,485.6 ns | 497.35 ns | 465.23 ns |         - |
-| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128KB        | 152,554.1 ns | 489.75 ns | 458.11 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 128KB        | 153,668.1 ns | 346.55 ns | 324.16 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 128KB        | 155,376.1 ns | 850.01 ns | 709.80 ns |         - |
-| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 128KB        | 158,099.0 ns | 192.69 ns | 180.24 ns |         - |
+| TryComputeHash · BLAKE2s-128 · Blake2Fast         | 128KB        | 143,963.1 ns | 504.80 ns | 421.53 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Scalar | 128KB        | 151,036.0 ns | 877.52 ns | 777.90 ns |         - |
+| TryComputeHash · BLAKE2s-128 · BouncyCastle       | 128KB        | 153,887.3 ns | 325.87 ns | 272.12 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-AVX2   | 128KB        | 154,442.2 ns | 637.63 ns | 532.45 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Ssse3  | 128KB        | 155,460.5 ns | 235.08 ns | 219.90 ns |         - |
+| TryComputeHash · BLAKE2s-128 · CryptoHives-Sse2   | 128KB        | 158,448.0 ns | 186.15 ns | 174.12 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake2s256.md
@@ -1,43 +1,43 @@
-﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev    | Allocated |
-|-------------------------------------------------- |------------- |-------------:|------------:|----------:|----------:|
-| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 128B         |     153.9 ns |     0.25 ns |   0.21 ns |         - |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128B         |     154.3 ns |     0.48 ns |   0.42 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128B         |     155.0 ns |     0.44 ns |   0.41 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 128B         |     156.4 ns |     0.16 ns |   0.15 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 128B         |     158.3 ns |     0.14 ns |   0.13 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128B         |     161.0 ns |     0.19 ns |   0.16 ns |         - |
-|                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 137B         |     226.1 ns |     0.42 ns |   0.37 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 137B         |     229.5 ns |     0.68 ns |   0.64 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 137B         |     233.4 ns |     1.41 ns |   1.25 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 137B         |     234.5 ns |     0.09 ns |   0.08 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 137B         |     239.8 ns |     0.26 ns |   0.24 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 137B         |     243.1 ns |     0.77 ns |   0.72 ns |         - |
-|                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1KB          |   1,135.3 ns |     3.63 ns |   3.39 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1KB          |   1,181.5 ns |     2.40 ns |   2.00 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 1KB          |   1,202.3 ns |     2.71 ns |   2.40 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 1KB          |   1,214.1 ns |     0.99 ns |   0.83 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1KB          |   1,219.5 ns |     2.52 ns |   2.24 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 1KB          |   1,243.0 ns |     1.53 ns |   1.43 ns |         - |
-|                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1025B        |   1,202.5 ns |     2.30 ns |   1.92 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1025B        |   1,277.0 ns |     3.43 ns |   3.21 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 1025B        |   1,282.7 ns |     2.33 ns |   2.18 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1025B        |   1,294.9 ns |     1.33 ns |   1.11 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 1025B        |   1,298.0 ns |     2.45 ns |   2.17 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 1025B        |   1,320.4 ns |     1.84 ns |   1.72 ns |         - |
-|                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 8KB          |   8,942.3 ns |    16.41 ns |  15.35 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 8KB          |   9,395.0 ns |    26.76 ns |  25.03 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 8KB          |   9,590.7 ns |    21.63 ns |  19.18 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 8KB          |   9,617.0 ns |    36.94 ns |  30.84 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 8KB          |   9,690.7 ns |    12.17 ns |  10.79 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 8KB          |   9,912.7 ns |    11.88 ns |  10.53 ns |         - |
-|                                                   |              |              |             |           |           |
-| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128KB        | 142,677.4 ns |   433.49 ns | 405.49 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128KB        | 150,481.1 ns |   394.21 ns | 368.75 ns |         - |
-| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128KB        | 152,703.2 ns |   625.80 ns | 554.75 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 128KB        | 153,850.7 ns |   508.93 ns | 424.98 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 128KB        | 155,375.7 ns | 1,114.46 ns | 987.94 ns |         - |
-| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 128KB        | 158,152.3 ns |   207.46 ns | 183.91 ns |         - |
+﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 128B         |     154.5 ns |     0.70 ns |     0.62 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128B         |     154.7 ns |     0.36 ns |     0.30 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 128B         |     154.9 ns |     0.17 ns |     0.15 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128B         |     157.6 ns |     0.35 ns |     0.31 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 128B         |     159.9 ns |     0.22 ns |     0.20 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128B         |     161.6 ns |     0.51 ns |     0.48 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 137B         |     233.4 ns |     0.84 ns |     0.79 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 137B         |     234.0 ns |     0.79 ns |     0.70 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 137B         |     234.8 ns |     0.14 ns |     0.13 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 137B         |     240.3 ns |     0.32 ns |     0.30 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 137B         |     245.1 ns |     1.31 ns |     1.23 ns |         - |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 137B         |     250.8 ns |     0.58 ns |     0.54 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1KB          |   1,141.2 ns |     3.56 ns |     3.15 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1KB          |   1,191.5 ns |    12.54 ns |    11.12 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 1KB          |   1,207.3 ns |     6.18 ns |     5.48 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 1KB          |   1,219.7 ns |     1.76 ns |     1.65 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1KB          |   1,233.9 ns |     3.43 ns |     2.86 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 1KB          |   1,238.4 ns |     1.25 ns |     1.04 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 1025B        |   1,210.1 ns |     3.16 ns |     2.80 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 1025B        |   1,274.9 ns |     5.81 ns |     5.15 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 1025B        |   1,291.2 ns |     5.66 ns |     5.29 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 1025B        |   1,297.6 ns |     2.69 ns |     2.51 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 1025B        |   1,309.2 ns |     3.40 ns |     3.01 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 1025B        |   1,320.1 ns |     1.97 ns |     1.84 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 8KB          |   9,009.9 ns |    24.42 ns |    21.64 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 8KB          |   9,438.0 ns |    31.32 ns |    26.15 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 8KB          |   9,632.5 ns |    30.54 ns |    28.57 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 8KB          |   9,648.3 ns |    41.08 ns |    38.42 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 8KB          |   9,714.1 ns |    24.31 ns |    22.74 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 8KB          |   9,899.8 ns |     9.15 ns |     7.14 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · BLAKE2s-256 · Blake2Fast         | 128KB        | 143,803.8 ns |   337.48 ns |   281.81 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Scalar | 128KB        | 151,225.6 ns |   585.27 ns |   547.46 ns |         - |
+| TryComputeHash · BLAKE2s-256 · BouncyCastle       | 128KB        | 153,660.5 ns |   440.59 ns |   412.13 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-AVX2   | 128KB        | 154,723.6 ns | 1,340.80 ns | 1,188.59 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Ssse3  | 128KB        | 154,973.5 ns |   268.47 ns |   251.13 ns |         - |
+| TryComputeHash · BLAKE2s-256 · CryptoHives-Sse2   | 128KB        | 158,363.6 ns |   389.87 ns |   364.69 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake3.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/blake3.md
@@ -1,31 +1,31 @@
 ﻿| Description                                  | TestDataSize | Mean            | Error        | StdDev       | Allocated |
 |--------------------------------------------- |------------- |----------------:|-------------:|-------------:|----------:|
-| TryComputeHash · BLAKE3 · Blake3Native       | 128B         |        98.61 ns |     0.855 ns |     0.758 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 128B         |       148.60 ns |     0.734 ns |     0.650 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128B         |       587.56 ns |     1.361 ns |     1.273 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 128B         |     1,285.48 ns |     2.560 ns |     2.395 ns |         - |
+| TryComputeHash · BLAKE3 · Blake3Native       | 128B         |        99.67 ns |     1.253 ns |     1.172 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 128B         |       153.56 ns |     0.642 ns |     0.601 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128B         |       593.99 ns |     1.881 ns |     1.760 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 128B         |     1,280.53 ns |     2.208 ns |     1.957 ns |         - |
 |                                              |              |                 |              |              |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 137B         |       149.40 ns |     0.445 ns |     0.416 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 137B         |       218.56 ns |     0.574 ns |     0.479 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 137B         |       868.48 ns |     2.480 ns |     2.320 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 137B         |     1,904.40 ns |     5.509 ns |     5.153 ns |         - |
+| TryComputeHash · BLAKE3 · Blake3Native       | 137B         |       150.99 ns |     0.547 ns |     0.485 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 137B         |       221.90 ns |     0.757 ns |     0.671 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 137B         |       878.13 ns |     2.261 ns |     2.004 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 137B         |     1,935.18 ns |     4.220 ns |     3.741 ns |         - |
 |                                              |              |                 |              |              |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 1KB          |       742.57 ns |     1.691 ns |     1.412 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 1KB          |     1,060.64 ns |     2.892 ns |     2.705 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1KB          |     4,526.54 ns |    17.652 ns |    16.512 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 1KB          |     9,566.15 ns |    24.563 ns |    22.976 ns |         - |
+| TryComputeHash · BLAKE3 · Blake3Native       | 1KB          |       753.39 ns |     5.106 ns |     5.015 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 1KB          |     1,075.63 ns |     3.015 ns |     2.672 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1KB          |     4,578.79 ns |    18.484 ns |    15.435 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 1KB          |     9,675.73 ns |    23.346 ns |    19.495 ns |         - |
 |                                              |              |                 |              |              |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 1025B        |       848.22 ns |     1.238 ns |     1.097 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 1025B        |     1,221.44 ns |     3.884 ns |     3.633 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1025B        |     5,112.20 ns |     9.463 ns |     8.852 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 1025B        |    10,785.00 ns |    22.956 ns |    21.473 ns |      56 B |
+| TryComputeHash · BLAKE3 · Blake3Native       | 1025B        |       850.73 ns |     2.275 ns |     1.776 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 1025B        |     1,229.09 ns |     3.371 ns |     3.153 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 1025B        |     5,197.38 ns |    22.377 ns |    20.931 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 1025B        |    10,760.39 ns |    21.098 ns |    17.618 ns |      56 B |
 |                                              |              |                 |              |              |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 8KB          |     1,157.22 ns |     4.674 ns |     4.372 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 8KB          |    10,261.63 ns |    86.687 ns |    81.087 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 8KB          |    38,159.58 ns |    89.667 ns |    83.874 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 8KB          |    79,464.11 ns |   272.869 ns |   255.242 ns |     392 B |
+| TryComputeHash · BLAKE3 · Blake3Native       | 8KB          |     1,171.02 ns |     2.191 ns |     1.942 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 8KB          |    10,147.28 ns |   115.494 ns |   108.033 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 8KB          |    38,745.23 ns |   133.595 ns |   111.558 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 8KB          |    81,347.98 ns |   228.671 ns |   202.711 ns |     392 B |
 |                                              |              |                 |              |              |           |
-| TryComputeHash · BLAKE3 · Blake3Native       | 128KB        |    14,185.28 ns |    26.225 ns |    23.248 ns |         - |
-| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 128KB        |   166,110.51 ns |   838.205 ns |   784.057 ns |      24 B |
-| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128KB        |   616,523.33 ns | 1,480.328 ns | 1,312.272 ns |      24 B |
-| TryComputeHash · BLAKE3 · BouncyCastle       | 128KB        | 1,304,976.51 ns | 3,011.859 ns | 2,669.935 ns |    7112 B |
+| TryComputeHash · BLAKE3 · Blake3Native       | 128KB        |    14,404.03 ns |    89.875 ns |    70.169 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Ssse3  | 128KB        |   165,900.83 ns |   375.950 ns |   333.270 ns |         - |
+| TryComputeHash · BLAKE3 · CryptoHives-Scalar | 128KB        |   623,212.95 ns | 1,899.429 ns | 1,683.794 ns |         - |
+| TryComputeHash · BLAKE3 · BouncyCastle       | 128KB        | 1,370,159.36 ns | 2,330.505 ns | 2,179.956 ns |    7112 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/camellia-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/camellia-cbc-128.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean           | Error       | StdDev      | Allocated |
-|------------------------------------------------ |------------- |---------------:|------------:|------------:|----------:|
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |       997.3 ns |     3.51 ns |     3.28 ns |     576 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     1,432.2 ns |     2.16 ns |     2.02 ns |         - |
-|                                                 |              |                |             |             |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |       986.3 ns |     2.90 ns |     2.71 ns |     576 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     1,392.4 ns |    24.43 ns |    22.85 ns |         - |
-|                                                 |              |                |             |             |           |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |     6,631.5 ns |    25.57 ns |    23.92 ns |    2816 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |    10,285.8 ns |    16.70 ns |    15.62 ns |         - |
-|                                                 |              |                |             |             |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |     6,472.6 ns |    25.34 ns |    23.70 ns |    2816 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |    10,019.4 ns |    42.54 ns |    33.21 ns |         - |
-|                                                 |              |                |             |             |           |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |    51,051.3 ns |   128.53 ns |   107.32 ns |   20736 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |    81,061.6 ns |   195.34 ns |   182.72 ns |         - |
-|                                                 |              |                |             |             |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |    50,461.3 ns |    92.26 ns |    81.78 ns |   20736 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |    77,783.5 ns |   271.69 ns |   254.14 ns |         - |
-|                                                 |              |                |             |             |           |
-| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        |   815,945.8 ns | 1,499.09 ns | 1,402.25 ns |  327936 B |
-| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 1,288,167.6 ns | 2,416.30 ns | 2,260.21 ns |         - |
-|                                                 |              |                |             |             |           |
-| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        |   804,039.2 ns | 3,087.85 ns | 2,888.38 ns |  327936 B |
-| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 1,267,783.9 ns | 6,593.98 ns | 6,168.01 ns |         - |
+﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     558.5 ns |     1.58 ns |     1.32 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |   1,000.8 ns |     4.70 ns |     4.17 ns |     576 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128B         |     595.3 ns |     1.70 ns |     1.33 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128B         |     988.9 ns |     4.18 ns |     3.91 ns |     576 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,136.4 ns |    11.15 ns |     9.89 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   6,567.2 ns |    22.50 ns |    21.04 ns |    2816 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 1KB          |   4,245.5 ns |    13.97 ns |    11.66 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 1KB          |   6,491.1 ns |    33.41 ns |    29.62 ns |    2816 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  31,046.8 ns |    84.39 ns |    70.47 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  51,167.1 ns |   213.12 ns |   199.36 ns |   20736 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 8KB          |  32,941.2 ns |   122.10 ns |   101.96 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 8KB          |  50,629.8 ns |   215.24 ns |   201.34 ns |   20736 B |
+|                                                 |              |              |             |             |           |
+| Decrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 524,037.7 ns | 1,927.75 ns | 1,803.22 ns |         - |
+| Decrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 816,509.8 ns | 1,865.98 ns | 1,558.17 ns |  327936 B |
+|                                                 |              |              |             |             |           |
+| Encrypt · Camellia-128-CBC (CryptoHives-Scalar) | 128KB        | 525,168.9 ns | 1,186.69 ns |   926.49 ns |         - |
+| Encrypt · Camellia-128-CBC (BouncyCastle)       | 128KB        | 805,274.2 ns | 3,474.21 ns | 2,712.44 ns |  327936 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/camellia-cbc-192.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/camellia-cbc-192.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|------------------------------------------------ |------------- |-------------:|----------:|----------:|----------:|
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |     1.236 μs | 0.0042 μs | 0.0039 μs |     584 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     1.768 μs | 0.0024 μs | 0.0022 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |     1.233 μs | 0.0036 μs | 0.0034 μs |     584 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |     1.762 μs | 0.0048 μs | 0.0045 μs |         - |
-|                                                 |              |              |           |           |           |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |     8.173 μs | 0.0224 μs | 0.0209 μs |    2824 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |    12.699 μs | 0.0194 μs | 0.0162 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |     8.172 μs | 0.0200 μs | 0.0187 μs |    2824 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |    12.678 μs | 0.0275 μs | 0.0257 μs |         - |
-|                                                 |              |              |           |           |           |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |    63.920 μs | 0.2255 μs | 0.1999 μs |   20744 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |   100.108 μs | 0.2153 μs | 0.2014 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |    62.978 μs | 0.1995 μs | 0.1666 μs |   20744 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |   102.859 μs | 0.2755 μs | 0.2301 μs |         - |
-|                                                 |              |              |           |           |           |
-| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 1,019.816 μs | 3.8777 μs | 3.6272 μs |  327944 B |
-| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 1,598.901 μs | 3.6409 μs | 3.4057 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 1,025.239 μs | 4.5628 μs | 4.2680 μs |  327944 B |
-| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        | 1,601.669 μs | 9.3909 μs | 8.7842 μs |         - |
+﻿| Description                                     | TestDataSize | Mean           | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |---------------:|------------:|------------:|----------:|
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |       761.1 ns |     1.76 ns |     1.56 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |     1,233.4 ns |     6.74 ns |     5.62 ns |     584 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128B         |       794.4 ns |     0.57 ns |     0.44 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128B         |     1,233.1 ns |     4.15 ns |     3.68 ns |     584 B |
+|                                                 |              |                |             |             |           |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |     5,357.5 ns |    15.35 ns |    14.36 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |     8,213.6 ns |    44.53 ns |    41.66 ns |    2824 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 1KB          |     5,601.4 ns |    12.34 ns |    10.94 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 1KB          |     8,120.3 ns |    59.18 ns |    55.36 ns |    2824 B |
+|                                                 |              |                |             |             |           |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |    43,069.6 ns |   136.11 ns |   113.66 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |    63,971.7 ns |   362.27 ns |   338.87 ns |   20744 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 8KB          |    44,457.5 ns |   163.77 ns |   153.19 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 8KB          |    63,345.8 ns |   534.75 ns |   446.54 ns |   20744 B |
+|                                                 |              |                |             |             |           |
+| Decrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        |   694,795.2 ns | 1,815.37 ns | 1,609.28 ns |         - |
+| Decrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 1,019,544.0 ns | 3,272.99 ns | 2,733.09 ns |  327944 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-192-CBC (CryptoHives-Scalar) | 128KB        |   737,488.5 ns | 2,697.29 ns | 2,523.04 ns |         - |
+| Encrypt · Camellia-192-CBC (BouncyCastle)       | 128KB        | 1,009,565.8 ns | 6,176.17 ns | 5,777.20 ns |  327944 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/camellia-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/camellia-cbc-256.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|------------------------------------------------ |------------- |-------------:|----------:|----------:|----------:|
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |     1.228 μs | 0.0020 μs | 0.0018 μs |     592 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     1.770 μs | 0.0012 μs | 0.0011 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |     1.228 μs | 0.0028 μs | 0.0027 μs |     592 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |     1.782 μs | 0.0112 μs | 0.0094 μs |         - |
-|                                                 |              |              |           |           |           |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |     8.171 μs | 0.0246 μs | 0.0230 μs |    2832 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |    12.707 μs | 0.0343 μs | 0.0321 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |     8.054 μs | 0.0251 μs | 0.0235 μs |    2832 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |    12.680 μs | 0.0184 μs | 0.0163 μs |         - |
-|                                                 |              |              |           |           |           |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |    63.813 μs | 0.3432 μs | 0.3211 μs |   20752 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |   100.675 μs | 0.2096 μs | 0.1961 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |    63.168 μs | 0.1463 μs | 0.1369 μs |   20752 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |    99.739 μs | 0.1687 μs | 0.1578 μs |         - |
-|                                                 |              |              |           |           |           |
-| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 1,022.040 μs | 4.8671 μs | 4.0642 μs |  327952 B |
-| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 1,594.247 μs | 3.9350 μs | 3.6808 μs |         - |
-|                                                 |              |              |           |           |           |
-| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 1,005.791 μs | 3.9560 μs | 3.5069 μs |  327952 B |
-| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        | 1,593.249 μs | 2.9679 μs | 2.7762 μs |         - |
+﻿| Description                                     | TestDataSize | Mean           | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |---------------:|------------:|------------:|----------:|
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |       750.5 ns |     2.23 ns |     2.08 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |     1,233.7 ns |     7.38 ns |     6.90 ns |     592 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128B         |       804.1 ns |     2.59 ns |     2.29 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128B         |     1,222.7 ns |     4.23 ns |     3.53 ns |     592 B |
+|                                                 |              |                |             |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |     5,308.2 ns |    21.39 ns |    17.86 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |     8,187.9 ns |    49.43 ns |    43.82 ns |    2832 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 1KB          |     5,605.6 ns |    22.87 ns |    20.27 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 1KB          |     8,087.9 ns |    34.91 ns |    27.25 ns |    2832 B |
+|                                                 |              |                |             |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |    42,935.1 ns |   128.89 ns |   114.26 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |    64,006.4 ns |   404.48 ns |   358.56 ns |   20752 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 8KB          |    44,244.8 ns |   176.47 ns |   156.43 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 8KB          |    63,254.9 ns |   255.71 ns |   226.68 ns |   20752 B |
+|                                                 |              |                |             |             |           |
+| Decrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        |   708,096.8 ns | 1,033.36 ns |   862.91 ns |         - |
+| Decrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 1,023,024.3 ns | 5,659.55 ns | 5,293.95 ns |  327952 B |
+|                                                 |              |                |             |             |           |
+| Encrypt · Camellia-256-CBC (CryptoHives-Scalar) | 128KB        |   718,076.9 ns | 1,384.94 ns | 1,227.71 ns |         - |
+| Encrypt · Camellia-256-CBC (BouncyCastle)       | 128KB        | 1,016,476.3 ns | 6,341.07 ns | 5,931.44 ns |  327952 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/chacha20-poly1305.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/chacha20-poly1305.md
@@ -1,57 +1,57 @@
 ﻿| Description                                      | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| Decrypt · ChaCha20-Poly1305 (OS)                 | 128B         |     342.3 ns |     1.00 ns |     0.94 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     342.6 ns |     0.45 ns |     0.42 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     382.7 ns |     0.59 ns |     0.52 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128B         |     572.5 ns |     1.66 ns |     1.55 ns |      48 B |
-| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128B         |     703.9 ns |     2.83 ns |     2.64 ns |     416 B |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |     866.1 ns |     1.37 ns |     1.28 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     340.1 ns |     5.76 ns |     5.39 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (OS)                 | 128B         |     355.0 ns |     2.40 ns |     2.13 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     393.1 ns |     4.04 ns |     3.58 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128B         |     590.9 ns |     2.55 ns |     2.26 ns |      48 B |
+| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128B         |     737.7 ns |     4.73 ns |     4.43 ns |     416 B |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |     914.9 ns |    14.82 ns |    13.87 ns |         - |
 |                                                  |              |              |             |             |           |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     295.1 ns |     0.61 ns |     0.57 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (OS)                 | 128B         |     342.2 ns |     0.71 ns |     0.63 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     350.8 ns |     0.32 ns |     0.27 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128B         |     406.2 ns |     0.98 ns |     0.91 ns |     336 B |
-| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128B         |     534.1 ns |     0.97 ns |     0.86 ns |      48 B |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |     837.5 ns |     1.16 ns |     1.09 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     291.5 ns |     2.18 ns |     1.93 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     349.9 ns |     6.27 ns |     5.87 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (OS)                 | 128B         |     362.0 ns |     5.92 ns |     5.53 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128B         |     427.2 ns |     6.07 ns |     5.38 ns |     336 B |
+| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128B         |     544.8 ns |     4.69 ns |     3.92 ns |      48 B |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |     859.3 ns |    13.70 ns |    12.82 ns |         - |
 |                                                  |              |              |             |             |           |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,252.4 ns |     1.99 ns |     1.86 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 1KB          |   1,682.7 ns |     3.84 ns |     3.59 ns |     416 B |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,717.9 ns |     1.92 ns |     1.79 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (OS)                 | 1KB          |   1,751.5 ns |     2.68 ns |     2.50 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   2,553.5 ns |     5.95 ns |     5.28 ns |      72 B |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,592.6 ns |     5.93 ns |     5.25 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,290.6 ns |    11.75 ns |    10.99 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,738.1 ns |     3.36 ns |     3.14 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 1KB          |   1,755.2 ns |    12.97 ns |    12.14 ns |     416 B |
+| Decrypt · ChaCha20-Poly1305 (OS)                 | 1KB          |   1,793.7 ns |     6.40 ns |     5.99 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   2,656.4 ns |    15.41 ns |    14.41 ns |      72 B |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,566.8 ns |    27.65 ns |    24.51 ns |         - |
 |                                                  |              |              |             |             |           |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,225.4 ns |     1.49 ns |     1.32 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 1KB          |   1,395.0 ns |     3.16 ns |     2.95 ns |     336 B |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,669.9 ns |     0.55 ns |     0.43 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (OS)                 | 1KB          |   1,749.2 ns |     2.58 ns |     2.41 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   2,506.2 ns |     4.92 ns |     4.61 ns |      72 B |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,428.2 ns |    16.03 ns |    14.99 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,236.2 ns |     7.77 ns |     6.89 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 1KB          |   1,464.5 ns |    22.00 ns |    20.58 ns |     336 B |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,739.2 ns |    34.03 ns |    34.95 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (OS)                 | 1KB          |   1,806.1 ns |    19.25 ns |    17.07 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   2,618.3 ns |    48.71 ns |    45.57 ns |      72 B |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,581.0 ns |    87.72 ns |    93.86 ns |         - |
 |                                                  |              |              |             |             |           |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,663.5 ns |     9.17 ns |     7.65 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 8KB          |   9,448.9 ns |    19.79 ns |    18.52 ns |     416 B |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,312.8 ns |    14.22 ns |    13.30 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (OS)                 | 8KB          |  13,037.5 ns |    27.70 ns |    25.91 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  18,460.3 ns |    43.74 ns |    40.91 ns |      72 B |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  33,174.0 ns |    47.65 ns |    44.58 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,800.9 ns |    36.11 ns |    32.01 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 8KB          |   9,859.2 ns |    73.26 ns |    68.53 ns |     416 B |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,443.6 ns |    26.82 ns |    22.40 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (OS)                 | 8KB          |  13,277.8 ns |    31.32 ns |    27.77 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  18,633.1 ns |    99.59 ns |    93.15 ns |      72 B |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  33,956.8 ns |   361.42 ns |   338.07 ns |         - |
 |                                                  |              |              |             |             |           |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,614.3 ns |    15.38 ns |    13.63 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 8KB          |   9,327.4 ns |    15.06 ns |    14.09 ns |     336 B |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,268.8 ns |    10.48 ns |     9.80 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (OS)                 | 8KB          |  13,036.2 ns |    18.87 ns |    16.73 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  18,138.1 ns |    37.79 ns |    35.35 ns |      72 B |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  33,068.5 ns |    62.13 ns |    58.12 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,840.1 ns |   164.71 ns |   154.07 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 8KB          |   9,720.5 ns |   183.37 ns |   180.10 ns |     336 B |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,560.6 ns |   233.48 ns |   218.40 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (OS)                 | 8KB          |  13,328.8 ns |   135.29 ns |   119.93 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  19,108.5 ns |   379.93 ns |   406.52 ns |      72 B |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  34,108.0 ns |   636.60 ns |   595.47 ns |         - |
 |                                                  |              |              |             |             |           |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 135,438.6 ns |   206.55 ns |   183.10 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128KB        | 145,704.3 ns |   482.52 ns |   451.35 ns |     416 B |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 194,017.2 ns |   229.67 ns |   214.83 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (OS)                 | 128KB        | 206,806.3 ns |   339.58 ns |   301.03 ns |         - |
-| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 290,364.0 ns | 1,249.90 ns | 1,169.16 ns |      72 B |
-| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 524,822.1 ns |   738.00 ns |   690.33 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 137,147.5 ns |   382.31 ns |   357.61 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128KB        | 150,580.9 ns | 1,054.92 ns |   935.16 ns |     416 B |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 195,815.1 ns |   698.66 ns |   653.53 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (OS)                 | 128KB        | 209,457.1 ns | 2,572.46 ns | 2,406.28 ns |         - |
+| Decrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 301,524.9 ns | 1,655.87 ns | 1,548.90 ns |      72 B |
+| Decrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 537,618.9 ns | 4,345.09 ns | 4,064.40 ns |         - |
 |                                                  |              |              |             |             |           |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 135,391.6 ns |   135.27 ns |   126.54 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128KB        | 147,828.9 ns |   197.10 ns |   174.73 ns |     336 B |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 194,029.2 ns |   211.68 ns |   198.01 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (OS)                 | 128KB        | 206,592.8 ns |   271.03 ns |   253.52 ns |         - |
-| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 290,543.6 ns |   727.42 ns |   680.43 ns |      72 B |
-| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 524,291.1 ns |   907.66 ns |   849.02 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 137,765.4 ns | 2,026.47 ns | 1,796.41 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (BouncyCastle)       | 128KB        | 154,914.0 ns | 2,926.50 ns | 3,252.79 ns |     336 B |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 198,854.7 ns | 3,339.44 ns | 3,123.72 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (OS)                 | 128KB        | 213,292.6 ns | 3,658.50 ns | 3,422.16 ns |         - |
+| Encrypt · ChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 302,588.3 ns | 5,606.65 ns | 5,244.46 ns |      72 B |
+| Encrypt · ChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 538,066.4 ns | 5,095.20 ns | 4,254.72 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/chacha20.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/chacha20.md
@@ -1,49 +1,49 @@
-﻿| Description                             | TestDataSize | Mean          | Error        | StdDev     | Allocated |
-|---------------------------------------- |------------- |--------------:|-------------:|-----------:|----------:|
-| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 128B         |      67.55 ns |     0.261 ns |   0.218 ns |         - |
-| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 128B         |     126.01 ns |     0.460 ns |   0.384 ns |         - |
-| Decrypt · ChaCha20 (NaCl.Core)          | 128B         |     277.67 ns |     0.477 ns |   0.423 ns |      24 B |
-| Decrypt · ChaCha20 (BouncyCastle)       | 128B         |     308.61 ns |     1.093 ns |   1.023 ns |      96 B |
-| Decrypt · ChaCha20 (CryptoHives-Scalar) | 128B         |     454.74 ns |     0.440 ns |   0.412 ns |         - |
-|                                         |              |               |              |            |           |
-| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 128B         |      67.68 ns |     0.205 ns |   0.182 ns |         - |
-| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 128B         |     123.94 ns |     0.455 ns |   0.404 ns |         - |
-| Encrypt · ChaCha20 (NaCl.Core)          | 128B         |     280.05 ns |     0.524 ns |   0.490 ns |      24 B |
-| Encrypt · ChaCha20 (BouncyCastle)       | 128B         |     308.35 ns |     0.520 ns |   0.461 ns |      96 B |
-| Encrypt · ChaCha20 (CryptoHives-Scalar) | 128B         |     453.89 ns |     0.686 ns |   0.642 ns |         - |
-|                                         |              |               |              |            |           |
-| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 1KB          |     512.56 ns |     1.483 ns |   1.315 ns |         - |
-| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 1KB          |     987.01 ns |     3.093 ns |   2.742 ns |         - |
-| Decrypt · ChaCha20 (NaCl.Core)          | 1KB          |   1,493.61 ns |     2.311 ns |   2.162 ns |      24 B |
-| Decrypt · ChaCha20 (BouncyCastle)       | 1KB          |   1,769.99 ns |     3.590 ns |   3.182 ns |      96 B |
-| Decrypt · ChaCha20 (CryptoHives-Scalar) | 1KB          |   3,538.19 ns |     4.612 ns |   4.314 ns |         - |
-|                                         |              |               |              |            |           |
-| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 1KB          |     513.55 ns |     1.166 ns |   1.034 ns |         - |
-| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 1KB          |     992.18 ns |    15.295 ns |  11.941 ns |         - |
-| Encrypt · ChaCha20 (NaCl.Core)          | 1KB          |   1,505.34 ns |     2.473 ns |   2.193 ns |      24 B |
-| Encrypt · ChaCha20 (BouncyCastle)       | 1KB          |   1,769.83 ns |     2.930 ns |   2.740 ns |      96 B |
-| Encrypt · ChaCha20 (CryptoHives-Scalar) | 1KB          |   3,535.70 ns |     5.249 ns |   4.910 ns |         - |
-|                                         |              |               |              |            |           |
-| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 8KB          |   4,077.43 ns |     8.447 ns |   7.054 ns |         - |
-| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 8KB          |   7,960.62 ns |   108.865 ns |  96.506 ns |         - |
-| Decrypt · ChaCha20 (NaCl.Core)          | 8KB          |  11,209.76 ns |    23.650 ns |  20.965 ns |      24 B |
-| Decrypt · ChaCha20 (BouncyCastle)       | 8KB          |  13,402.93 ns |    30.141 ns |  28.194 ns |      96 B |
-| Decrypt · ChaCha20 (CryptoHives-Scalar) | 8KB          |  28,267.31 ns |    32.359 ns |  30.269 ns |         - |
-|                                         |              |               |              |            |           |
-| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 8KB          |   4,083.97 ns |     8.244 ns |   7.711 ns |         - |
-| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 8KB          |   7,897.85 ns |    18.287 ns |  17.106 ns |         - |
-| Encrypt · ChaCha20 (NaCl.Core)          | 8KB          |  11,293.96 ns |    17.476 ns |  16.347 ns |      24 B |
-| Encrypt · ChaCha20 (BouncyCastle)       | 8KB          |  13,414.61 ns |    29.113 ns |  27.233 ns |      96 B |
-| Encrypt · ChaCha20 (CryptoHives-Scalar) | 8KB          |  28,136.97 ns |    28.923 ns |  27.054 ns |         - |
-|                                         |              |               |              |            |           |
-| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 128KB        |  65,264.31 ns |   220.054 ns | 205.839 ns |         - |
-| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 128KB        | 126,363.85 ns |   511.892 ns | 427.453 ns |         - |
-| Decrypt · ChaCha20 (NaCl.Core)          | 128KB        | 206,611.27 ns | 1,059.845 ns | 885.018 ns |      24 B |
-| Decrypt · ChaCha20 (BouncyCastle)       | 128KB        | 213,005.90 ns |   352.533 ns | 312.511 ns |      96 B |
-| Decrypt · ChaCha20 (CryptoHives-Scalar) | 128KB        | 451,890.37 ns |   649.580 ns | 607.617 ns |         - |
-|                                         |              |               |              |            |           |
-| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 128KB        |  65,191.51 ns |   153.744 ns | 128.383 ns |         - |
-| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 128KB        | 126,474.21 ns |   371.853 ns | 347.832 ns |         - |
-| Encrypt · ChaCha20 (NaCl.Core)          | 128KB        | 205,533.24 ns |   789.461 ns | 659.236 ns |      24 B |
-| Encrypt · ChaCha20 (BouncyCastle)       | 128KB        | 213,216.11 ns |   483.442 ns | 452.212 ns |      96 B |
-| Encrypt · ChaCha20 (CryptoHives-Scalar) | 128KB        | 450,820.34 ns |   651.128 ns | 609.065 ns |         - |
+﻿| Description                             | TestDataSize | Mean          | Error        | StdDev       | Allocated |
+|---------------------------------------- |------------- |--------------:|-------------:|-------------:|----------:|
+| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 128B         |      68.12 ns |     0.303 ns |     0.268 ns |         - |
+| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 128B         |     125.02 ns |     0.483 ns |     0.428 ns |         - |
+| Decrypt · ChaCha20 (NaCl.Core)          | 128B         |     278.77 ns |     0.909 ns |     0.759 ns |      24 B |
+| Decrypt · ChaCha20 (BouncyCastle)       | 128B         |     361.47 ns |     1.201 ns |     1.124 ns |      96 B |
+| Decrypt · ChaCha20 (CryptoHives-Scalar) | 128B         |     457.72 ns |     0.780 ns |     0.692 ns |         - |
+|                                         |              |               |              |              |           |
+| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 128B         |      67.99 ns |     0.448 ns |     0.397 ns |         - |
+| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 128B         |     125.49 ns |     0.405 ns |     0.379 ns |         - |
+| Encrypt · ChaCha20 (NaCl.Core)          | 128B         |     283.42 ns |     0.451 ns |     0.400 ns |      24 B |
+| Encrypt · ChaCha20 (BouncyCastle)       | 128B         |     308.45 ns |     1.069 ns |     1.000 ns |      96 B |
+| Encrypt · ChaCha20 (CryptoHives-Scalar) | 128B         |     455.31 ns |     1.198 ns |     1.062 ns |         - |
+|                                         |              |               |              |              |           |
+| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 1KB          |     517.04 ns |     1.487 ns |     1.242 ns |         - |
+| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 1KB          |     993.49 ns |     1.972 ns |     1.748 ns |         - |
+| Decrypt · ChaCha20 (NaCl.Core)          | 1KB          |   1,492.87 ns |     2.690 ns |     2.384 ns |      24 B |
+| Decrypt · ChaCha20 (BouncyCastle)       | 1KB          |   1,782.13 ns |     6.678 ns |     5.920 ns |      96 B |
+| Decrypt · ChaCha20 (CryptoHives-Scalar) | 1KB          |   3,549.72 ns |     7.166 ns |     6.352 ns |         - |
+|                                         |              |               |              |              |           |
+| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 1KB          |     517.17 ns |     1.431 ns |     1.269 ns |         - |
+| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 1KB          |     993.84 ns |     3.039 ns |     2.843 ns |         - |
+| Encrypt · ChaCha20 (NaCl.Core)          | 1KB          |   1,510.31 ns |     4.616 ns |     3.855 ns |      24 B |
+| Encrypt · ChaCha20 (BouncyCastle)       | 1KB          |   1,778.35 ns |    15.179 ns |    14.198 ns |      96 B |
+| Encrypt · ChaCha20 (CryptoHives-Scalar) | 1KB          |   3,550.02 ns |     7.507 ns |     6.655 ns |         - |
+|                                         |              |               |              |              |           |
+| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 8KB          |   4,112.21 ns |    10.676 ns |     8.335 ns |         - |
+| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 8KB          |   7,973.43 ns |    15.091 ns |    12.601 ns |         - |
+| Decrypt · ChaCha20 (NaCl.Core)          | 8KB          |  11,215.16 ns |    17.882 ns |    15.852 ns |      24 B |
+| Decrypt · ChaCha20 (BouncyCastle)       | 8KB          |  13,453.92 ns |    35.210 ns |    29.402 ns |      96 B |
+| Decrypt · ChaCha20 (CryptoHives-Scalar) | 8KB          |  28,355.75 ns |    57.121 ns |    50.636 ns |         - |
+|                                         |              |               |              |              |           |
+| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 8KB          |   4,108.21 ns |     7.424 ns |     6.199 ns |         - |
+| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 8KB          |   7,967.10 ns |    18.206 ns |    16.139 ns |         - |
+| Encrypt · ChaCha20 (NaCl.Core)          | 8KB          |  11,203.31 ns |    17.016 ns |    15.084 ns |      24 B |
+| Encrypt · ChaCha20 (BouncyCastle)       | 8KB          |  13,428.49 ns |    33.346 ns |    27.846 ns |      96 B |
+| Encrypt · ChaCha20 (CryptoHives-Scalar) | 8KB          |  28,222.93 ns |    29.969 ns |    26.567 ns |         - |
+|                                         |              |               |              |              |           |
+| Decrypt · ChaCha20 (CryptoHives-AVX2)   | 128KB        |  65,691.31 ns |   148.419 ns |   138.831 ns |         - |
+| Decrypt · ChaCha20 (CryptoHives-SSSE3)  | 128KB        | 127,341.47 ns |   419.809 ns |   350.560 ns |         - |
+| Decrypt · ChaCha20 (NaCl.Core)          | 128KB        | 177,926.79 ns |   519.198 ns |   485.658 ns |      24 B |
+| Decrypt · ChaCha20 (BouncyCastle)       | 128KB        | 213,883.77 ns |   557.884 ns |   494.550 ns |      96 B |
+| Decrypt · ChaCha20 (CryptoHives-Scalar) | 128KB        | 453,279.03 ns | 1,172.416 ns | 1,039.316 ns |         - |
+|                                         |              |               |              |              |           |
+| Encrypt · ChaCha20 (CryptoHives-AVX2)   | 128KB        |  65,867.15 ns |   194.891 ns |   162.743 ns |         - |
+| Encrypt · ChaCha20 (CryptoHives-SSSE3)  | 128KB        | 127,506.50 ns |   509.641 ns |   451.783 ns |         - |
+| Encrypt · ChaCha20 (NaCl.Core)          | 128KB        | 177,904.71 ns |   249.016 ns |   207.940 ns |      24 B |
+| Encrypt · ChaCha20 (BouncyCastle)       | 128KB        | 213,657.74 ns |   701.518 ns |   585.800 ns |      96 B |
+| Encrypt · ChaCha20 (CryptoHives-Scalar) | 128KB        | 451,041.46 ns | 1,146.715 ns | 1,072.638 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/cipher.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/cipher.md
@@ -31,7 +31,7 @@ Each cipher family exposes multiple acceleration tiers. The runtime automaticall
 
 - **Small messages (≤128 B)**: AES-GCM with AES-NI is ~2× faster than OS due to zero P/Invoke overhead and no kernel transition. ChaCha20-Poly1305 AVX2 is competitive with OS at these sizes.
 - **Medium messages (256 B–1 KB)**: AES-GCM V256 stitched pipeline engages at >=256 B (>=16 blocks), providing the best throughput. This range covers QUIC (~1.4 KB), WireGuard (~1.4 KB), and IPsec packets.
-- **Large messages (8 KB–128 KB)**: AES-GCM V256 decrypt stays within 1.24× of OS. ChaCha20-Poly1305 AVX2 is ~1.7× faster than OS. This range covers TLS records (1–16 KB) and OPC UA chunks (8 KB default).
+- **Large messages (8 KB–128 KB)**: AES-GCM V256 decrypt stays within 1.24× of OS. ChaCha20-Poly1305 AVX2 is ~1.53× faster than OS at 128 KiB. This range covers TLS records (1–16 KB) and OPC UA chunks (8 KB default).
 - **No hardware AES**: Use ChaCha20-Poly1305 — it is designed for software-only execution and outperforms managed AES-GCM by 10–20×.
 - **IoT / constrained devices**: AES-CCM with AES-NI provides ~3× speedup over managed. Supports variable nonce (7–13 bytes) and tag sizes.
 
@@ -40,9 +40,9 @@ Each cipher family exposes multiple acceleration tiers. The runtime automaticall
 | Family | Leader | Key Insight |
 |--------|--------|-------------|
 | **ChaCha20** | Managed AVX2 | AVX2 ~3× faster than BouncyCastle; SSSE3 ~1.7×; zero allocation |
-| **ChaCha20-Poly1305** | Managed AVX2 | ~1.7× faster than OS at 128 KiB; zero allocation |
+| **ChaCha20-Poly1305** | Managed AVX2 | ~1.53× faster than OS at 128 KiB; zero allocation |
 | **XChaCha20-Poly1305** | Managed AVX2 | Same core as ChaCha20-Poly1305; negligible overhead for extended nonce |
-| **AES-CBC** | AES-NI | Decrypt on par with OS at 128 KiB; **~8× faster than OS at 128 B**; zero allocation |
+| **AES-CBC** | AES-NI | Decrypt ~5.8× faster than OS at 128 B; OS leads at ≥2 KB (wider AES pipeline); zero allocation |
 | **AES-GCM** | AES-NI+PClMulV256 | **~2× faster than OS at 128 B encrypt**; V256 decrypt within 1.24× of OS at 128 KiB; 8-block stitched AES+GHASH pipeline |
 | **AES-CCM** | AES-NI | ~3× faster than Managed; zero allocation; no OS adapter available |
 
@@ -75,19 +75,19 @@ ChaCha20 is a stream cipher designed by Daniel J. Bernstein. Three acceleration 
 AES-CBC (Cipher Block Chaining) is the most widely deployed AES mode. Two acceleration tiers are available:
 
 - **AES-NI**: Uses hardware `AESENC`/`AESDEC` instructions. Decrypt uses **8-block interleaving** — 8 ciphertext blocks are loaded and decrypted simultaneously, exploiting the fact that CBC decrypt is embarrassingly parallel (each block decrypts independently using only its predecessor as the XOR mask). This saturates the AES execution unit pipeline (10 rounds × 8 blocks = 80 `AESDEC` instructions in flight). Encrypt remains serial because each plaintext block must be XORed with the previous ciphertext before encryption.
-- **Managed**: T-table AES using four 256-entry lookup tables per round. Fully portable, zero-allocation. Outperforms BouncyCastle by ~22%.
+- **Managed**: T-table AES using four 256-entry lookup tables per round. Fully portable, zero-allocation. Outperforms BouncyCastle by ~22% at small sizes.
 
 **Key observations:**
-- **AES-NI**: Fastest overall — on par with OS at 128 KiB decrypt, ~8× faster at 128 B
-- **AES-NI Encrypt**: ~2× slower than OS at large sizes (CBC encrypt is inherently serial; OS may use kernel-level optimizations)
-- **Managed**: Zero-allocation T-table AES, outperforms BouncyCastle by ~22%
+- **AES-NI Decrypt**: ~5.8× faster than OS at 128 B (46 ns vs 268 ns); crossover at ~1 KB; **OS is ~3× faster at 128 KiB** — the OS uses a wider AES pipeline (potentially VAES/AVX-512 AES internally) for bulk operations
+- **AES-NI Encrypt**: ~1.65× faster than OS at 128 B; ~2.4× slower than OS at 128 KiB (CBC encrypt is inherently serial; OS benefits from kernel-level prefetch and NUMA scheduling)
+- **Managed**: Zero-allocation T-table AES; outperforms BouncyCastle by ~22% at small inputs; comparable at bulk sizes
 - **OS**: Allocates 128 B per call (P/Invoke marshalling overhead)
 
 [!INCLUDE[](aes-cbc-128.md)]
 
 ### AES-256-CBC
 
-AES-256-CBC uses 14 rounds (vs 10 for AES-128), adding ~25-30% overhead. The same 8-block interleaved decrypt and serial encrypt architecture applies. The AES-NI decrypt path achieves parity with OS at 128 KiB.
+AES-256-CBC uses 14 rounds (vs 10 for AES-128), adding ~25-30% overhead. The same 8-block interleaved decrypt and serial encrypt architecture applies. The AES-NI decrypt path is ~5× faster than OS at 128 B; OS leads from ~2 KiB due to its wider bulk AES pipeline.
 
 [!INCLUDE[](aes-cbc-256.md)]
 
@@ -152,12 +152,12 @@ AES-256-CCM uses 14 rounds (vs 10 for AES-128). The same AES-NI / Managed dispat
 
 ChaCha20-Poly1305 is a software-friendly AEAD cipher (RFC 8439) that combines ChaCha20 stream encryption with Poly1305 MAC authentication. It is the recommended AEAD cipher when hardware AES acceleration is unavailable. Three acceleration tiers are available:
 
-- **AVX2**: Dual-block ChaCha20 encryption via `Vector256<uint>`, combined with Poly1305 donna-64 MAC (3×44-bit limbs, 9 multiplications per 16-byte block using `Math.BigMul`). ~1.7× faster than OS at 128 KiB.
-- **SSSE3**: Single-block ChaCha20 via `Vector128<uint>` with the same Poly1305 donna-64 MAC. ~12% faster than OS at 128 KiB.
+- **AVX2**: Dual-block ChaCha20 encryption via `Vector256<uint>`, combined with Poly1305 donna-64 MAC (3×44-bit limbs, 9 multiplications per 16-byte block using `Math.BigMul`). ~1.53× faster than OS at 128 KiB.
+- **SSSE3**: Single-block ChaCha20 via `Vector128<uint>` with the same Poly1305 donna-64 MAC. ~6.5% faster than OS at 128 KiB.
 - **Managed**: Scalar ChaCha20 + Poly1305 donna-32 (5×26-bit limbs, 25 multiplications per block on .NET Framework / .NET Standard). Fully portable.
 
 **Key observations:**
-- **AVX2** ~40% faster than OS at 128 KiB; **SSSE3** ~12% faster than OS
+- **AVX2** ~35% faster than OS at 128 KiB; **SSSE3** ~6.5% faster than OS
 - At smaller sizes (128 B), OS is competitive due to lower per-call overhead
 - **Managed**, **SSSE3**, and **AVX2** paths are zero-allocation
 - **BouncyCastle** allocates 336–416 B per call; **NaCl.Core** allocates 48–72 B per call

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/cshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/cshake128.md
@@ -1,31 +1,31 @@
-﻿| Description                                      | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 128B         |     245.9 ns |   0.84 ns |   0.79 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 128B         |     314.8 ns |   1.45 ns |   1.28 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 128B         |     321.1 ns |   1.25 ns |   0.98 ns |         - |
-| TryComputeHash · cSHAKE128 · BouncyCastle        | 128B         |     334.1 ns |   1.19 ns |   1.12 ns |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 137B         |     240.9 ns |   0.85 ns |   0.76 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 137B         |     309.7 ns |   0.66 ns |   0.62 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 137B         |     318.5 ns |   0.86 ns |   0.81 ns |         - |
-| TryComputeHash · cSHAKE128 · BouncyCastle        | 137B         |     333.7 ns |   1.39 ns |   1.30 ns |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 1KB          |   1,485.5 ns |   3.32 ns |   3.11 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 1KB          |   1,980.8 ns |   9.00 ns |   8.41 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 1KB          |   2,027.2 ns |   5.51 ns |   5.15 ns |         - |
-| TryComputeHash · cSHAKE128 · BouncyCastle        | 1KB          |   2,170.8 ns |   9.75 ns |   9.12 ns |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 1025B        |   1,485.6 ns |   5.72 ns |   5.35 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 1025B        |   1,979.7 ns |   6.91 ns |   6.12 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 1025B        |   2,024.5 ns |   5.26 ns |   4.66 ns |         - |
-| TryComputeHash · cSHAKE128 · BouncyCastle        | 1025B        |   2,172.7 ns |   9.65 ns |   9.02 ns |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 8KB          |   9,787.9 ns |  29.97 ns |  28.04 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 8KB          |  13,200.1 ns |  19.47 ns |  17.26 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 8KB          |  13,510.5 ns |  39.72 ns |  33.16 ns |         - |
-| TryComputeHash · cSHAKE128 · BouncyCastle        | 8KB          |  15,063.7 ns |  63.39 ns |  59.29 ns |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 128KB        | 155,292.5 ns | 658.05 ns | 615.54 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 128KB        | 209,713.7 ns | 354.10 ns | 313.90 ns |         - |
-| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 128KB        | 214,699.5 ns | 341.21 ns | 319.17 ns |         - |
-| TryComputeHash · cSHAKE128 · BouncyCastle        | 128KB        | 239,585.2 ns | 530.12 ns | 495.87 ns |         - |
+﻿| Description                                      | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 128B         |     211.6 ns |     1.47 ns |     1.31 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 128B         |     283.3 ns |     0.67 ns |     0.63 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 128B         |     294.2 ns |     1.13 ns |     1.06 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle        | 128B         |     335.8 ns |     1.91 ns |     1.60 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 137B         |     211.3 ns |     1.88 ns |     1.57 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 137B         |     283.1 ns |     0.27 ns |     0.24 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 137B         |     294.4 ns |     0.86 ns |     0.81 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle        | 137B         |     336.2 ns |     1.75 ns |     1.46 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 1KB          |   1,409.3 ns |     7.17 ns |     6.71 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 1KB          |   1,904.3 ns |     3.85 ns |     3.21 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 1KB          |   1,955.7 ns |     6.22 ns |     5.20 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle        | 1KB          |   2,186.8 ns |    12.46 ns |    11.66 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 1025B        |   1,405.4 ns |     5.10 ns |     4.26 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 1025B        |   1,906.6 ns |     5.31 ns |     4.44 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 1025B        |   1,957.2 ns |     9.93 ns |     9.29 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle        | 1025B        |   2,178.2 ns |     8.29 ns |     6.92 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 8KB          |   9,778.7 ns |    48.74 ns |    43.20 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 8KB          |  13,249.0 ns |    24.35 ns |    21.59 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 8KB          |  13,579.4 ns |    21.48 ns |    20.09 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle        | 8KB          |  15,101.7 ns |    48.35 ns |    37.75 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE128 · CryptoHives-Scalar  | 128KB        | 156,207.9 ns | 1,016.70 ns |   848.99 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX2    | 128KB        | 210,981.7 ns |   334.86 ns |   313.22 ns |         - |
+| TryComputeHash · cSHAKE128 · CryptoHives-AVX512F | 128KB        | 216,154.9 ns |   389.36 ns |   345.16 ns |         - |
+| TryComputeHash · cSHAKE128 · BouncyCastle        | 128KB        | 239,817.8 ns | 1,081.52 ns | 1,011.66 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/cshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/cshake256.md
@@ -1,31 +1,31 @@
-﻿| Description                                      | TestDataSize | Mean         | Error       | StdDev      | Median       | Allocated |
-|------------------------------------------------- |------------- |-------------:|------------:|------------:|-------------:|----------:|
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 128B         |     251.5 ns |     1.46 ns |     1.36 ns |     251.0 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 128B         |     321.7 ns |     1.69 ns |     1.32 ns |     321.6 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 128B         |     328.9 ns |     0.87 ns |     0.77 ns |     328.9 ns |         - |
-| TryComputeHash · cSHAKE256 · BouncyCastle        | 128B         |     333.2 ns |     1.30 ns |     1.22 ns |     333.5 ns |         - |
-|                                                  |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 137B         |     503.1 ns |     1.70 ns |     1.59 ns |     502.7 ns |         - |
-| TryComputeHash · cSHAKE256 · BouncyCastle        | 137B         |     633.6 ns |     2.98 ns |     2.79 ns |     632.9 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 137B         |     649.5 ns |     2.77 ns |     2.59 ns |     649.2 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 137B         |     665.7 ns |     2.20 ns |     1.72 ns |     665.6 ns |         - |
-|                                                  |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 1KB          |   1,658.1 ns |     2.60 ns |     2.31 ns |   1,658.4 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 1KB          |   2,223.7 ns |     7.68 ns |     6.42 ns |   2,221.8 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 1KB          |   2,283.6 ns |     5.09 ns |     4.76 ns |   2,283.3 ns |         - |
-| TryComputeHash · cSHAKE256 · BouncyCastle        | 1KB          |   2,467.7 ns |    13.88 ns |    12.30 ns |   2,463.0 ns |         - |
-|                                                  |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 1025B        |   1,662.9 ns |     4.08 ns |     3.18 ns |   1,664.2 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 1025B        |   2,218.4 ns |     3.70 ns |     2.89 ns |   2,218.5 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 1025B        |   2,280.4 ns |     7.44 ns |     6.59 ns |   2,279.6 ns |         - |
-| TryComputeHash · cSHAKE256 · BouncyCastle        | 1025B        |   2,461.9 ns |     6.97 ns |     6.52 ns |   2,463.2 ns |         - |
-|                                                  |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 8KB          |  12,921.4 ns |   255.28 ns |   404.90 ns |  12,917.4 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 8KB          |  17,917.9 ns |   482.23 ns | 1,421.87 ns |  17,288.6 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 8KB          |  19,193.8 ns |   487.71 ns | 1,430.37 ns |  19,893.6 ns |         - |
-| TryComputeHash · cSHAKE256 · BouncyCastle        | 8KB          |  19,456.3 ns |   387.39 ns |   866.45 ns |  19,105.4 ns |         - |
-|                                                  |              |              |             |             |              |           |
-| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 128KB        | 190,140.8 ns |   875.83 ns |   819.26 ns | 189,943.2 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 128KB        | 257,335.9 ns |   283.27 ns |   236.54 ns | 257,355.4 ns |         - |
-| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 128KB        | 265,191.6 ns | 1,847.11 ns | 1,542.42 ns | 264,595.1 ns |         - |
-| TryComputeHash · cSHAKE256 · BouncyCastle        | 128KB        | 293,843.4 ns | 1,587.37 ns | 1,484.83 ns | 293,312.5 ns |         - |
+﻿| Description                                      | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 128B         |     210.6 ns |     1.84 ns |     1.72 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 128B         |     282.2 ns |     0.66 ns |     0.61 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 128B         |     293.1 ns |     2.26 ns |     1.89 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle        | 128B         |     334.1 ns |     1.90 ns |     1.68 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 137B         |     407.2 ns |     1.97 ns |     1.75 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 137B         |     551.6 ns |     1.37 ns |     1.29 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 137B         |     574.2 ns |     2.45 ns |     2.29 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle        | 137B         |     631.3 ns |     2.01 ns |     1.78 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 1KB          |   1,591.7 ns |     7.99 ns |     7.09 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 1KB          |   2,163.6 ns |     9.04 ns |     8.46 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 1KB          |   2,227.5 ns |     7.80 ns |     7.30 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle        | 1KB          |   2,473.7 ns |    11.22 ns |    10.49 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 1025B        |   1,592.1 ns |     9.00 ns |     8.42 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 1025B        |   2,163.4 ns |     8.64 ns |     7.66 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 1025B        |   2,228.8 ns |     5.32 ns |     4.71 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle        | 1025B        |   2,470.1 ns |    14.35 ns |    12.72 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 8KB          |  12,087.1 ns |    54.27 ns |    50.76 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 8KB          |  16,412.3 ns |    65.03 ns |    60.83 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 8KB          |  16,836.6 ns |    57.92 ns |    54.18 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle        | 8KB          |  18,640.7 ns |    68.80 ns |    60.99 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · cSHAKE256 · CryptoHives-Scalar  | 128KB        | 190,313.7 ns |   674.97 ns |   631.37 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX2    | 128KB        | 259,853.9 ns | 1,113.65 ns | 1,041.71 ns |         - |
+| TryComputeHash · cSHAKE256 · CryptoHives-AVX512F | 128KB        | 266,000.8 ns | 1,088.10 ns | 1,017.81 ns |         - |
+| TryComputeHash · cSHAKE256 · BouncyCastle        | 128KB        | 292,749.3 ns | 1,572.09 ns | 1,393.61 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/hash.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/hash.md
@@ -19,11 +19,11 @@ Implementations are compared against:
 |--------|--------|-------------|
 | **SHA-2** | OS (SHA-NI) | Hardware SHA-NI gives OS ~4.5× advantage; managed outperforms BouncyCastle by ~13% |
 | **SHA-3/Keccak** | Managed | Scalar Keccak outperforms OS by ~30% and SIMD variants by 25–35% |
-| **BLAKE2b/2s** | Managed SIMD | BLAKE2s SIMD on parity with BouncyCastle; BLAKE2b AVX2 within ~20% |
-| **BLAKE3** | Native (Rust) | Rust interop ~1.4× faster at small inputs, ~12× at large due to multi-chunk parallelism; SSSE3 managed ~4× faster than BouncyCastle |
+| **BLAKE2b/2s** | Managed AVX2 | BLAKE2b AVX2 ~10% faster than BouncyCastle; BLAKE2s SIMD on parity with BouncyCastle |
+| **BLAKE3** | Native (Rust) | Rust interop ~1.4× faster at small inputs, ~12× at large due to multi-chunk parallelism; SSSE3 managed ~8–9× faster than BouncyCastle |
 | **Streebog** | Managed | 1.4–1.8× faster than OpenGost/BouncyCastle |
 | **Kupyna** | Managed | T-table optimization ~30–45% faster than BouncyCastle |
-| **KMAC** | Managed | ~30% faster than OS and ~48% faster than BouncyCastle at all sizes |
+| **KMAC** | Managed | ~36–67% faster than OS and ~35–67% faster than BouncyCastle depending on payload size |
 | **Ascon** | Managed | ~33% faster than BouncyCastle across all input sizes |
 
 ---
@@ -127,12 +127,13 @@ The managed Keccak core uses an optimized **scalar implementation** that outperf
 
 ## BLAKE2 Family
 
-BouncyCastle leads the BLAKE2 benchmarks due to highly optimized native code. The managed AVX2/SSSE3/SSE2 SIMD implementations are competitive (within ~15% of BouncyCastle or even), while the scalar fallback is significantly slower (~3.5× for BLAKE2b, ~4× for BLAKE2s).
+CryptoHives leads the BLAKE2b benchmarks on x86. The **AVX2** path is ~10–15% faster than BouncyCastle across all payload sizes — 84 ns vs 98 ns at 128 B and 79 μs vs 89 μs at 128 KiB. `Blake2Fast` (a dedicated fast BLAKE2 library) is competitive with CryptoHives-AVX2 and BouncyCastle. For BLAKE2s, the SIMD implementation is on parity with BouncyCastle. The scalar fallback is ~1.5–1.6× slower than the SIMD paths.
 
 **Key observations:**
-- **BouncyCastle**: Highly optimized reference
-- **Managed AVX2**: Competitive SIMD implementation
-- **Managed scalar**: Fallback for non-SIMD platforms
+- **CryptoHives AVX2**: Fastest overall — ~10–15% faster than BouncyCastle and `Blake2Fast` for BLAKE2b
+- **BouncyCastle**: Competitive but slower than AVX2 at all sizes; zero allocation for BLAKE2b at sizes ≤8 KiB
+- **Managed scalar**: Fallback for non-SIMD platforms; ~1.5× slower than AVX2; zero allocation
+- **Konscious**: Slowest option, allocates heavily (~130 KB per 128 KiB hash call)
 
 ### BLAKE2b-256
 [!INCLUDE[](blake2b256.md)]
@@ -152,7 +153,7 @@ BouncyCastle leads the BLAKE2 benchmarks due to highly optimized native code. Th
 
 BLAKE3 is a modern hash function designed for extreme parallelism and speed. It can leverage tree hashing to process multiple chunks simultaneously, making it ideal for hashing large files. The **Native (Rust)** variant uses `blake3-dotnet`, which wraps the official Rust implementation via P/Invoke—this is the fastest option and recommended when native dependencies are acceptable.
 
-The managed CryptoHives implementation uses SSSE3 SIMD instructions with optimized state management. At small inputs (128B-1kb), the SSSE3 path is ~1.4× slower than the native Rust implementation and ~9× faster than BouncyCastle. At large inputs (128KB), the gap widens to ~12× because the native implementation parallelizes chunk compression across SIMD lanes (AVX2/AVX-512 `hash_many`), while the managed version processes chunks sequentially.
+The managed CryptoHives implementation uses SSSE3 SIMD instructions with optimized state management. At small inputs (128 B–1 KB), the SSSE3 path is ~1.4× slower than the native Rust implementation and **~8–9× faster than BouncyCastle** (154 ns vs 1,281 ns at 128 B). At large inputs (128 KB), the gap widens to ~12× between native and BouncyCastle because the native implementation parallelizes chunk compression across SIMD lanes (AVX2/AVX-512 `hash_many`), while the managed version processes chunks sequentially. The SSSE3 path remains ~8× faster than BouncyCastle at 128 KB (166 μs vs 1,370 μs).
 
 [!INCLUDE[](blake3.md)]
 
@@ -176,7 +177,7 @@ The managed implementation is approximately **33% faster** than BouncyCastle acr
 
 KMAC (Keccak Message Authentication Code) is defined in NIST SP 800-185 and provides a **Keccak-based keyed hash function**. Like SHA-3, SHAKE, and cSHAKE, KMAC shares the same optimized Keccak permutation core, benefiting from the scalar optimizations described in the Keccak section above.
 
-The managed CryptoHives implementation is the **fastest at all input sizes**, outperforming the OS-provided KMAC by ~30% and BouncyCastle by ~48%. This advantage comes from the highly optimized scalar Keccak core that benefits both the hash computation and the KMAC-specific cSHAKE encoding overhead.
+The managed CryptoHives implementation is the **fastest at all input sizes**. At 128 B, CryptoHives (639 ns) is ~36% faster than OS (1,000 ns) and ~67% faster than BouncyCastle (1,971 ns). At 128 KiB, it is ~30% faster than OS and ~36% faster than BouncyCastle. The per-call advantage is largest at small payloads where the OS incurs marshalling overhead and BouncyCastle incurs per-call allocation (256 B); the gap narrows at bulk sizes as the Keccak permutation throughput dominates.
 
 ### KMAC128
 [!INCLUDE[](kmac128.md)]

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kalyna-cbc-128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kalyna-cbc-128.md
@@ -1,25 +1,25 @@
-﻿| Description                                   | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|---------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |     2.337 μs | 0.0096 μs | 0.0085 μs |     872 B |
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |     5.027 μs | 0.0179 μs | 0.0159 μs |         - |
-|                                               |              |              |           |           |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |     1.327 μs | 0.0032 μs | 0.0027 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |     3.547 μs | 0.0115 μs | 0.0102 μs |         - |
-|                                               |              |              |           |           |           |
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |    14.360 μs | 0.0585 μs | 0.0547 μs |     872 B |
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |    36.403 μs | 0.1291 μs | 0.1207 μs |         - |
-|                                               |              |              |           |           |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |     7.055 μs | 0.0150 μs | 0.0141 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |    25.714 μs | 0.0604 μs | 0.0565 μs |         - |
-|                                               |              |              |           |           |           |
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |   113.686 μs | 0.2425 μs | 0.2268 μs |     872 B |
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |   285.070 μs | 0.8701 μs | 0.7713 μs |         - |
-|                                               |              |              |           |           |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |    52.924 μs | 0.1145 μs | 0.0956 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |   201.055 μs | 0.5040 μs | 0.4468 μs |         - |
-|                                               |              |              |           |           |           |
-| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        | 1,750.147 μs | 5.0284 μs | 4.4575 μs |     872 B |
-| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        | 4,551.189 μs | 8.7791 μs | 6.8542 μs |         - |
-|                                               |              |              |           |           |           |
-| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        |   837.794 μs | 1.5960 μs | 1.4929 μs |     872 B |
-| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        | 3,258.497 μs | 4.4095 μs | 4.1246 μs |         - |
+﻿| Description                                   | TestDataSize | Mean           | Error       | StdDev      | Allocated |
+|---------------------------------------------- |------------- |---------------:|------------:|------------:|----------:|
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |       929.8 ns |     9.34 ns |     8.74 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |     2,372.6 ns |    13.01 ns |    12.17 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128B         |       392.6 ns |     3.58 ns |     3.35 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128B         |     1,357.1 ns |     5.66 ns |     5.01 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |     6,569.8 ns |    14.88 ns |    13.92 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |    14,381.0 ns |    63.39 ns |    56.20 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 1KB          |     2,785.7 ns |    19.83 ns |    16.56 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 1KB          |     7,090.0 ns |    30.89 ns |    27.39 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |    51,860.2 ns |   182.83 ns |   171.02 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |   110,702.4 ns |   507.11 ns |   474.35 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 8KB          |    21,379.4 ns |    79.21 ns |    70.22 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 8KB          |    53,086.9 ns |   158.20 ns |   132.10 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Decrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        |   826,959.4 ns | 1,971.56 ns | 1,844.20 ns |         - |
+| Decrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        | 1,762,739.8 ns | 9,967.62 ns | 9,323.72 ns |     872 B |
+|                                               |              |                |             |             |           |
+| Encrypt · Kalyna-128-CBC (CryptoHives-Scalar) | 128KB        |   341,884.5 ns | 1,493.29 ns | 1,396.83 ns |         - |
+| Encrypt · Kalyna-128-CBC (BouncyCastle)       | 128KB        |   838,112.3 ns | 1,680.78 ns | 1,312.24 ns |     872 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kalyna-cbc-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kalyna-cbc-256.md
@@ -1,25 +1,25 @@
-﻿| Description                                   | TestDataSize | Mean         | Error      | StdDev     | Allocated |
-|---------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |     3.197 μs |  0.0154 μs |  0.0144 μs |    1112 B |
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |     6.990 μs |  0.0165 μs |  0.0155 μs |         - |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |     1.730 μs |  0.0034 μs |  0.0030 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |     4.950 μs |  0.0113 μs |  0.0100 μs |         - |
-|                                               |              |              |            |            |           |
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |    19.554 μs |  0.0696 μs |  0.0651 μs |    1112 B |
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |    50.070 μs |  0.0529 μs |  0.0469 μs |         - |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |     9.425 μs |  0.0239 μs |  0.0224 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |    35.668 μs |  0.1717 μs |  0.1606 μs |         - |
-|                                               |              |              |            |            |           |
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |   150.010 μs |  0.3986 μs |  0.3729 μs |    1112 B |
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |   396.756 μs |  1.1871 μs |  1.0523 μs |         - |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |    70.744 μs |  0.1432 μs |  0.1340 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |   285.500 μs |  0.7955 μs |  0.7442 μs |         - |
-|                                               |              |              |            |            |           |
-| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        | 2,387.112 μs |  9.0364 μs |  8.4527 μs |    1112 B |
-| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        | 6,303.839 μs | 25.1612 μs | 23.5358 μs |         - |
-|                                               |              |              |            |            |           |
-| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        | 1,120.473 μs |  2.2923 μs |  2.1442 μs |    1112 B |
-| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        | 4,492.113 μs | 16.7600 μs | 15.6773 μs |         - |
+﻿| Description                                   | TestDataSize | Mean           | Error        | StdDev       | Allocated |
+|---------------------------------------------- |------------- |---------------:|-------------:|-------------:|----------:|
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |     1,251.2 ns |      3.77 ns |      3.15 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |     3,170.1 ns |     22.24 ns |     20.80 ns |    1112 B |
+|                                               |              |                |              |              |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128B         |       538.2 ns |      3.82 ns |      3.39 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128B         |     1,759.1 ns |     11.33 ns |     10.04 ns |    1112 B |
+|                                               |              |                |              |              |           |
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |     8,946.5 ns |     47.97 ns |     42.52 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |    19,582.4 ns |     95.84 ns |     80.03 ns |    1112 B |
+|                                               |              |                |              |              |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 1KB          |     3,790.6 ns |      9.36 ns |      8.75 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 1KB          |     9,454.2 ns |     48.34 ns |     45.22 ns |    1112 B |
+|                                               |              |                |              |              |           |
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |    74,906.3 ns |    284.29 ns |    265.93 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |   151,295.3 ns |  1,324.45 ns |  1,238.89 ns |    1112 B |
+|                                               |              |                |              |              |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 8KB          |    29,792.6 ns |     65.27 ns |     61.05 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 8KB          |    71,155.1 ns |    358.34 ns |    317.66 ns |    1112 B |
+|                                               |              |                |              |              |           |
+| Decrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        | 1,124,427.5 ns |  4,483.91 ns |  3,974.87 ns |         - |
+| Decrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        | 2,401,999.9 ns | 15,429.08 ns | 14,432.37 ns |    1112 B |
+|                                               |              |                |              |              |           |
+| Encrypt · Kalyna-256-CBC (CryptoHives-Scalar) | 128KB        |   489,780.4 ns |  2,184.52 ns |  1,936.52 ns |         - |
+| Encrypt · Kalyna-256-CBC (BouncyCastle)       | 128KB        | 1,127,764.5 ns |  4,344.35 ns |  3,627.73 ns |    1112 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/keccak256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/keccak256.md
@@ -1,31 +1,31 @@
-﻿| Description                                       | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|-------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 128B         |     210.5 ns |   0.37 ns |   0.34 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 128B         |     279.9 ns |   0.45 ns |   0.38 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 128B         |     287.7 ns |   0.57 ns |   0.51 ns |         - |
-| TryComputeHash · Keccak-256 · BouncyCastle        | 128B         |     330.6 ns |   1.69 ns |   1.58 ns |         - |
-|                                                   |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 137B         |     461.8 ns |   0.64 ns |   0.57 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 137B         |     606.4 ns |   1.70 ns |   1.51 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 137B         |     624.8 ns |   1.36 ns |   1.20 ns |         - |
-| TryComputeHash · Keccak-256 · BouncyCastle        | 137B         |     628.6 ns |   1.84 ns |   1.72 ns |         - |
-|                                                   |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 1KB          |   1,615.1 ns |   3.87 ns |   3.62 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 1KB          |   2,178.5 ns |   3.96 ns |   3.09 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 1KB          |   2,241.6 ns |   5.12 ns |   4.54 ns |         - |
-| TryComputeHash · Keccak-256 · BouncyCastle        | 1KB          |   2,465.2 ns |   9.69 ns |   9.07 ns |         - |
-|                                                   |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 1025B        |   1,614.3 ns |   3.80 ns |   3.37 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 1025B        |   2,180.6 ns |   4.52 ns |   3.77 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 1025B        |   2,236.2 ns |   3.58 ns |   3.17 ns |         - |
-| TryComputeHash · Keccak-256 · BouncyCastle        | 1025B        |   2,458.1 ns |   6.99 ns |   6.54 ns |         - |
-|                                                   |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 8KB          |  12,076.8 ns |  41.72 ns |  36.98 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 8KB          |  16,650.7 ns |  34.09 ns |  30.22 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 8KB          |  16,793.1 ns |  27.16 ns |  24.08 ns |         - |
-| TryComputeHash · Keccak-256 · BouncyCastle        | 8KB          |  18,572.8 ns |  41.08 ns |  36.42 ns |         - |
-|                                                   |              |              |           |           |           |
-| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 128KB        | 193,050.3 ns | 684.65 ns | 640.42 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 128KB        | 257,863.1 ns | 412.70 ns | 365.84 ns |         - |
-| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 128KB        | 264,299.7 ns | 562.84 ns | 439.43 ns |         - |
-| TryComputeHash · Keccak-256 · BouncyCastle        | 128KB        | 294,293.3 ns | 564.70 ns | 528.22 ns |         - |
+﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 128B         |     207.3 ns |     1.00 ns |     0.88 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 128B         |     278.6 ns |     0.95 ns |     0.89 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 128B         |     287.7 ns |     1.10 ns |     0.97 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle        | 128B         |     330.7 ns |     1.15 ns |     0.96 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 137B         |     404.1 ns |     1.75 ns |     1.64 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 137B         |     547.3 ns |     1.67 ns |     1.39 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 137B         |     568.8 ns |     1.17 ns |     1.10 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle        | 137B         |     628.7 ns |     2.51 ns |     2.35 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 1KB          |   1,588.9 ns |     8.10 ns |     7.58 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 1KB          |   2,158.9 ns |     3.37 ns |     2.82 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 1KB          |   2,220.1 ns |     5.94 ns |     5.27 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle        | 1KB          |   2,466.2 ns |    16.58 ns |    15.51 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 1025B        |   1,590.1 ns |     7.34 ns |     6.50 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 1025B        |   2,159.4 ns |     6.35 ns |     5.94 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 1025B        |   2,217.5 ns |     7.56 ns |     6.31 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle        | 1025B        |   2,463.8 ns |    13.38 ns |    11.18 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 8KB          |  12,088.7 ns |    80.06 ns |    74.89 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 8KB          |  16,392.5 ns |    42.23 ns |    39.50 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 8KB          |  16,825.6 ns |    41.71 ns |    39.02 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle        | 8KB          |  18,612.4 ns |    91.00 ns |    85.12 ns |         - |
+|                                                   |              |              |             |             |           |
+| TryComputeHash · Keccak-256 · CryptoHives-Scalar  | 128KB        | 190,579.1 ns | 1,239.67 ns | 1,035.18 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX2    | 128KB        | 259,048.9 ns |   601.92 ns |   563.03 ns |         - |
+| TryComputeHash · Keccak-256 · CryptoHives-AVX512F | 128KB        | 265,689.8 ns |   771.76 ns |   721.90 ns |         - |
+| TryComputeHash · Keccak-256 · BouncyCastle        | 128KB        | 293,571.9 ns | 1,607.29 ns | 1,424.82 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/keccak384.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/keccak384.md
@@ -1,31 +1,31 @@
 ﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 128B         |     438.8 ns |     0.81 ns |     0.68 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 128B         |     583.3 ns |     2.73 ns |     2.42 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 128B         |     602.2 ns |     1.42 ns |     1.18 ns |         - |
-| TryComputeHash · Keccak-384 · BouncyCastle        | 128B         |     625.0 ns |     1.14 ns |     1.07 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 128B         |     400.7 ns |     2.29 ns |     2.03 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 128B         |     547.7 ns |     1.14 ns |     0.96 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 128B         |     565.8 ns |     1.13 ns |     0.88 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle        | 128B         |     627.7 ns |     3.96 ns |     3.71 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 137B         |     434.1 ns |     1.27 ns |     1.19 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 137B         |     578.6 ns |     2.36 ns |     1.97 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 137B         |     604.0 ns |     9.00 ns |     8.42 ns |         - |
-| TryComputeHash · Keccak-384 · BouncyCastle        | 137B         |     626.8 ns |     2.13 ns |     1.99 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 137B         |     400.0 ns |     1.08 ns |     0.84 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 137B         |     549.2 ns |     1.54 ns |     1.36 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 137B         |     563.6 ns |     2.29 ns |     2.14 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle        | 137B         |     625.6 ns |     2.29 ns |     2.03 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 1KB          |   1,977.8 ns |    11.26 ns |    10.53 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 1KB          |   2,691.4 ns |     5.28 ns |     4.68 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 1KB          |   2,760.4 ns |     7.42 ns |     5.79 ns |         - |
-| TryComputeHash · Keccak-384 · BouncyCastle        | 1KB          |   3,044.7 ns |    11.79 ns |    11.03 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 1KB          |   1,966.6 ns |    10.57 ns |     9.88 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 1KB          |   2,695.1 ns |     5.58 ns |     5.22 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 1KB          |   2,760.5 ns |     7.78 ns |     6.90 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle        | 1KB          |   3,045.1 ns |    14.42 ns |    13.49 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 1025B        |   1,980.8 ns |     7.23 ns |     6.77 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 1025B        |   2,690.8 ns |     6.72 ns |     5.96 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 1025B        |   2,763.6 ns |     6.21 ns |     5.51 ns |         - |
-| TryComputeHash · Keccak-384 · BouncyCastle        | 1025B        |   3,045.7 ns |     9.51 ns |     8.89 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 1025B        |   1,969.1 ns |    11.76 ns |     9.82 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 1025B        |   2,694.6 ns |     5.51 ns |     4.89 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 1025B        |   2,764.8 ns |     7.08 ns |     6.28 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle        | 1025B        |   3,049.8 ns |    14.23 ns |    12.61 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 8KB          |  15,434.8 ns |    54.08 ns |    50.59 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 8KB          |  21,043.6 ns |    68.89 ns |    61.07 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 8KB          |  21,643.9 ns |    75.08 ns |    70.23 ns |         - |
-| TryComputeHash · Keccak-384 · BouncyCastle        | 8KB          |  23,896.4 ns |    37.14 ns |    34.74 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 8KB          |  15,463.0 ns |    62.33 ns |    52.05 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 8KB          |  21,126.8 ns |    66.80 ns |    62.48 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 8KB          |  21,779.2 ns |    49.21 ns |    46.03 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle        | 8KB          |  24,081.4 ns |   366.22 ns |   342.56 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 128KB        | 246,538.3 ns | 1,240.47 ns | 1,099.64 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 128KB        | 336,208.6 ns |   571.74 ns |   477.43 ns |         - |
-| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 128KB        | 344,599.3 ns |   534.16 ns |   446.05 ns |         - |
-| TryComputeHash · Keccak-384 · BouncyCastle        | 128KB        | 381,226.2 ns |   781.21 ns |   730.74 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-Scalar  | 128KB        | 247,297.5 ns | 1,927.22 ns | 1,802.72 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX2    | 128KB        | 337,419.3 ns |   845.70 ns |   791.07 ns |         - |
+| TryComputeHash · Keccak-384 · CryptoHives-AVX512F | 128KB        | 347,540.7 ns |   784.89 ns |   655.42 ns |         - |
+| TryComputeHash · Keccak-384 · BouncyCastle        | 128KB        | 389,063.2 ns | 1,985.22 ns | 1,856.98 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/keccak512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/keccak512.md
@@ -1,31 +1,31 @@
 ﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 128B         |     411.4 ns |     0.78 ns |     0.70 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 128B         |     554.8 ns |     1.93 ns |     1.80 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 128B         |     574.8 ns |     2.00 ns |     1.87 ns |         - |
-| TryComputeHash · Keccak-512 · BouncyCastle        | 128B         |     625.5 ns |     2.42 ns |     2.14 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 128B         |     399.8 ns |     4.32 ns |     4.05 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 128B         |     545.2 ns |     2.31 ns |     2.16 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 128B         |     561.1 ns |     1.60 ns |     1.50 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle        | 128B         |     625.8 ns |     3.32 ns |     3.10 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 137B         |     400.2 ns |     0.50 ns |     0.44 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 137B         |     547.1 ns |     8.55 ns |     8.40 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 137B         |     556.9 ns |     1.97 ns |     1.75 ns |         - |
-| TryComputeHash · Keccak-512 · BouncyCastle        | 137B         |     626.1 ns |     2.13 ns |     1.99 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 137B         |     398.1 ns |     2.33 ns |     2.06 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 137B         |     544.5 ns |     2.18 ns |     1.93 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 137B         |     563.0 ns |     2.05 ns |     1.92 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle        | 137B         |     626.5 ns |     2.53 ns |     2.24 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 1KB          |   2,946.9 ns |    13.57 ns |    12.70 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 1KB          |   4,004.1 ns |    17.66 ns |    16.52 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 1KB          |   4,131.6 ns |    17.24 ns |    15.28 ns |         - |
-| TryComputeHash · Keccak-512 · BouncyCastle        | 1KB          |   4,523.0 ns |    18.75 ns |    17.54 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 1KB          |   2,938.9 ns |    19.36 ns |    18.11 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 1KB          |   4,000.9 ns |    14.78 ns |    12.34 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 1KB          |   4,121.2 ns |    10.57 ns |     9.37 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle        | 1KB          |   4,524.9 ns |    21.00 ns |    18.62 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 1025B        |   2,951.7 ns |     9.73 ns |     9.10 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 1025B        |   4,006.9 ns |    12.42 ns |    10.37 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 1025B        |   4,137.8 ns |    27.93 ns |    21.81 ns |         - |
-| TryComputeHash · Keccak-512 · BouncyCastle        | 1025B        |   4,524.5 ns |    15.63 ns |    14.62 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 1025B        |   2,933.9 ns |    15.10 ns |    14.12 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 1025B        |   4,011.6 ns |    14.13 ns |    12.53 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 1025B        |   4,134.2 ns |    11.53 ns |     9.63 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle        | 1025B        |   4,519.2 ns |    18.21 ns |    17.03 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 8KB          |  22,174.1 ns |    65.65 ns |    58.20 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 8KB          |  30,140.3 ns |    40.21 ns |    35.65 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 8KB          |  31,081.1 ns |   110.63 ns |    86.38 ns |         - |
-| TryComputeHash · Keccak-512 · BouncyCastle        | 8KB          |  34,277.4 ns |   120.24 ns |   106.59 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 8KB          |  22,180.5 ns |   150.53 ns |   125.70 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 8KB          |  30,390.5 ns |    93.26 ns |    82.67 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 8KB          |  31,171.7 ns |    96.00 ns |    89.80 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle        | 8KB          |  34,416.4 ns |   196.80 ns |   174.46 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 128KB        | 353,737.5 ns |   872.10 ns |   815.77 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 128KB        | 484,958.1 ns | 5,067.74 ns | 7,268.00 ns |         - |
-| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 128KB        | 496,425.7 ns | 1,628.53 ns | 1,523.33 ns |         - |
-| TryComputeHash · Keccak-512 · BouncyCastle        | 128KB        | 561,994.7 ns | 2,048.58 ns | 1,916.25 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-Scalar  | 128KB        | 355,415.3 ns | 2,350.04 ns | 2,198.23 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX2    | 128KB        | 484,546.4 ns |   949.76 ns |   841.93 ns |         - |
+| TryComputeHash · Keccak-512 · CryptoHives-AVX512F | 128KB        | 500,648.4 ns | 1,676.36 ns | 1,568.07 ns |         - |
+| TryComputeHash · Keccak-512 · BouncyCastle        | 128KB        | 551,718.7 ns | 2,190.32 ns | 1,829.02 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kmac128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kmac128.md
@@ -1,25 +1,25 @@
-﻿| Description                                    | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|----------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 128B         |     663.9 ns |   1.44 ns |   1.27 ns |         - |
-| TryComputeHash · KMAC-128 · OS Native          | 128B         |     992.3 ns |   5.65 ns |   5.28 ns |     184 B |
-| TryComputeHash · KMAC-128 · BouncyCastle       | 128B         |   1,985.0 ns |   9.48 ns |   8.86 ns |     256 B |
-|                                                |              |              |           |           |           |
-| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 137B         |     661.9 ns |   2.32 ns |   2.17 ns |         - |
-| TryComputeHash · KMAC-128 · OS Native          | 137B         |   1,010.5 ns |   4.93 ns |   4.61 ns |     200 B |
-| TryComputeHash · KMAC-128 · BouncyCastle       | 137B         |   1,975.6 ns |   5.81 ns |   4.85 ns |     256 B |
-|                                                |              |              |           |           |           |
-| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 1KB          |   1,896.1 ns |   5.62 ns |   4.99 ns |         - |
-| TryComputeHash · KMAC-128 · OS Native          | 1KB          |   2,469.1 ns |  12.45 ns |  11.65 ns |    1080 B |
-| TryComputeHash · KMAC-128 · BouncyCastle       | 1KB          |   3,800.3 ns |  11.24 ns |   9.96 ns |     256 B |
-|                                                |              |              |           |           |           |
-| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 1025B        |   1,892.1 ns |   4.95 ns |   4.63 ns |         - |
-| TryComputeHash · KMAC-128 · OS Native          | 1025B        |   2,471.4 ns |   7.34 ns |   6.13 ns |    1088 B |
-| TryComputeHash · KMAC-128 · BouncyCastle       | 1025B        |   3,793.2 ns |  15.75 ns |  14.73 ns |     256 B |
-|                                                |              |              |           |           |           |
-| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 8KB          |  10,216.7 ns |  24.79 ns |  21.97 ns |         - |
-| TryComputeHash · KMAC-128 · OS Native          | 8KB          |  12,841.6 ns |  88.38 ns |  82.67 ns |    8248 B |
-| TryComputeHash · KMAC-128 · BouncyCastle       | 8KB          |  16,717.3 ns |  27.52 ns |  24.40 ns |     256 B |
-|                                                |              |              |           |           |           |
-| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 128KB        | 155,580.2 ns | 378.44 ns | 354.00 ns |         - |
-| TryComputeHash · KMAC-128 · OS Native          | 128KB        | 222,272.4 ns | 486.38 ns | 454.96 ns |  131151 B |
-| TryComputeHash · KMAC-128 · BouncyCastle       | 128KB        | 241,623.2 ns | 268.95 ns | 238.42 ns |     256 B |
+﻿| Description                                    | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|----------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 128B         |     639.3 ns |     4.43 ns |     4.15 ns |         - |
+| TryComputeHash · KMAC-128 · OS Native          | 128B         |     999.7 ns |     6.60 ns |     5.85 ns |     184 B |
+| TryComputeHash · KMAC-128 · BouncyCastle       | 128B         |   1,971.0 ns |     7.39 ns |     6.17 ns |     256 B |
+|                                                |              |              |             |             |           |
+| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 137B         |     637.9 ns |     3.86 ns |     3.23 ns |         - |
+| TryComputeHash · KMAC-128 · OS Native          | 137B         |   1,011.2 ns |     7.80 ns |     6.92 ns |     200 B |
+| TryComputeHash · KMAC-128 · BouncyCastle       | 137B         |   1,994.4 ns |    12.68 ns |    11.86 ns |     256 B |
+|                                                |              |              |             |             |           |
+| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 1KB          |   1,845.7 ns |    25.21 ns |    23.58 ns |         - |
+| TryComputeHash · KMAC-128 · OS Native          | 1KB          |   2,500.8 ns |    22.71 ns |    21.25 ns |    1080 B |
+| TryComputeHash · KMAC-128 · BouncyCastle       | 1KB          |   3,802.3 ns |    14.47 ns |    12.08 ns |     256 B |
+|                                                |              |              |             |             |           |
+| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 1025B        |   1,831.1 ns |    11.22 ns |    10.50 ns |         - |
+| TryComputeHash · KMAC-128 · OS Native          | 1025B        |   2,490.6 ns |    17.50 ns |    16.37 ns |    1088 B |
+| TryComputeHash · KMAC-128 · BouncyCastle       | 1025B        |   3,805.8 ns |    14.19 ns |    12.58 ns |     256 B |
+|                                                |              |              |             |             |           |
+| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 8KB          |  10,164.6 ns |    51.04 ns |    47.74 ns |         - |
+| TryComputeHash · KMAC-128 · OS Native          | 8KB          |  12,849.2 ns |    54.87 ns |    45.82 ns |    8248 B |
+| TryComputeHash · KMAC-128 · BouncyCastle       | 8KB          |  16,837.5 ns |    91.76 ns |    81.34 ns |     256 B |
+|                                                |              |              |             |             |           |
+| TryComputeHash · KMAC-128 · CryptoHives-Scalar | 128KB        | 155,699.8 ns | 1,005.02 ns |   940.10 ns |         - |
+| TryComputeHash · KMAC-128 · OS Native          | 128KB        | 223,175.9 ns | 1,345.67 ns | 1,258.74 ns |  131151 B |
+| TryComputeHash · KMAC-128 · BouncyCastle       | 128KB        | 241,935.6 ns | 1,192.39 ns | 1,057.02 ns |     256 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kmac256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kmac256.md
@@ -1,25 +1,25 @@
 ﻿| Description                                    | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |----------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 128B         |     664.9 ns |     1.26 ns |     0.98 ns |         - |
-| TryComputeHash · KMAC-256 · OS Native          | 128B         |   1,003.7 ns |     4.39 ns |     4.10 ns |     184 B |
-| TryComputeHash · KMAC-256 · BouncyCastle       | 128B         |   1,943.8 ns |     5.95 ns |     5.57 ns |     256 B |
+| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 128B         |     629.6 ns |     3.16 ns |     2.80 ns |         - |
+| TryComputeHash · KMAC-256 · OS Native          | 128B         |   1,006.4 ns |     5.70 ns |     5.33 ns |     184 B |
+| TryComputeHash · KMAC-256 · BouncyCastle       | 128B         |   1,952.9 ns |    15.74 ns |    14.73 ns |     256 B |
 |                                                |              |              |             |             |           |
-| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 137B         |     909.5 ns |     1.47 ns |     1.31 ns |         - |
-| TryComputeHash · KMAC-256 · OS Native          | 137B         |   1,252.5 ns |     5.27 ns |     4.93 ns |     200 B |
-| TryComputeHash · KMAC-256 · BouncyCastle       | 137B         |   2,243.1 ns |     9.81 ns |     9.18 ns |     256 B |
+| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 137B         |     826.2 ns |     4.23 ns |     3.30 ns |         - |
+| TryComputeHash · KMAC-256 · OS Native          | 137B         |   1,257.4 ns |     6.32 ns |     5.61 ns |     200 B |
+| TryComputeHash · KMAC-256 · BouncyCastle       | 137B         |   2,241.1 ns |    13.80 ns |    12.23 ns |     256 B |
 |                                                |              |              |             |             |           |
-| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 1KB          |   2,066.0 ns |     5.75 ns |     4.80 ns |         - |
-| TryComputeHash · KMAC-256 · OS Native          | 1KB          |   2,703.7 ns |    12.64 ns |    11.82 ns |    1080 B |
-| TryComputeHash · KMAC-256 · BouncyCastle       | 1KB          |   4,082.9 ns |     6.86 ns |     6.08 ns |     256 B |
+| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 1KB          |   2,012.7 ns |    12.28 ns |    11.49 ns |         - |
+| TryComputeHash · KMAC-256 · OS Native          | 1KB          |   2,715.3 ns |    19.65 ns |    18.38 ns |    1080 B |
+| TryComputeHash · KMAC-256 · BouncyCastle       | 1KB          |   4,091.3 ns |    15.59 ns |    13.02 ns |     256 B |
 |                                                |              |              |             |             |           |
-| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 1025B        |   2,066.2 ns |     4.91 ns |     4.60 ns |         - |
-| TryComputeHash · KMAC-256 · OS Native          | 1025B        |   2,684.8 ns |    16.50 ns |    15.43 ns |    1088 B |
-| TryComputeHash · KMAC-256 · BouncyCastle       | 1025B        |   4,076.9 ns |    21.02 ns |    19.66 ns |     256 B |
+| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 1025B        |   2,013.1 ns |    19.41 ns |    18.16 ns |         - |
+| TryComputeHash · KMAC-256 · OS Native          | 1025B        |   2,714.8 ns |    16.76 ns |    14.86 ns |    1088 B |
+| TryComputeHash · KMAC-256 · BouncyCastle       | 1025B        |   4,111.0 ns |    43.10 ns |    40.31 ns |     256 B |
 |                                                |              |              |             |             |           |
-| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 8KB          |  12,529.6 ns |    20.19 ns |    17.90 ns |         - |
-| TryComputeHash · KMAC-256 · OS Native          | 8KB          |  15,591.3 ns |    77.34 ns |    68.56 ns |    8248 B |
-| TryComputeHash · KMAC-256 · BouncyCastle       | 8KB          |  20,205.7 ns |    35.71 ns |    33.40 ns |     256 B |
+| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 8KB          |  12,476.3 ns |    62.15 ns |    58.14 ns |         - |
+| TryComputeHash · KMAC-256 · OS Native          | 8KB          |  15,712.9 ns |   109.22 ns |    96.82 ns |    8248 B |
+| TryComputeHash · KMAC-256 · BouncyCastle       | 8KB          |  20,277.5 ns |   125.13 ns |   110.93 ns |     256 B |
 |                                                |              |              |             |             |           |
-| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 128KB        | 190,123.7 ns |   374.20 ns |   331.72 ns |         - |
-| TryComputeHash · KMAC-256 · OS Native          | 128KB        | 263,794.1 ns | 1,310.26 ns | 1,225.61 ns |  131151 B |
-| TryComputeHash · KMAC-256 · BouncyCastle       | 128KB        | 294,678.9 ns | 1,025.68 ns |   959.43 ns |     256 B |
+| TryComputeHash · KMAC-256 · CryptoHives-Scalar | 128KB        | 190,673.8 ns |   958.36 ns |   849.56 ns |         - |
+| TryComputeHash · KMAC-256 · OS Native          | 128KB        | 264,992.3 ns | 1,632.14 ns | 1,446.85 ns |  131151 B |
+| TryComputeHash · KMAC-256 · BouncyCastle       | 128KB        | 294,836.4 ns | 1,281.56 ns | 1,198.77 ns |     256 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kt128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kt128.md
@@ -1,25 +1,25 @@
 ﻿| Description                                  | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |--------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · KT128 · CryptoHives-Scalar  | 128B         |     162.2 ns |   0.38 ns |   0.34 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX2    | 128B         |     181.0 ns |   0.23 ns |   0.20 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX512F | 128B         |     185.4 ns |   0.44 ns |   0.41 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar  | 128B         |     129.6 ns |   0.41 ns |   0.34 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX2    | 128B         |     160.6 ns |   0.30 ns |   0.28 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX512F | 128B         |     167.7 ns |   0.59 ns |   0.53 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar  | 137B         |     152.9 ns |   0.57 ns |   0.53 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX2    | 137B         |     179.7 ns |   0.45 ns |   0.42 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX512F | 137B         |     184.5 ns |   0.47 ns |   0.44 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar  | 137B         |     127.0 ns |   0.82 ns |   0.73 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX2    | 137B         |     160.2 ns |   0.51 ns |   0.48 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX512F | 137B         |     169.0 ns |   0.44 ns |   0.39 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar  | 1KB          |     857.2 ns |   1.86 ns |   1.74 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX2    | 1KB          |   1,082.0 ns |   5.31 ns |   4.97 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX512F | 1KB          |   1,114.8 ns |   2.19 ns |   1.94 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar  | 1KB          |     775.6 ns |   3.09 ns |   2.89 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX2    | 1KB          |   1,014.0 ns |   4.93 ns |   4.62 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX512F | 1KB          |   1,044.0 ns |   3.81 ns |   3.56 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-AVX2    | 1025B        |   1,078.2 ns |   2.11 ns |   1.87 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX512F | 1025B        |   1,110.0 ns |   2.35 ns |   2.20 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-Scalar  | 1025B        |   1,140.6 ns |   3.52 ns |   3.12 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar  | 1025B        |     775.7 ns |   2.80 ns |   2.48 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX2    | 1025B        |   1,016.2 ns |   3.04 ns |   2.70 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX512F | 1025B        |   1,046.8 ns |   2.45 ns |   2.18 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar  | 8KB          |   5,898.2 ns |  27.66 ns |  25.87 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX2    | 8KB          |   7,586.2 ns |  13.48 ns |  11.95 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX512F | 8KB          |   7,780.8 ns |  25.80 ns |  22.87 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar  | 8KB          |   5,731.0 ns |  36.43 ns |  30.42 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX2    | 8KB          |   7,471.6 ns |  11.61 ns |  10.86 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX512F | 8KB          |   7,680.2 ns |  11.71 ns |  10.38 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT128 · CryptoHives-Scalar  | 128KB        |  90,129.8 ns | 316.85 ns | 280.88 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX2    | 128KB        | 114,815.4 ns | 186.47 ns | 155.71 ns |         - |
-| TryComputeHash · KT128 · CryptoHives-AVX512F | 128KB        | 117,891.4 ns | 406.83 ns | 339.72 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-Scalar  | 128KB        |  88,219.0 ns | 558.99 ns | 522.88 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX2    | 128KB        | 115,185.2 ns | 283.92 ns | 237.09 ns |         - |
+| TryComputeHash · KT128 · CryptoHives-AVX512F | 128KB        | 118,251.8 ns | 312.34 ns | 276.88 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kt256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kt256.md
@@ -1,25 +1,25 @@
 ﻿| Description                                  | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |--------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · KT256 · CryptoHives-Scalar  | 128B         |     165.5 ns |   0.89 ns |   0.83 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX2    | 128B         |     191.2 ns |   0.49 ns |   0.46 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX512F | 128B         |     212.2 ns |   0.33 ns |   0.31 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar  | 128B         |     125.5 ns |   0.58 ns |   0.52 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX2    | 128B         |     162.6 ns |   0.43 ns |   0.38 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX512F | 128B         |     170.5 ns |   0.56 ns |   0.47 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar  | 137B         |     315.7 ns |   1.46 ns |   1.37 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX2    | 137B         |     369.7 ns |   0.66 ns |   0.61 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX512F | 137B         |     381.5 ns |   0.49 ns |   0.43 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar  | 137B         |     232.0 ns |   1.30 ns |   1.22 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX2    | 137B         |     303.9 ns |   0.96 ns |   0.85 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX512F | 137B         |     315.2 ns |   0.50 ns |   0.44 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar  | 1KB          |     930.1 ns |   3.39 ns |   3.01 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX2    | 1KB          |   1,199.8 ns |   3.18 ns |   2.66 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX512F | 1KB          |   1,237.0 ns |   3.80 ns |   2.97 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar  | 1KB          |     871.2 ns |   4.91 ns |   4.59 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX2    | 1KB          |   1,146.3 ns |   3.38 ns |   2.99 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX512F | 1KB          |   1,182.6 ns |   3.84 ns |   3.41 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar  | 1025B        |     930.7 ns |   1.42 ns |   1.19 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX2    | 1025B        |   1,200.6 ns |   3.99 ns |   3.54 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX512F | 1025B        |   1,236.9 ns |   2.51 ns |   2.10 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar  | 1025B        |     871.7 ns |   4.74 ns |   4.20 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX2    | 1025B        |   1,147.2 ns |   5.51 ns |   5.15 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX512F | 1025B        |   1,186.0 ns |   3.56 ns |   3.15 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar  | 8KB          |   6,981.4 ns |  28.49 ns |  26.65 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX2    | 8KB          |   9,014.8 ns |  29.03 ns |  24.24 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX512F | 8KB          |   9,296.1 ns |  25.26 ns |  21.10 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar  | 8KB          |   6,826.9 ns |  27.66 ns |  25.87 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX2    | 8KB          |   8,918.5 ns |  23.60 ns |  22.08 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX512F | 8KB          |   9,238.1 ns |  21.63 ns |  18.06 ns |         - |
 |                                              |              |              |           |           |           |
-| TryComputeHash · KT256 · CryptoHives-Scalar  | 128KB        | 108,908.5 ns | 191.53 ns | 169.79 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX2    | 128KB        | 142,730.1 ns | 472.13 ns | 394.25 ns |         - |
-| TryComputeHash · KT256 · CryptoHives-AVX512F | 128KB        | 147,636.6 ns | 510.45 ns | 452.50 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-Scalar  | 128KB        | 108,019.6 ns | 533.94 ns | 499.45 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX2    | 128KB        | 141,199.3 ns | 443.54 ns | 393.19 ns |         - |
+| TryComputeHash · KT256 · CryptoHives-AVX512F | 128KB        | 145,618.3 ns | 330.90 ns | 293.33 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kupyna256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kupyna256.md
@@ -1,19 +1,19 @@
-﻿| Description                                      | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 128B         |     2.220 μs | 0.0136 μs | 0.0127 μs |         - |
-| TryComputeHash · Kupyna-256 · BouncyCastle       | 128B         |     3.261 μs | 0.0088 μs | 0.0078 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 137B         |     2.219 μs | 0.0139 μs | 0.0130 μs |         - |
-| TryComputeHash · Kupyna-256 · BouncyCastle       | 137B         |     3.259 μs | 0.0121 μs | 0.0101 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 1KB          |    11.005 μs | 0.0620 μs | 0.0580 μs |         - |
-| TryComputeHash · Kupyna-256 · BouncyCastle       | 1KB          |    16.274 μs | 0.0461 μs | 0.0409 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 1025B        |    11.013 μs | 0.0373 μs | 0.0311 μs |         - |
-| TryComputeHash · Kupyna-256 · BouncyCastle       | 1025B        |    16.254 μs | 0.0334 μs | 0.0279 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 8KB          |    83.245 μs | 0.4614 μs | 0.4091 μs |         - |
-| TryComputeHash · Kupyna-256 · BouncyCastle       | 8KB          |   120.267 μs | 0.3854 μs | 0.3417 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 128KB        | 1,287.223 μs | 6.2702 μs | 5.8652 μs |         - |
-| TryComputeHash · Kupyna-256 · BouncyCastle       | 128KB        | 1,896.451 μs | 4.4788 μs | 4.1895 μs |         - |
+﻿| Description                                      | TestDataSize | Mean         | Error      | StdDev     | Allocated |
+|------------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
+| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 128B         |     2.233 μs |  0.0185 μs |  0.0164 μs |         - |
+| TryComputeHash · Kupyna-256 · BouncyCastle       | 128B         |     3.397 μs |  0.0132 μs |  0.0110 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 137B         |     2.242 μs |  0.0163 μs |  0.0152 μs |         - |
+| TryComputeHash · Kupyna-256 · BouncyCastle       | 137B         |     3.271 μs |  0.0167 μs |  0.0148 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 1KB          |    11.081 μs |  0.0695 μs |  0.0616 μs |         - |
+| TryComputeHash · Kupyna-256 · BouncyCastle       | 1KB          |    16.327 μs |  0.0748 μs |  0.0699 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 1025B        |    11.060 μs |  0.0585 μs |  0.0519 μs |         - |
+| TryComputeHash · Kupyna-256 · BouncyCastle       | 1025B        |    16.302 μs |  0.1060 μs |  0.0992 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 8KB          |    83.084 μs |  1.2922 μs |  2.2633 μs |         - |
+| TryComputeHash · Kupyna-256 · BouncyCastle       | 8KB          |   120.768 μs |  0.8643 μs |  0.8084 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-256 · CryptoHives-Scalar | 128KB        | 1,294.659 μs |  6.5798 μs |  5.8329 μs |         - |
+| TryComputeHash · Kupyna-256 · BouncyCastle       | 128KB        | 1,902.040 μs | 11.0804 μs | 10.3646 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kupyna384.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kupyna384.md
@@ -1,19 +1,19 @@
 ﻿| Description                                      | TestDataSize | Mean         | Error      | StdDev     | Allocated |
 |------------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
-| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 128B         |     4.325 μs |  0.0177 μs |  0.0166 μs |         - |
-| TryComputeHash · Kupyna-384 · BouncyCastle       | 128B         |     6.612 μs |  0.0245 μs |  0.0217 μs |         - |
+| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 128B         |     4.363 μs |  0.0329 μs |  0.0292 μs |         - |
+| TryComputeHash · Kupyna-384 · BouncyCastle       | 128B         |     6.642 μs |  0.0350 μs |  0.0328 μs |         - |
 |                                                  |              |              |            |            |           |
-| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 137B         |     4.346 μs |  0.0336 μs |  0.0314 μs |         - |
-| TryComputeHash · Kupyna-384 · BouncyCastle       | 137B         |     6.627 μs |  0.0142 μs |  0.0133 μs |         - |
+| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 137B         |     4.338 μs |  0.0215 μs |  0.0191 μs |         - |
+| TryComputeHash · Kupyna-384 · BouncyCastle       | 137B         |     6.661 μs |  0.0327 μs |  0.0290 μs |         - |
 |                                                  |              |              |            |            |           |
-| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 1KB          |    16.747 μs |  0.0723 μs |  0.0640 μs |         - |
-| TryComputeHash · Kupyna-384 · BouncyCastle       | 1KB          |    25.267 μs |  0.0671 μs |  0.0627 μs |         - |
+| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 1KB          |    16.417 μs |  0.1065 μs |  0.0996 μs |         - |
+| TryComputeHash · Kupyna-384 · BouncyCastle       | 1KB          |    25.305 μs |  0.1567 μs |  0.1390 μs |         - |
 |                                                  |              |              |            |            |           |
-| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 1025B        |    16.785 μs |  0.0770 μs |  0.0601 μs |         - |
-| TryComputeHash · Kupyna-384 · BouncyCastle       | 1025B        |    25.294 μs |  0.0985 μs |  0.0922 μs |         - |
+| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 1025B        |    16.438 μs |  0.1075 μs |  0.0953 μs |         - |
+| TryComputeHash · Kupyna-384 · BouncyCastle       | 1025B        |    25.397 μs |  0.1346 μs |  0.1051 μs |         - |
 |                                                  |              |              |            |            |           |
-| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 8KB          |   112.783 μs |  0.5747 μs |  0.5376 μs |         - |
-| TryComputeHash · Kupyna-384 · BouncyCastle       | 8KB          |   174.868 μs |  0.7924 μs |  0.7412 μs |         - |
+| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 8KB          |   112.927 μs |  0.5562 μs |  0.5203 μs |         - |
+| TryComputeHash · Kupyna-384 · BouncyCastle       | 8KB          |   175.458 μs |  2.3004 μs |  2.1518 μs |         - |
 |                                                  |              |              |            |            |           |
-| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 128KB        | 1,762.595 μs |  8.0637 μs |  7.1482 μs |         - |
-| TryComputeHash · Kupyna-384 · BouncyCastle       | 128KB        | 2,732.476 μs | 12.3853 μs | 11.5852 μs |         - |
+| TryComputeHash · Kupyna-384 · CryptoHives-Scalar | 128KB        | 1,770.080 μs |  7.9694 μs |  7.0646 μs |         - |
+| TryComputeHash · Kupyna-384 · BouncyCastle       | 128KB        | 2,745.614 μs | 13.6668 μs | 12.7840 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kupyna512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kupyna512.md
@@ -1,19 +1,19 @@
-﻿| Description                                      | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 128B         |     4.329 μs | 0.0174 μs | 0.0155 μs |         - |
-| TryComputeHash · Kupyna-512 · BouncyCastle       | 128B         |     6.613 μs | 0.0252 μs | 0.0235 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 137B         |     4.329 μs | 0.0128 μs | 0.0120 μs |         - |
-| TryComputeHash · Kupyna-512 · BouncyCastle       | 137B         |     6.640 μs | 0.0203 μs | 0.0189 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 1KB          |    16.758 μs | 0.0634 μs | 0.0529 μs |         - |
-| TryComputeHash · Kupyna-512 · BouncyCastle       | 1KB          |    25.290 μs | 0.0911 μs | 0.0852 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 1025B        |    16.389 μs | 0.0658 μs | 0.0615 μs |         - |
-| TryComputeHash · Kupyna-512 · BouncyCastle       | 1025B        |    25.343 μs | 0.0507 μs | 0.0449 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 8KB          |   112.743 μs | 0.4196 μs | 0.3925 μs |         - |
-| TryComputeHash · Kupyna-512 · BouncyCastle       | 8KB          |   175.390 μs | 0.7403 μs | 0.6182 μs |         - |
-|                                                  |              |              |           |           |           |
-| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 128KB        | 1,802.125 μs | 5.3072 μs | 4.9643 μs |         - |
-| TryComputeHash · Kupyna-512 · BouncyCastle       | 128KB        | 2,738.838 μs | 7.5028 μs | 7.0181 μs |         - |
+﻿| Description                                      | TestDataSize | Mean         | Error      | StdDev     | Allocated |
+|------------------------------------------------- |------------- |-------------:|-----------:|-----------:|----------:|
+| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 128B         |     4.337 μs |  0.0245 μs |  0.0217 μs |         - |
+| TryComputeHash · Kupyna-512 · BouncyCastle       | 128B         |     6.707 μs |  0.0898 μs |  0.0840 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 137B         |     4.350 μs |  0.0343 μs |  0.0321 μs |         - |
+| TryComputeHash · Kupyna-512 · BouncyCastle       | 137B         |     6.650 μs |  0.0318 μs |  0.0265 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 1KB          |    16.414 μs |  0.1396 μs |  0.1237 μs |         - |
+| TryComputeHash · Kupyna-512 · BouncyCastle       | 1KB          |    25.350 μs |  0.0886 μs |  0.0785 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 1025B        |    16.404 μs |  0.1286 μs |  0.1203 μs |         - |
+| TryComputeHash · Kupyna-512 · BouncyCastle       | 1025B        |    25.351 μs |  0.1466 μs |  0.1299 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 8KB          |   112.929 μs |  0.5714 μs |  0.5066 μs |         - |
+| TryComputeHash · Kupyna-512 · BouncyCastle       | 8KB          |   174.499 μs |  0.8201 μs |  0.7270 μs |         - |
+|                                                  |              |              |            |            |           |
+| TryComputeHash · Kupyna-512 · CryptoHives-Scalar | 128KB        | 1,771.726 μs | 11.1152 μs |  9.8533 μs |         - |
+| TryComputeHash · Kupyna-512 · BouncyCastle       | 128KB        | 2,741.613 μs | 13.1621 μs | 12.3118 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kuznyechik-cbc.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/kuznyechik-cbc.md
@@ -1,17 +1,17 @@
 ﻿| Description                                   | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |---------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128B         |     422.1 μs |     1.89 μs |     1.77 μs |         - |
+| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128B         |     417.9 μs |     1.61 μs |     1.43 μs |         - |
 |                                               |              |              |             |             |           |
-| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128B         |     420.6 μs |     2.04 μs |     1.91 μs |         - |
+| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128B         |     430.8 μs |     2.83 μs |     2.65 μs |         - |
 |                                               |              |              |             |             |           |
-| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 1KB          |   3,164.9 μs |    13.50 μs |    12.63 μs |         - |
+| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 1KB          |   3,169.6 μs |    18.50 μs |    17.30 μs |         - |
 |                                               |              |              |             |             |           |
-| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 1KB          |   3,112.5 μs |    10.94 μs |     9.14 μs |         - |
+| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 1KB          |   3,051.2 μs |     9.47 μs |     8.86 μs |         - |
 |                                               |              |              |             |             |           |
-| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 8KB          |  24,335.0 μs |    76.30 μs |    71.37 μs |         - |
+| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 8KB          |  24,439.3 μs |    84.78 μs |    79.30 μs |         - |
 |                                               |              |              |             |             |           |
-| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 8KB          |  24,002.4 μs |   118.90 μs |   111.22 μs |         - |
+| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 8KB          |  24,127.4 μs |   109.88 μs |   102.78 μs |         - |
 |                                               |              |              |             |             |           |
-| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128KB        | 384,833.5 μs |   904.78 μs |   802.07 μs |         - |
+| Decrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128KB        | 385,783.1 μs | 1,298.34 μs | 1,214.46 μs |         - |
 |                                               |              |              |             |             |           |
-| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128KB        | 393,069.0 μs | 1,641.49 μs | 1,535.45 μs |         - |
+| Encrypt · Kuznyechik-CBC (CryptoHives-Scalar) | 128KB        | 385,158.8 μs | 3,070.56 μs | 2,872.20 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/lsh256-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/lsh256-256.md
@@ -1,13 +1,13 @@
 ﻿| Description                                       | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |-------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 128B         |   1.857 μs | 0.0143 μs | 0.0111 μs |         - |
+| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 128B         |   1.848 μs | 0.0063 μs | 0.0059 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 137B         |   1.858 μs | 0.0116 μs | 0.0103 μs |         - |
+| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 137B         |   1.861 μs | 0.0099 μs | 0.0082 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 1KB          |   8.146 μs | 0.0245 μs | 0.0230 μs |         - |
+| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 1KB          |   8.130 μs | 0.0335 μs | 0.0297 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 1025B        |   8.183 μs | 0.0429 μs | 0.0358 μs |         - |
+| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 1025B        |   8.163 μs | 0.0585 μs | 0.0547 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 8KB          |  58.381 μs | 0.1942 μs | 0.1622 μs |         - |
+| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 8KB          |  58.416 μs | 0.2323 μs | 0.2173 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 128KB        | 921.112 μs | 4.5933 μs | 4.2966 μs |         - |
+| TryComputeHash · LSH-256-256 · CryptoHives-Scalar | 128KB        | 918.406 μs | 3.1978 μs | 2.9912 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/lsh512-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/lsh512-256.md
@@ -1,13 +1,13 @@
 ﻿| Description                                       | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |-------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 128B         |   1.082 μs | 0.0052 μs | 0.0048 μs |         - |
+| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 128B         |   1.044 μs | 0.0057 μs | 0.0053 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 137B         |   1.039 μs | 0.0056 μs | 0.0047 μs |         - |
+| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 137B         |   1.039 μs | 0.0073 μs | 0.0065 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 1KB          |   4.975 μs | 0.0287 μs | 0.0254 μs |         - |
+| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 1KB          |   4.967 μs | 0.0311 μs | 0.0291 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 1025B        |   4.982 μs | 0.0251 μs | 0.0223 μs |         - |
+| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 1025B        |   4.973 μs | 0.0158 μs | 0.0140 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 8KB          |  32.210 μs | 0.1599 μs | 0.1335 μs |         - |
+| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 8KB          |  32.176 μs | 0.1356 μs | 0.1268 μs |         - |
 |                                                   |              |            |           |           |           |
-| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 128KB        | 512.227 μs | 9.5797 μs | 9.8377 μs |         - |
+| TryComputeHash · LSH-512-256 · CryptoHives-Scalar | 128KB        | 501.782 μs | 4.0564 μs | 3.7944 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/lsh512-512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/lsh512-512.md
@@ -1,13 +1,13 @@
-﻿| Description                                       | TestDataSize | Mean       | Error     | StdDev     | Allocated |
-|-------------------------------------------------- |------------- |-----------:|----------:|-----------:|----------:|
-| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 128B         |   1.070 μs | 0.0120 μs |  0.0106 μs |         - |
-|                                                   |              |            |           |            |           |
-| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 137B         |   1.047 μs | 0.0079 μs |  0.0061 μs |         - |
-|                                                   |              |            |           |            |           |
-| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 1KB          |   5.060 μs | 0.0740 μs |  0.0760 μs |         - |
-|                                                   |              |            |           |            |           |
-| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 1025B        |   5.246 μs | 0.0996 μs |  0.0978 μs |         - |
-|                                                   |              |            |           |            |           |
-| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 8KB          |  32.626 μs | 0.3396 μs |  0.2836 μs |         - |
-|                                                   |              |            |           |            |           |
-| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 128KB        | 511.232 μs | 9.7303 μs | 10.4113 μs |         - |
+﻿| Description                                       | TestDataSize | Mean       | Error     | StdDev    | Allocated |
+|-------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
+| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 128B         |   1.045 μs | 0.0047 μs | 0.0044 μs |         - |
+|                                                   |              |            |           |           |           |
+| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 137B         |   1.044 μs | 0.0027 μs | 0.0024 μs |         - |
+|                                                   |              |            |           |           |           |
+| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 1KB          |   4.967 μs | 0.0212 μs | 0.0199 μs |         - |
+|                                                   |              |            |           |           |           |
+| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 1025B        |   4.983 μs | 0.0244 μs | 0.0217 μs |         - |
+|                                                   |              |            |           |           |           |
+| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 8KB          |  32.108 μs | 0.1955 μs | 0.1829 μs |         - |
+|                                                   |              |            |           |           |           |
+| TryComputeHash · LSH-512-512 · CryptoHives-Scalar | 128KB        | 541.612 μs | 1.5951 μs | 1.2454 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/md5.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/md5.md
@@ -1,25 +1,25 @@
-﻿| Description                               | TestDataSize | Mean         | Error       | StdDev    | Allocated |
-|------------------------------------------ |------------- |-------------:|------------:|----------:|----------:|
-| TryComputeHash · MD5 · OS Native          | 128B         |     271.1 ns |     1.10 ns |   1.03 ns |         - |
-| TryComputeHash · MD5 · CryptoHives-Scalar | 128B         |     310.8 ns |     2.25 ns |   2.00 ns |         - |
-| TryComputeHash · MD5 · BouncyCastle       | 128B         |     369.5 ns |     0.94 ns |   0.83 ns |         - |
-|                                           |              |              |             |           |           |
-| TryComputeHash · MD5 · OS Native          | 137B         |     267.4 ns |     0.68 ns |   0.64 ns |         - |
-| TryComputeHash · MD5 · CryptoHives-Scalar | 137B         |     314.9 ns |     2.28 ns |   2.13 ns |         - |
-| TryComputeHash · MD5 · BouncyCastle       | 137B         |     369.1 ns |     0.86 ns |   0.76 ns |         - |
-|                                           |              |              |             |           |           |
-| TryComputeHash · MD5 · OS Native          | 1KB          |   1,370.5 ns |     2.67 ns |   2.50 ns |         - |
-| TryComputeHash · MD5 · CryptoHives-Scalar | 1KB          |   1,709.8 ns |    11.18 ns |   9.92 ns |         - |
-| TryComputeHash · MD5 · BouncyCastle       | 1KB          |   2,020.2 ns |     8.50 ns |   7.54 ns |         - |
-|                                           |              |              |             |           |           |
-| TryComputeHash · MD5 · OS Native          | 1025B        |   1,370.1 ns |     3.49 ns |   3.26 ns |         - |
-| TryComputeHash · MD5 · CryptoHives-Scalar | 1025B        |   1,744.0 ns |    30.69 ns |  32.84 ns |         - |
-| TryComputeHash · MD5 · BouncyCastle       | 1025B        |   2,025.5 ns |    27.79 ns |  21.70 ns |         - |
-|                                           |              |              |             |           |           |
-| TryComputeHash · MD5 · OS Native          | 8KB          |  10,167.3 ns |    24.01 ns |  21.28 ns |         - |
-| TryComputeHash · MD5 · CryptoHives-Scalar | 8KB          |  12,935.8 ns |    70.42 ns |  62.42 ns |         - |
-| TryComputeHash · MD5 · BouncyCastle       | 8KB          |  15,168.1 ns |    56.68 ns |  50.24 ns |         - |
-|                                           |              |              |             |           |           |
-| TryComputeHash · MD5 · OS Native          | 128KB        | 160,970.5 ns |   362.16 ns | 338.77 ns |         - |
-| TryComputeHash · MD5 · CryptoHives-Scalar | 128KB        | 204,965.4 ns | 1,077.14 ns | 954.86 ns |         - |
-| TryComputeHash · MD5 · BouncyCastle       | 128KB        | 240,281.1 ns |   392.25 ns | 327.55 ns |         - |
+﻿| Description                               | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|------------------------------------------ |------------- |-------------:|----------:|----------:|----------:|
+| TryComputeHash · MD5 · OS Native          | 128B         |     268.4 ns |   0.57 ns |   0.54 ns |         - |
+| TryComputeHash · MD5 · CryptoHives-Scalar | 128B         |     309.1 ns |   3.11 ns |   2.91 ns |         - |
+| TryComputeHash · MD5 · BouncyCastle       | 128B         |     368.9 ns |   0.49 ns |   0.46 ns |         - |
+|                                           |              |              |           |           |           |
+| TryComputeHash · MD5 · OS Native          | 137B         |     266.4 ns |   0.28 ns |   0.23 ns |         - |
+| TryComputeHash · MD5 · CryptoHives-Scalar | 137B         |     312.8 ns |   1.63 ns |   1.45 ns |         - |
+| TryComputeHash · MD5 · BouncyCastle       | 137B         |     369.1 ns |   0.87 ns |   0.72 ns |         - |
+|                                           |              |              |           |           |           |
+| TryComputeHash · MD5 · OS Native          | 1KB          |   1,377.6 ns |   1.87 ns |   1.75 ns |         - |
+| TryComputeHash · MD5 · CryptoHives-Scalar | 1KB          |   1,713.9 ns |  10.44 ns |   9.25 ns |         - |
+| TryComputeHash · MD5 · BouncyCastle       | 1KB          |   2,011.5 ns |   4.96 ns |   4.40 ns |         - |
+|                                           |              |              |           |           |           |
+| TryComputeHash · MD5 · OS Native          | 1025B        |   1,369.2 ns |   1.59 ns |   1.41 ns |         - |
+| TryComputeHash · MD5 · CryptoHives-Scalar | 1025B        |   1,715.1 ns |   8.07 ns |   7.55 ns |         - |
+| TryComputeHash · MD5 · BouncyCastle       | 1025B        |   2,013.3 ns |   4.85 ns |   4.30 ns |         - |
+|                                           |              |              |           |           |           |
+| TryComputeHash · MD5 · OS Native          | 8KB          |  10,155.2 ns |  10.60 ns |   9.92 ns |         - |
+| TryComputeHash · MD5 · CryptoHives-Scalar | 8KB          |  12,895.3 ns |  76.00 ns |  67.38 ns |         - |
+| TryComputeHash · MD5 · BouncyCastle       | 8KB          |  15,144.2 ns |  24.49 ns |  21.71 ns |         - |
+|                                           |              |              |           |           |           |
+| TryComputeHash · MD5 · OS Native          | 128KB        | 160,835.1 ns | 167.68 ns | 156.85 ns |         - |
+| TryComputeHash · MD5 · CryptoHives-Scalar | 128KB        | 204,922.0 ns | 896.17 ns | 838.28 ns |         - |
+| TryComputeHash · MD5 · BouncyCastle       | 128KB        | 240,671.1 ns | 915.29 ns | 811.38 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/ripemd160.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/ripemd160.md
@@ -1,19 +1,19 @@
-﻿| Description                                                   | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|-------------------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · RIPEMD-160 · BouncyCastle                    | 128B         |     645.2 ns |     1.58 ns |     1.48 ns |         - |
-| TryComputeHash · RIPEMD-160 · RIPEMD-160 (CryptoHives-Scalar) | 128B         |     709.8 ns |     3.68 ns |     3.45 ns |         - |
-|                                                               |              |              |             |             |           |
-| TryComputeHash · RIPEMD-160 · BouncyCastle                    | 137B         |     642.0 ns |     2.04 ns |     1.91 ns |         - |
-| TryComputeHash · RIPEMD-160 · RIPEMD-160 (CryptoHives-Scalar) | 137B         |     709.9 ns |     4.26 ns |     3.55 ns |         - |
-|                                                               |              |              |             |             |           |
-| TryComputeHash · RIPEMD-160 · BouncyCastle                    | 1KB          |   3,558.8 ns |    10.27 ns |     9.61 ns |         - |
-| TryComputeHash · RIPEMD-160 · RIPEMD-160 (CryptoHives-Scalar) | 1KB          |   3,963.5 ns |    18.64 ns |    15.56 ns |         - |
-|                                                               |              |              |             |             |           |
-| TryComputeHash · RIPEMD-160 · BouncyCastle                    | 1025B        |   3,561.5 ns |     7.18 ns |     6.37 ns |         - |
-| TryComputeHash · RIPEMD-160 · RIPEMD-160 (CryptoHives-Scalar) | 1025B        |   3,989.0 ns |    34.82 ns |    29.08 ns |         - |
-|                                                               |              |              |             |             |           |
-| TryComputeHash · RIPEMD-160 · BouncyCastle                    | 8KB          |  26,841.8 ns |    85.91 ns |    71.74 ns |         - |
-| TryComputeHash · RIPEMD-160 · RIPEMD-160 (CryptoHives-Scalar) | 8KB          |  30,041.1 ns |   133.84 ns |   111.76 ns |         - |
-|                                                               |              |              |             |             |           |
-| TryComputeHash · RIPEMD-160 · BouncyCastle                    | 128KB        | 426,090.8 ns | 1,779.83 ns | 1,486.24 ns |         - |
-| TryComputeHash · RIPEMD-160 · RIPEMD-160 (CryptoHives-Scalar) | 128KB        | 475,533.0 ns | 2,189.58 ns | 1,941.01 ns |         - |
+﻿| Description                                      | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · RIPEMD-160 · BouncyCastle       | 128B         |     638.8 ns |     1.59 ns |     1.41 ns |         - |
+| TryComputeHash · RIPEMD-160 · CryptoHives-Scalar | 128B         |     703.1 ns |     4.50 ns |     3.99 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · RIPEMD-160 · BouncyCastle       | 137B         |     639.3 ns |     2.85 ns |     2.53 ns |         - |
+| TryComputeHash · RIPEMD-160 · CryptoHives-Scalar | 137B         |     712.4 ns |     7.27 ns |     6.45 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · RIPEMD-160 · BouncyCastle       | 1KB          |   3,551.4 ns |     3.91 ns |     3.05 ns |         - |
+| TryComputeHash · RIPEMD-160 · CryptoHives-Scalar | 1KB          |   3,942.6 ns |    24.81 ns |    21.99 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · RIPEMD-160 · BouncyCastle       | 1025B        |   3,561.0 ns |     9.13 ns |     7.63 ns |         - |
+| TryComputeHash · RIPEMD-160 · CryptoHives-Scalar | 1025B        |   3,950.1 ns |    14.31 ns |    12.69 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · RIPEMD-160 · BouncyCastle       | 8KB          |  26,855.9 ns |    68.48 ns |    60.70 ns |         - |
+| TryComputeHash · RIPEMD-160 · CryptoHives-Scalar | 8KB          |  29,928.6 ns |   266.76 ns |   208.27 ns |         - |
+|                                                  |              |              |             |             |           |
+| TryComputeHash · RIPEMD-160 · BouncyCastle       | 128KB        | 426,882.3 ns | 1,441.29 ns | 1,203.54 ns |         - |
+| TryComputeHash · RIPEMD-160 · CryptoHives-Scalar | 128KB        | 474,293.7 ns | 3,466.28 ns | 3,242.36 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/seed-cbc.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/seed-cbc.md
@@ -1,25 +1,25 @@
 ﻿| Description                             | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |---------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| Decrypt · SEED-CBC (CryptoHives-Scalar) | 128B         |     1.194 μs | 0.0018 μs | 0.0017 μs |         - |
-| Decrypt · SEED-CBC (BouncyCastle)       | 128B         |     1.290 μs | 0.0018 μs | 0.0017 μs |     152 B |
+| Decrypt · SEED-CBC (CryptoHives-Scalar) | 128B         |     1.197 μs | 0.0030 μs | 0.0028 μs |         - |
+| Decrypt · SEED-CBC (BouncyCastle)       | 128B         |     1.294 μs | 0.0027 μs | 0.0024 μs |     152 B |
 |                                         |              |              |           |           |           |
-| Encrypt · SEED-CBC (CryptoHives-Scalar) | 128B         |     1.203 μs | 0.0013 μs | 0.0012 μs |         - |
-| Encrypt · SEED-CBC (BouncyCastle)       | 128B         |     1.286 μs | 0.0028 μs | 0.0026 μs |     152 B |
+| Encrypt · SEED-CBC (CryptoHives-Scalar) | 128B         |     1.206 μs | 0.0012 μs | 0.0011 μs |         - |
+| Encrypt · SEED-CBC (BouncyCastle)       | 128B         |     1.290 μs | 0.0035 μs | 0.0033 μs |     152 B |
 |                                         |              |              |           |           |           |
-| Decrypt · SEED-CBC (CryptoHives-Scalar) | 1KB          |     8.539 μs | 0.0125 μs | 0.0111 μs |         - |
-| Decrypt · SEED-CBC (BouncyCastle)       | 1KB          |     8.745 μs | 0.0140 μs | 0.0131 μs |     152 B |
+| Decrypt · SEED-CBC (CryptoHives-Scalar) | 1KB          |     8.563 μs | 0.0234 μs | 0.0219 μs |         - |
+| Decrypt · SEED-CBC (BouncyCastle)       | 1KB          |     8.764 μs | 0.0429 μs | 0.0402 μs |     152 B |
 |                                         |              |              |           |           |           |
-| Encrypt · SEED-CBC (CryptoHives-Scalar) | 1KB          |     8.626 μs | 0.0123 μs | 0.0115 μs |         - |
-| Encrypt · SEED-CBC (BouncyCastle)       | 1KB          |     8.802 μs | 0.0150 μs | 0.0140 μs |     152 B |
+| Encrypt · SEED-CBC (CryptoHives-Scalar) | 1KB          |     8.642 μs | 0.0170 μs | 0.0159 μs |         - |
+| Encrypt · SEED-CBC (BouncyCastle)       | 1KB          |     8.814 μs | 0.0182 μs | 0.0162 μs |     152 B |
 |                                         |              |              |           |           |           |
-| Decrypt · SEED-CBC (CryptoHives-Scalar) | 8KB          |    67.278 μs | 0.0757 μs | 0.0708 μs |         - |
-| Decrypt · SEED-CBC (BouncyCastle)       | 8KB          |    68.374 μs | 0.0937 μs | 0.0876 μs |     152 B |
+| Decrypt · SEED-CBC (CryptoHives-Scalar) | 8KB          |    67.367 μs | 0.0978 μs | 0.0867 μs |         - |
+| Decrypt · SEED-CBC (BouncyCastle)       | 8KB          |    68.531 μs | 0.2005 μs | 0.1875 μs |     152 B |
 |                                         |              |              |           |           |           |
-| Encrypt · SEED-CBC (CryptoHives-Scalar) | 8KB          |    67.979 μs | 0.0610 μs | 0.0540 μs |         - |
-| Encrypt · SEED-CBC (BouncyCastle)       | 8KB          |    68.824 μs | 0.0622 μs | 0.0582 μs |     152 B |
+| Encrypt · SEED-CBC (CryptoHives-Scalar) | 8KB          |    68.232 μs | 0.1106 μs | 0.1035 μs |         - |
+| Encrypt · SEED-CBC (BouncyCastle)       | 8KB          |    69.019 μs | 0.0988 μs | 0.0876 μs |     152 B |
 |                                         |              |              |           |           |           |
-| Decrypt · SEED-CBC (CryptoHives-Scalar) | 128KB        | 1,075.115 μs | 0.7034 μs | 0.6579 μs |         - |
-| Decrypt · SEED-CBC (BouncyCastle)       | 128KB        | 1,104.152 μs | 1.2752 μs | 1.1304 μs |     152 B |
+| Decrypt · SEED-CBC (CryptoHives-Scalar) | 128KB        | 1,075.896 μs | 2.1281 μs | 1.9907 μs |         - |
+| Decrypt · SEED-CBC (BouncyCastle)       | 128KB        | 1,095.910 μs | 8.1496 μs | 7.2244 μs |     152 B |
 |                                         |              |              |           |           |           |
-| Encrypt · SEED-CBC (CryptoHives-Scalar) | 128KB        | 1,085.774 μs | 1.4721 μs | 1.3050 μs |         - |
-| Encrypt · SEED-CBC (BouncyCastle)       | 128KB        | 1,098.385 μs | 1.5355 μs | 1.4363 μs |     152 B |
+| Encrypt · SEED-CBC (CryptoHives-Scalar) | 128KB        | 1,085.838 μs | 3.0743 μs | 2.8757 μs |         - |
+| Encrypt · SEED-CBC (BouncyCastle)       | 128KB        | 1,099.553 μs | 3.1768 μs | 2.4802 μs |     152 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha1.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha1.md
@@ -1,25 +1,25 @@
 ﻿| Description                                 | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA-1 · OS Native          | 128B         |     229.5 ns |     2.64 ns |     2.34 ns |         - |
-| TryComputeHash · SHA-1 · BouncyCastle       | 128B         |     439.1 ns |     2.54 ns |     2.38 ns |         - |
-| TryComputeHash · SHA-1 · CryptoHives-Scalar | 128B         |     457.1 ns |     3.13 ns |     2.93 ns |         - |
+| TryComputeHash · SHA-1 · OS Native          | 128B         |     229.0 ns |     0.78 ns |     0.69 ns |         - |
+| TryComputeHash · SHA-1 · BouncyCastle       | 128B         |     434.3 ns |     1.70 ns |     1.59 ns |         - |
+| TryComputeHash · SHA-1 · CryptoHives-Scalar | 128B         |     455.1 ns |     2.96 ns |     2.63 ns |         - |
 |                                             |              |              |             |             |           |
-| TryComputeHash · SHA-1 · OS Native          | 137B         |     229.6 ns |     1.49 ns |     1.32 ns |         - |
-| TryComputeHash · SHA-1 · BouncyCastle       | 137B         |     443.6 ns |     5.37 ns |     4.76 ns |         - |
-| TryComputeHash · SHA-1 · CryptoHives-Scalar | 137B         |     454.5 ns |     2.75 ns |     2.57 ns |         - |
+| TryComputeHash · SHA-1 · OS Native          | 137B         |     229.7 ns |     1.01 ns |     0.95 ns |         - |
+| TryComputeHash · SHA-1 · BouncyCastle       | 137B         |     435.8 ns |     1.55 ns |     1.38 ns |         - |
+| TryComputeHash · SHA-1 · CryptoHives-Scalar | 137B         |     452.2 ns |     2.07 ns |     1.61 ns |         - |
 |                                             |              |              |             |             |           |
-| TryComputeHash · SHA-1 · OS Native          | 1KB          |   1,097.0 ns |     6.77 ns |     6.00 ns |         - |
-| TryComputeHash · SHA-1 · BouncyCastle       | 1KB          |   2,428.5 ns |     9.24 ns |     8.64 ns |         - |
-| TryComputeHash · SHA-1 · CryptoHives-Scalar | 1KB          |   2,450.6 ns |    17.82 ns |    16.67 ns |         - |
+| TryComputeHash · SHA-1 · OS Native          | 1KB          |   1,096.1 ns |     2.12 ns |     1.66 ns |         - |
+| TryComputeHash · SHA-1 · BouncyCastle       | 1KB          |   2,420.6 ns |     7.26 ns |     6.44 ns |         - |
+| TryComputeHash · SHA-1 · CryptoHives-Scalar | 1KB          |   2,457.2 ns |    14.34 ns |    13.41 ns |         - |
 |                                             |              |              |             |             |           |
-| TryComputeHash · SHA-1 · OS Native          | 1025B        |   1,098.0 ns |     7.59 ns |     5.93 ns |         - |
-| TryComputeHash · SHA-1 · BouncyCastle       | 1025B        |   2,423.7 ns |     7.96 ns |     7.44 ns |         - |
-| TryComputeHash · SHA-1 · CryptoHives-Scalar | 1025B        |   2,448.9 ns |     9.26 ns |     8.67 ns |         - |
+| TryComputeHash · SHA-1 · OS Native          | 1025B        |   1,098.1 ns |     3.65 ns |     3.23 ns |         - |
+| TryComputeHash · SHA-1 · BouncyCastle       | 1025B        |   2,416.6 ns |     7.45 ns |     5.82 ns |         - |
+| TryComputeHash · SHA-1 · CryptoHives-Scalar | 1025B        |   2,449.5 ns |    12.44 ns |    11.63 ns |         - |
 |                                             |              |              |             |             |           |
-| TryComputeHash · SHA-1 · OS Native          | 8KB          |   8,039.6 ns |    25.24 ns |    21.08 ns |         - |
-| TryComputeHash · SHA-1 · BouncyCastle       | 8KB          |  18,327.4 ns |    92.63 ns |    86.65 ns |         - |
-| TryComputeHash · SHA-1 · CryptoHives-Scalar | 8KB          |  18,341.0 ns |    55.50 ns |    49.20 ns |         - |
+| TryComputeHash · SHA-1 · OS Native          | 8KB          |   8,037.1 ns |    28.62 ns |    23.90 ns |         - |
+| TryComputeHash · SHA-1 · BouncyCastle       | 8KB          |  18,224.4 ns |    66.77 ns |    59.19 ns |         - |
+| TryComputeHash · SHA-1 · CryptoHives-Scalar | 8KB          |  18,364.5 ns |    60.05 ns |    50.14 ns |         - |
 |                                             |              |              |             |             |           |
-| TryComputeHash · SHA-1 · OS Native          | 128KB        | 127,568.2 ns |   906.92 ns |   803.96 ns |         - |
-| TryComputeHash · SHA-1 · BouncyCastle       | 128KB        | 290,098.5 ns | 1,690.71 ns | 1,498.77 ns |         - |
-| TryComputeHash · SHA-1 · CryptoHives-Scalar | 128KB        | 291,079.8 ns | 1,104.77 ns |   979.35 ns |         - |
+| TryComputeHash · SHA-1 · OS Native          | 128KB        | 127,098.6 ns |   155.43 ns |   129.79 ns |         - |
+| TryComputeHash · SHA-1 · BouncyCastle       | 128KB        | 289,536.6 ns | 1,181.97 ns | 1,047.78 ns |         - |
+| TryComputeHash · SHA-1 · CryptoHives-Scalar | 128KB        | 291,638.8 ns | 1,352.95 ns | 1,265.55 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha224.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha224.md
@@ -1,19 +1,19 @@
 ﻿| Description                                   | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |---------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA-224 · CryptoHives-Scalar | 128B         |     474.4 ns |     2.51 ns |     2.23 ns |         - |
-| TryComputeHash · SHA-224 · BouncyCastle       | 128B         |     555.1 ns |     1.66 ns |     1.47 ns |         - |
+| TryComputeHash · SHA-224 · CryptoHives-Scalar | 128B         |     474.7 ns |     1.48 ns |     1.31 ns |         - |
+| TryComputeHash · SHA-224 · BouncyCastle       | 128B         |     553.1 ns |     2.74 ns |     2.29 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-224 · CryptoHives-Scalar | 137B         |     476.8 ns |     2.91 ns |     2.58 ns |         - |
-| TryComputeHash · SHA-224 · BouncyCastle       | 137B         |     556.0 ns |     2.22 ns |     1.97 ns |         - |
+| TryComputeHash · SHA-224 · CryptoHives-Scalar | 137B         |     475.5 ns |     1.38 ns |     1.15 ns |         - |
+| TryComputeHash · SHA-224 · BouncyCastle       | 137B         |     555.3 ns |     2.78 ns |     2.60 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-224 · CryptoHives-Scalar | 1KB          |   2,644.8 ns |    14.86 ns |    13.90 ns |         - |
-| TryComputeHash · SHA-224 · BouncyCastle       | 1KB          |   3,079.7 ns |    11.38 ns |     8.89 ns |         - |
+| TryComputeHash · SHA-224 · CryptoHives-Scalar | 1KB          |   2,640.4 ns |    14.56 ns |    13.62 ns |         - |
+| TryComputeHash · SHA-224 · BouncyCastle       | 1KB          |   3,075.8 ns |    13.73 ns |    12.84 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-224 · CryptoHives-Scalar | 1025B        |   2,656.0 ns |    13.87 ns |    12.29 ns |         - |
-| TryComputeHash · SHA-224 · BouncyCastle       | 1025B        |   3,090.2 ns |    11.63 ns |    10.88 ns |         - |
+| TryComputeHash · SHA-224 · CryptoHives-Scalar | 1025B        |   2,647.5 ns |    10.78 ns |     9.55 ns |         - |
+| TryComputeHash · SHA-224 · BouncyCastle       | 1025B        |   3,077.8 ns |    13.97 ns |    12.38 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-224 · CryptoHives-Scalar | 8KB          |  19,927.8 ns |    98.61 ns |    92.24 ns |         - |
-| TryComputeHash · SHA-224 · BouncyCastle       | 8KB          |  23,259.6 ns |   112.20 ns |    93.69 ns |         - |
+| TryComputeHash · SHA-224 · CryptoHives-Scalar | 8KB          |  19,901.7 ns |    68.55 ns |    60.77 ns |         - |
+| TryComputeHash · SHA-224 · BouncyCastle       | 8KB          |  23,252.6 ns |    97.27 ns |    86.23 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-224 · CryptoHives-Scalar | 128KB        | 316,203.4 ns | 1,347.93 ns | 1,125.58 ns |         - |
-| TryComputeHash · SHA-224 · BouncyCastle       | 128KB        | 369,484.8 ns | 1,069.57 ns | 1,000.47 ns |         - |
+| TryComputeHash · SHA-224 · CryptoHives-Scalar | 128KB        | 316,589.1 ns | 2,196.12 ns | 1,946.80 ns |         - |
+| TryComputeHash · SHA-224 · BouncyCastle       | 128KB        | 369,038.1 ns | 1,868.64 ns | 1,747.92 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha256.md
@@ -1,25 +1,25 @@
 ﻿| Description                                   | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |---------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA-256 · OS Native          | 128B         |     106.2 ns |     0.26 ns |     0.25 ns |         - |
-| TryComputeHash · SHA-256 · CryptoHives-Scalar | 128B         |     477.4 ns |     2.73 ns |     2.42 ns |         - |
-| TryComputeHash · SHA-256 · BouncyCastle       | 128B         |     552.7 ns |     4.28 ns |     4.01 ns |         - |
+| TryComputeHash · SHA-256 · OS Native          | 128B         |     106.2 ns |     0.25 ns |     0.23 ns |         - |
+| TryComputeHash · SHA-256 · CryptoHives-Scalar | 128B         |     474.5 ns |     2.14 ns |     1.78 ns |         - |
+| TryComputeHash · SHA-256 · BouncyCastle       | 128B         |     554.0 ns |     2.54 ns |     2.25 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-256 · OS Native          | 137B         |     105.9 ns |     0.26 ns |     0.24 ns |         - |
-| TryComputeHash · SHA-256 · CryptoHives-Scalar | 137B         |     477.1 ns |     1.65 ns |     1.54 ns |         - |
-| TryComputeHash · SHA-256 · BouncyCastle       | 137B         |     562.3 ns |     3.32 ns |     2.78 ns |         - |
+| TryComputeHash · SHA-256 · OS Native          | 137B         |     106.3 ns |     0.28 ns |     0.26 ns |         - |
+| TryComputeHash · SHA-256 · CryptoHives-Scalar | 137B         |     476.7 ns |     2.56 ns |     2.40 ns |         - |
+| TryComputeHash · SHA-256 · BouncyCastle       | 137B         |     583.6 ns |     1.23 ns |     1.03 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-256 · OS Native          | 1KB          |     460.4 ns |     0.89 ns |     0.83 ns |         - |
-| TryComputeHash · SHA-256 · CryptoHives-Scalar | 1KB          |   2,643.8 ns |    16.37 ns |    15.31 ns |         - |
-| TryComputeHash · SHA-256 · BouncyCastle       | 1KB          |   3,048.3 ns |    11.26 ns |    10.54 ns |         - |
+| TryComputeHash · SHA-256 · OS Native          | 1KB          |     463.4 ns |     0.66 ns |     0.59 ns |         - |
+| TryComputeHash · SHA-256 · CryptoHives-Scalar | 1KB          |   2,640.9 ns |    13.29 ns |    12.43 ns |         - |
+| TryComputeHash · SHA-256 · BouncyCastle       | 1KB          |   3,039.1 ns |     8.52 ns |     7.55 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-256 · OS Native          | 1025B        |     461.5 ns |     1.72 ns |     1.43 ns |         - |
-| TryComputeHash · SHA-256 · CryptoHives-Scalar | 1025B        |   2,659.4 ns |    16.39 ns |    14.53 ns |         - |
-| TryComputeHash · SHA-256 · BouncyCastle       | 1025B        |   3,037.7 ns |     6.84 ns |     6.07 ns |         - |
+| TryComputeHash · SHA-256 · OS Native          | 1025B        |     463.7 ns |     0.74 ns |     0.66 ns |         - |
+| TryComputeHash · SHA-256 · CryptoHives-Scalar | 1025B        |   2,649.5 ns |    15.33 ns |    14.34 ns |         - |
+| TryComputeHash · SHA-256 · BouncyCastle       | 1025B        |   3,035.4 ns |    10.71 ns |     9.50 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-256 · OS Native          | 8KB          |   3,255.3 ns |    21.91 ns |    18.30 ns |         - |
-| TryComputeHash · SHA-256 · CryptoHives-Scalar | 8KB          |  19,949.7 ns |   139.08 ns |   130.09 ns |         - |
-| TryComputeHash · SHA-256 · BouncyCastle       | 8KB          |  22,995.5 ns |   103.62 ns |    91.86 ns |         - |
+| TryComputeHash · SHA-256 · OS Native          | 8KB          |   3,276.0 ns |     7.24 ns |     6.77 ns |         - |
+| TryComputeHash · SHA-256 · CryptoHives-Scalar | 8KB          |  20,058.6 ns |   223.86 ns |   209.39 ns |         - |
+| TryComputeHash · SHA-256 · BouncyCastle       | 8KB          |  22,964.1 ns |   120.51 ns |   112.72 ns |         - |
 |                                               |              |              |             |             |           |
-| TryComputeHash · SHA-256 · OS Native          | 128KB        |  51,212.7 ns |   141.84 ns |   132.68 ns |         - |
-| TryComputeHash · SHA-256 · CryptoHives-Scalar | 128KB        | 319,255.3 ns | 2,612.42 ns | 2,443.65 ns |         - |
-| TryComputeHash · SHA-256 · BouncyCastle       | 128KB        | 367,402.4 ns | 1,887.04 ns | 1,473.28 ns |         - |
+| TryComputeHash · SHA-256 · OS Native          | 128KB        |  51,492.5 ns |   109.27 ns |    91.24 ns |         - |
+| TryComputeHash · SHA-256 · CryptoHives-Scalar | 128KB        | 316,993.3 ns | 1,838.70 ns | 1,629.96 ns |         - |
+| TryComputeHash · SHA-256 · BouncyCastle       | 128KB        | 363,789.5 ns | 1,264.91 ns | 1,183.20 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-224.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-224.md
@@ -1,31 +1,31 @@
 ﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 128B         |     212.2 ns |     1.38 ns |     1.15 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 128B         |     284.3 ns |     0.90 ns |     0.80 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 128B         |     289.7 ns |     1.99 ns |     1.77 ns |         - |
-| TryComputeHash · SHA3-224 · BouncyCastle        | 128B         |     334.5 ns |     1.53 ns |     1.43 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 128B         |     208.3 ns |     1.13 ns |     1.05 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 128B         |     278.8 ns |     0.54 ns |     0.48 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 128B         |     288.7 ns |     0.68 ns |     0.64 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle        | 128B         |     333.3 ns |     1.82 ns |     1.70 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 137B         |     212.6 ns |     1.77 ns |     1.66 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 137B         |     283.8 ns |     0.92 ns |     0.82 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 137B         |     287.5 ns |     1.23 ns |     1.15 ns |         - |
-| TryComputeHash · SHA3-224 · BouncyCastle        | 137B         |     334.9 ns |     1.71 ns |     1.51 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 137B         |     208.8 ns |     1.00 ns |     0.83 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 137B         |     278.8 ns |     0.82 ns |     0.77 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 137B         |     287.7 ns |     0.52 ns |     0.46 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle        | 137B         |     333.9 ns |     2.53 ns |     2.25 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 1KB          |   1,650.5 ns |    10.03 ns |     8.37 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 1KB          |   2,219.1 ns |    14.53 ns |    12.88 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 1KB          |   2,265.0 ns |     6.32 ns |     5.92 ns |         - |
-| TryComputeHash · SHA3-224 · BouncyCastle        | 1KB          |   2,475.0 ns |    14.30 ns |    12.67 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 1KB          |   1,594.7 ns |    17.07 ns |    14.25 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 1KB          |   2,161.8 ns |     7.45 ns |     6.97 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 1KB          |   2,227.0 ns |    22.21 ns |    17.34 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle        | 1KB          |   2,457.1 ns |     7.03 ns |     5.87 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 1025B        |   1,648.3 ns |     7.06 ns |     6.26 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 1025B        |   2,207.7 ns |     6.27 ns |     5.87 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 1025B        |   2,267.6 ns |     5.76 ns |     5.11 ns |         - |
-| TryComputeHash · SHA3-224 · BouncyCastle        | 1025B        |   2,472.5 ns |     9.00 ns |     7.52 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 1025B        |   1,591.9 ns |     5.94 ns |     4.96 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 1025B        |   2,160.1 ns |     5.45 ns |     4.55 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 1025B        |   2,223.8 ns |     6.95 ns |     6.50 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle        | 1025B        |   2,466.6 ns |    13.44 ns |    12.57 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 8KB          |  11,322.5 ns |    37.14 ns |    34.74 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 8KB          |  15,276.7 ns |    22.95 ns |    20.35 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 8KB          |  15,672.0 ns |    51.11 ns |    47.80 ns |         - |
-| TryComputeHash · SHA3-224 · BouncyCastle        | 8KB          |  17,525.2 ns |    64.65 ns |    53.99 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 8KB          |  11,287.9 ns |    48.42 ns |    42.92 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 8KB          |  15,355.3 ns |    41.49 ns |    34.65 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 8KB          |  15,736.7 ns |    47.10 ns |    41.75 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle        | 8KB          |  17,485.1 ns |   113.87 ns |   106.51 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 128KB        | 180,231.0 ns |   719.60 ns |   673.11 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 128KB        | 244,522.6 ns |   625.59 ns |   585.17 ns |         - |
-| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 128KB        | 250,013.8 ns |   488.82 ns |   433.33 ns |         - |
-| TryComputeHash · SHA3-224 · BouncyCastle        | 128KB        | 279,786.9 ns | 2,409.51 ns | 2,135.97 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-Scalar  | 128KB        | 180,536.4 ns | 1,189.28 ns | 1,112.46 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX2    | 128KB        | 245,357.1 ns |   713.93 ns |   632.88 ns |         - |
+| TryComputeHash · SHA3-224 · CryptoHives-AVX512F | 128KB        | 251,644.1 ns |   355.56 ns |   332.59 ns |         - |
+| TryComputeHash · SHA3-224 · BouncyCastle        | 128KB        | 278,583.9 ns | 1,059.15 ns |   884.44 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-256.md
@@ -1,37 +1,37 @@
-﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev    | Allocated |
-|------------------------------------------------ |------------- |-------------:|------------:|----------:|----------:|
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 128B         |     208.6 ns |     0.80 ns |   0.62 ns |         - |
-| TryComputeHash · SHA3-256 · OS Native           | 128B         |     274.9 ns |     1.71 ns |   1.52 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 128B         |     279.2 ns |     0.64 ns |   0.60 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 128B         |     288.1 ns |     0.55 ns |   0.46 ns |         - |
-| TryComputeHash · SHA3-256 · BouncyCastle        | 128B         |     332.2 ns |     1.57 ns |   1.39 ns |         - |
-|                                                 |              |              |             |           |           |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 137B         |     464.4 ns |     2.18 ns |   1.93 ns |         - |
-| TryComputeHash · SHA3-256 · OS Native           | 137B         |     506.1 ns |     2.37 ns |   2.22 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 137B         |     606.3 ns |     1.52 ns |   1.27 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 137B         |     625.8 ns |     2.06 ns |   1.82 ns |         - |
-| TryComputeHash · SHA3-256 · BouncyCastle        | 137B         |     632.6 ns |     2.01 ns |   1.78 ns |         - |
-|                                                 |              |              |             |           |           |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 1KB          |   1,620.3 ns |     9.21 ns |   8.17 ns |         - |
-| TryComputeHash · SHA3-256 · OS Native           | 1KB          |   1,926.2 ns |     7.27 ns |   6.45 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 1KB          |   2,188.1 ns |     7.60 ns |   7.11 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 1KB          |   2,245.3 ns |     6.65 ns |   6.22 ns |         - |
-| TryComputeHash · SHA3-256 · BouncyCastle        | 1KB          |   2,473.8 ns |     9.93 ns |   8.80 ns |         - |
-|                                                 |              |              |             |           |           |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 1025B        |   1,622.1 ns |     5.33 ns |   4.45 ns |         - |
-| TryComputeHash · SHA3-256 · OS Native           | 1025B        |   1,925.0 ns |     7.81 ns |   6.92 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 1025B        |   2,183.5 ns |     4.52 ns |   4.23 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 1025B        |   2,243.0 ns |     6.71 ns |   5.24 ns |         - |
-| TryComputeHash · SHA3-256 · BouncyCastle        | 1025B        |   2,472.5 ns |     6.97 ns |   5.82 ns |         - |
-|                                                 |              |              |             |           |           |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 8KB          |  12,138.5 ns |    55.81 ns |  43.57 ns |         - |
-| TryComputeHash · SHA3-256 · OS Native           | 8KB          |  14,424.3 ns |    55.51 ns |  46.36 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 8KB          |  16,403.8 ns |    36.19 ns |  33.86 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 8KB          |  16,806.2 ns |    22.75 ns |  20.17 ns |         - |
-| TryComputeHash · SHA3-256 · BouncyCastle        | 8KB          |  18,663.0 ns |    41.24 ns |  36.56 ns |         - |
-|                                                 |              |              |             |           |           |
-| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 128KB        | 190,388.2 ns |   929.83 ns | 824.27 ns |         - |
-| TryComputeHash · SHA3-256 · OS Native           | 128KB        | 228,226.4 ns | 1,039.45 ns | 921.44 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 128KB        | 258,495.3 ns |   969.93 ns | 757.26 ns |         - |
-| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 128KB        | 264,997.8 ns |   671.83 ns | 561.01 ns |         - |
-| TryComputeHash · SHA3-256 · BouncyCastle        | 128KB        | 293,926.5 ns |   594.74 ns | 527.22 ns |         - |
+﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 128B         |     209.3 ns |     0.82 ns |     0.77 ns |         - |
+| TryComputeHash · SHA3-256 · OS Native           | 128B         |     272.4 ns |     2.16 ns |     1.91 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 128B         |     283.1 ns |     0.75 ns |     0.70 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 128B         |     287.6 ns |     0.76 ns |     0.67 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle        | 128B         |     333.5 ns |     2.17 ns |     1.93 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 137B         |     404.0 ns |     2.40 ns |     2.25 ns |         - |
+| TryComputeHash · SHA3-256 · OS Native           | 137B         |     504.0 ns |     4.60 ns |     4.30 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 137B         |     547.2 ns |     1.65 ns |     1.38 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 137B         |     566.9 ns |     1.95 ns |     1.52 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle        | 137B         |     632.7 ns |     3.60 ns |     3.37 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 1KB          |   1,587.3 ns |     7.36 ns |     6.15 ns |         - |
+| TryComputeHash · SHA3-256 · OS Native           | 1KB          |   1,920.5 ns |    17.25 ns |    16.14 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 1KB          |   2,163.6 ns |     5.12 ns |     4.28 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 1KB          |   2,220.6 ns |     6.42 ns |     6.01 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle        | 1KB          |   2,461.8 ns |    14.41 ns |    13.48 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 1025B        |   1,586.1 ns |     7.93 ns |     7.03 ns |         - |
+| TryComputeHash · SHA3-256 · OS Native           | 1025B        |   1,932.1 ns |    14.34 ns |    13.41 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 1025B        |   2,163.0 ns |     5.92 ns |     5.53 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 1025B        |   2,228.8 ns |    10.72 ns |    10.03 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle        | 1025B        |   2,464.4 ns |    15.37 ns |    14.38 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 8KB          |  12,066.3 ns |    62.73 ns |    52.39 ns |         - |
+| TryComputeHash · SHA3-256 · OS Native           | 8KB          |  14,395.3 ns |    69.48 ns |    61.60 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 8KB          |  16,481.3 ns |    55.37 ns |    51.79 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 8KB          |  16,834.0 ns |    81.16 ns |    71.95 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle        | 8KB          |  18,518.3 ns |    47.59 ns |    39.74 ns |         - |
+|                                                 |              |              |             |             |           |
+| TryComputeHash · SHA3-256 · CryptoHives-Scalar  | 128KB        | 189,859.5 ns | 1,430.20 ns | 1,194.28 ns |         - |
+| TryComputeHash · SHA3-256 · OS Native           | 128KB        | 226,920.8 ns |   724.42 ns |   642.18 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX2    | 128KB        | 259,405.8 ns | 1,073.17 ns |   951.34 ns |         - |
+| TryComputeHash · SHA3-256 · CryptoHives-AVX512F | 128KB        | 265,529.6 ns |   977.32 ns |   866.37 ns |         - |
+| TryComputeHash · SHA3-256 · BouncyCastle        | 128KB        | 294,199.9 ns | 1,743.86 ns | 1,631.21 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-384.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-384.md
@@ -1,37 +1,37 @@
 ﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 128B         |     439.2 ns |     0.83 ns |     0.70 ns |         - |
-| TryComputeHash · SHA3-384 · OS Native           | 128B         |     507.8 ns |     2.49 ns |     2.21 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 128B         |     584.4 ns |     1.04 ns |     0.97 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 128B         |     603.4 ns |     1.54 ns |     1.44 ns |         - |
-| TryComputeHash · SHA3-384 · BouncyCastle        | 128B         |     630.3 ns |     2.19 ns |     1.83 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 128B         |     400.5 ns |     3.16 ns |     2.80 ns |         - |
+| TryComputeHash · SHA3-384 · OS Native           | 128B         |     505.7 ns |     3.17 ns |     2.64 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 128B         |     548.8 ns |     2.01 ns |     1.79 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 128B         |     570.3 ns |     2.93 ns |     2.74 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle        | 128B         |     627.3 ns |     2.18 ns |     1.93 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 137B         |     436.4 ns |     1.63 ns |     1.53 ns |         - |
-| TryComputeHash · SHA3-384 · OS Native           | 137B         |     506.5 ns |     2.92 ns |     2.59 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 137B         |     581.0 ns |     1.71 ns |     1.51 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 137B         |     599.8 ns |     1.80 ns |     1.41 ns |         - |
-| TryComputeHash · SHA3-384 · BouncyCastle        | 137B         |     627.9 ns |     1.46 ns |     1.29 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 137B         |     400.7 ns |     2.61 ns |     2.44 ns |         - |
+| TryComputeHash · SHA3-384 · OS Native           | 137B         |     507.9 ns |     3.87 ns |     3.43 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 137B         |     549.3 ns |     1.82 ns |     1.61 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 137B         |     573.4 ns |     2.58 ns |     2.41 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle        | 137B         |     627.9 ns |     2.87 ns |     2.55 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 1KB          |   1,988.8 ns |    13.28 ns |    11.09 ns |         - |
-| TryComputeHash · SHA3-384 · OS Native           | 1KB          |   2,373.1 ns |     8.86 ns |     7.40 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 1KB          |   2,686.4 ns |     4.36 ns |     4.08 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 1KB          |   2,764.2 ns |     6.16 ns |     5.76 ns |         - |
-| TryComputeHash · SHA3-384 · BouncyCastle        | 1KB          |   3,064.3 ns |    10.04 ns |     9.39 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 1KB          |   1,965.3 ns |    12.23 ns |    10.84 ns |         - |
+| TryComputeHash · SHA3-384 · OS Native           | 1KB          |   2,409.3 ns |    17.84 ns |    16.68 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 1KB          |   2,692.5 ns |     5.22 ns |     4.63 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 1KB          |   2,780.3 ns |     9.02 ns |     8.44 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle        | 1KB          |   3,060.8 ns |    13.67 ns |    12.12 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 1025B        |   1,981.0 ns |     6.91 ns |     6.12 ns |         - |
-| TryComputeHash · SHA3-384 · OS Native           | 1025B        |   2,379.7 ns |     9.10 ns |     7.60 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 1025B        |   2,698.3 ns |     5.35 ns |     5.01 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 1025B        |   2,768.2 ns |     5.07 ns |     4.74 ns |         - |
-| TryComputeHash · SHA3-384 · BouncyCastle        | 1025B        |   3,052.8 ns |     8.72 ns |     7.28 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 1025B        |   1,966.1 ns |    13.83 ns |    12.93 ns |         - |
+| TryComputeHash · SHA3-384 · OS Native           | 1025B        |   2,385.3 ns |    13.17 ns |    12.32 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 1025B        |   2,694.5 ns |     6.65 ns |     5.89 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 1025B        |   2,773.7 ns |     6.43 ns |     6.01 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle        | 1025B        |   3,057.5 ns |    17.05 ns |    15.95 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 8KB          |  15,565.0 ns |   213.03 ns |   188.85 ns |         - |
-| TryComputeHash · SHA3-384 · OS Native           | 8KB          |  18,558.3 ns |    58.72 ns |    52.06 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 8KB          |  21,046.2 ns |   107.18 ns |    83.68 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 8KB          |  21,649.9 ns |    52.53 ns |    49.14 ns |         - |
-| TryComputeHash · SHA3-384 · BouncyCastle        | 8KB          |  23,955.6 ns |    94.23 ns |    88.15 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 8KB          |  15,455.6 ns |    88.04 ns |    78.04 ns |         - |
+| TryComputeHash · SHA3-384 · OS Native           | 8KB          |  18,456.5 ns |   122.13 ns |   108.26 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 8KB          |  21,104.2 ns |    35.65 ns |    29.77 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 8KB          |  21,712.6 ns |    41.23 ns |    34.43 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle        | 8KB          |  23,890.2 ns |   135.65 ns |   113.27 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 128KB        | 246,973.4 ns | 1,762.01 ns | 1,561.98 ns |         - |
-| TryComputeHash · SHA3-384 · OS Native           | 128KB        | 294,269.0 ns | 1,853.16 ns | 1,642.78 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 128KB        | 335,786.4 ns | 1,002.47 ns |   888.66 ns |         - |
-| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 128KB        | 345,351.8 ns |   491.99 ns |   436.13 ns |         - |
-| TryComputeHash · SHA3-384 · BouncyCastle        | 128KB        | 380,802.1 ns | 1,875.97 ns | 1,663.00 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-Scalar  | 128KB        | 246,663.2 ns | 1,369.74 ns | 1,143.80 ns |         - |
+| TryComputeHash · SHA3-384 · OS Native           | 128KB        | 294,081.1 ns | 1,658.06 ns | 1,384.56 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX2    | 128KB        | 337,639.6 ns |   386.10 ns |   342.27 ns |         - |
+| TryComputeHash · SHA3-384 · CryptoHives-AVX512F | 128KB        | 347,626.4 ns |   786.53 ns |   697.24 ns |         - |
+| TryComputeHash · SHA3-384 · BouncyCastle        | 128KB        | 381,335.5 ns | 1,445.01 ns | 1,351.66 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha3-512.md
@@ -1,37 +1,37 @@
 ﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 128B         |     411.8 ns |     1.95 ns |     1.82 ns |         - |
-| TryComputeHash · SHA3-512 · OS Native           | 128B         |     507.4 ns |     2.30 ns |     2.04 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 128B         |     555.8 ns |     1.68 ns |     1.57 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 128B         |     575.3 ns |     1.41 ns |     1.17 ns |         - |
-| TryComputeHash · SHA3-512 · BouncyCastle        | 128B         |     626.6 ns |     1.44 ns |     1.12 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 128B         |     397.5 ns |     1.74 ns |     1.63 ns |         - |
+| TryComputeHash · SHA3-512 · OS Native           | 128B         |     503.4 ns |     4.23 ns |     3.75 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 128B         |     544.5 ns |     2.11 ns |     1.65 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 128B         |     561.4 ns |     0.83 ns |     0.74 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle        | 128B         |     628.4 ns |     3.32 ns |     3.10 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 137B         |     400.7 ns |     1.58 ns |     1.40 ns |         - |
-| TryComputeHash · SHA3-512 · OS Native           | 137B         |     506.9 ns |     2.28 ns |     2.13 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 137B         |     544.9 ns |     0.90 ns |     0.84 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 137B         |     556.1 ns |     1.15 ns |     1.02 ns |         - |
-| TryComputeHash · SHA3-512 · BouncyCastle        | 137B         |     626.6 ns |     2.62 ns |     2.05 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 137B         |     397.5 ns |     1.86 ns |     1.65 ns |         - |
+| TryComputeHash · SHA3-512 · OS Native           | 137B         |     503.7 ns |     3.34 ns |     2.78 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 137B         |     543.4 ns |     1.65 ns |     1.55 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 137B         |     563.0 ns |     1.97 ns |     1.84 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle        | 137B         |     630.4 ns |     3.72 ns |     2.90 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 1KB          |   2,966.6 ns |     6.54 ns |     5.80 ns |         - |
-| TryComputeHash · SHA3-512 · OS Native           | 1KB          |   3,525.5 ns |    11.98 ns |    10.62 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 1KB          |   4,015.5 ns |    10.27 ns |     9.60 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 1KB          |   4,129.1 ns |     9.57 ns |     8.48 ns |         - |
-| TryComputeHash · SHA3-512 · BouncyCastle        | 1KB          |   4,522.1 ns |    19.84 ns |    17.59 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 1KB          |   2,930.4 ns |    19.11 ns |    16.94 ns |         - |
+| TryComputeHash · SHA3-512 · OS Native           | 1KB          |   3,560.2 ns |    13.57 ns |    12.69 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 1KB          |   4,005.6 ns |     7.96 ns |     7.44 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 1KB          |   4,123.3 ns |    10.96 ns |    10.25 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle        | 1KB          |   4,525.2 ns |    30.00 ns |    28.06 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 1025B        |   2,947.8 ns |     9.97 ns |     8.32 ns |         - |
-| TryComputeHash · SHA3-512 · OS Native           | 1025B        |   3,523.8 ns |     9.49 ns |     8.88 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 1025B        |   4,010.0 ns |     8.46 ns |     7.50 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 1025B        |   4,126.6 ns |    14.01 ns |    11.70 ns |         - |
-| TryComputeHash · SHA3-512 · BouncyCastle        | 1025B        |   4,521.0 ns |     8.58 ns |     8.02 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 1025B        |   3,011.3 ns |    58.95 ns |    60.54 ns |         - |
+| TryComputeHash · SHA3-512 · OS Native           | 1025B        |   3,540.0 ns |    28.46 ns |    23.77 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 1025B        |   4,009.7 ns |     7.87 ns |     7.36 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 1025B        |   4,108.9 ns |    15.44 ns |    12.05 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle        | 1025B        |   4,625.2 ns |    15.59 ns |    13.82 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 8KB          |  22,208.4 ns |    80.10 ns |    74.92 ns |         - |
-| TryComputeHash · SHA3-512 · OS Native           | 8KB          |  26,453.3 ns |   131.49 ns |   122.99 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 8KB          |  30,257.8 ns |   153.87 ns |   136.40 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 8KB          |  31,144.5 ns |   104.95 ns |    98.17 ns |         - |
-| TryComputeHash · SHA3-512 · BouncyCastle        | 8KB          |  34,445.3 ns |    89.83 ns |    79.63 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 8KB          |  22,688.6 ns |   117.75 ns |   104.39 ns |         - |
+| TryComputeHash · SHA3-512 · OS Native           | 8KB          |  27,168.3 ns |   116.87 ns |   109.32 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 8KB          |  30,874.1 ns |   553.56 ns |   568.47 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 8KB          |  31,465.6 ns |   140.83 ns |   117.60 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle        | 8KB          |  34,955.9 ns |   101.28 ns |    84.57 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 128KB        | 354,950.5 ns |   738.50 ns |   616.68 ns |         - |
-| TryComputeHash · SHA3-512 · OS Native           | 128KB        | 421,937.8 ns | 1,500.20 ns | 1,403.29 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 128KB        | 481,645.6 ns |   531.24 ns |   470.93 ns |         - |
-| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 128KB        | 497,023.6 ns | 1,206.89 ns | 1,128.92 ns |         - |
-| TryComputeHash · SHA3-512 · BouncyCastle        | 128KB        | 554,246.0 ns | 1,254.79 ns | 1,112.34 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-Scalar  | 128KB        | 361,595.1 ns | 1,332.76 ns | 1,181.46 ns |         - |
+| TryComputeHash · SHA3-512 · OS Native           | 128KB        | 431,914.3 ns | 1,653.65 ns | 1,546.83 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX2    | 128KB        | 488,040.2 ns | 1,170.30 ns | 1,094.70 ns |         - |
+| TryComputeHash · SHA3-512 · CryptoHives-AVX512F | 128KB        | 503,092.2 ns | 5,960.81 ns | 4,977.54 ns |         - |
+| TryComputeHash · SHA3-512 · BouncyCastle        | 128KB        | 561,587.0 ns | 3,252.43 ns | 3,042.33 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha384.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha384.md
@@ -1,25 +1,25 @@
-﻿| Description                                   | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|---------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · SHA-384 · OS Native          | 128B         |     347.2 ns |   1.35 ns |   1.20 ns |         - |
-| TryComputeHash · SHA-384 · CryptoHives-Scalar | 128B         |     402.3 ns |   1.93 ns |   1.71 ns |         - |
-| TryComputeHash · SHA-384 · BouncyCastle       | 128B         |     479.5 ns |   1.35 ns |   1.19 ns |         - |
-|                                               |              |              |           |           |           |
-| TryComputeHash · SHA-384 · OS Native          | 137B         |     349.5 ns |   1.52 ns |   1.18 ns |         - |
-| TryComputeHash · SHA-384 · CryptoHives-Scalar | 137B         |     407.3 ns |   1.62 ns |   1.35 ns |         - |
-| TryComputeHash · SHA-384 · BouncyCastle       | 137B         |     481.8 ns |   3.25 ns |   2.88 ns |         - |
-|                                               |              |              |           |           |           |
-| TryComputeHash · SHA-384 · OS Native          | 1KB          |   1,385.5 ns |   6.42 ns |   5.69 ns |         - |
-| TryComputeHash · SHA-384 · CryptoHives-Scalar | 1KB          |   1,779.2 ns |   7.22 ns |   6.40 ns |         - |
-| TryComputeHash · SHA-384 · BouncyCastle       | 1KB          |   2,103.9 ns |  10.81 ns |   9.03 ns |         - |
-|                                               |              |              |           |           |           |
-| TryComputeHash · SHA-384 · OS Native          | 1025B        |   1,388.9 ns |   5.15 ns |   4.82 ns |         - |
-| TryComputeHash · SHA-384 · CryptoHives-Scalar | 1025B        |   1,778.6 ns |   5.49 ns |   4.87 ns |         - |
-| TryComputeHash · SHA-384 · BouncyCastle       | 1025B        |   2,106.0 ns |   6.95 ns |   5.80 ns |         - |
-|                                               |              |              |           |           |           |
-| TryComputeHash · SHA-384 · OS Native          | 8KB          |   9,696.0 ns |  26.27 ns |  24.58 ns |         - |
-| TryComputeHash · SHA-384 · CryptoHives-Scalar | 8KB          |  12,764.0 ns |  39.56 ns |  33.03 ns |         - |
-| TryComputeHash · SHA-384 · BouncyCastle       | 8KB          |  15,094.2 ns |  74.12 ns |  65.71 ns |         - |
-|                                               |              |              |           |           |           |
-| TryComputeHash · SHA-384 · OS Native          | 128KB        | 151,788.6 ns | 469.89 ns | 416.55 ns |         - |
-| TryComputeHash · SHA-384 · CryptoHives-Scalar | 128KB        | 200,994.9 ns | 766.06 ns | 716.57 ns |         - |
-| TryComputeHash · SHA-384 · BouncyCastle       | 128KB        | 237,966.9 ns | 676.31 ns | 564.75 ns |         - |
+﻿| Description                                   | TestDataSize | Mean         | Error       | StdDev    | Allocated |
+|---------------------------------------------- |------------- |-------------:|------------:|----------:|----------:|
+| TryComputeHash · SHA-384 · OS Native          | 128B         |     351.7 ns |     1.46 ns |   1.30 ns |         - |
+| TryComputeHash · SHA-384 · CryptoHives-Scalar | 128B         |     407.1 ns |     1.37 ns |   1.14 ns |         - |
+| TryComputeHash · SHA-384 · BouncyCastle       | 128B         |     482.6 ns |     1.75 ns |   1.64 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-384 · OS Native          | 137B         |     353.9 ns |     1.93 ns |   1.81 ns |         - |
+| TryComputeHash · SHA-384 · CryptoHives-Scalar | 137B         |     409.6 ns |     1.47 ns |   1.30 ns |         - |
+| TryComputeHash · SHA-384 · BouncyCastle       | 137B         |     498.3 ns |     1.78 ns |   1.66 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-384 · OS Native          | 1KB          |   1,405.2 ns |     4.39 ns |   4.10 ns |         - |
+| TryComputeHash · SHA-384 · CryptoHives-Scalar | 1KB          |   1,803.4 ns |     6.75 ns |   6.32 ns |         - |
+| TryComputeHash · SHA-384 · BouncyCastle       | 1KB          |   2,145.2 ns |     9.49 ns |   8.41 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-384 · OS Native          | 1025B        |   1,408.8 ns |     5.44 ns |   4.82 ns |         - |
+| TryComputeHash · SHA-384 · CryptoHives-Scalar | 1025B        |   1,810.8 ns |     8.21 ns |   7.68 ns |         - |
+| TryComputeHash · SHA-384 · BouncyCastle       | 1025B        |   2,135.0 ns |     7.15 ns |   6.69 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-384 · OS Native          | 8KB          |   9,818.9 ns |    48.02 ns |  44.91 ns |         - |
+| TryComputeHash · SHA-384 · CryptoHives-Scalar | 8KB          |  13,073.9 ns |    65.11 ns |  57.72 ns |         - |
+| TryComputeHash · SHA-384 · BouncyCastle       | 8KB          |  15,307.5 ns |    29.15 ns |  27.27 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-384 · OS Native          | 128KB        | 155,011.7 ns |   743.30 ns | 695.28 ns |         - |
+| TryComputeHash · SHA-384 · CryptoHives-Scalar | 128KB        | 205,995.8 ns | 1,173.90 ns | 980.26 ns |         - |
+| TryComputeHash · SHA-384 · BouncyCastle       | 128KB        | 241,125.3 ns |   506.21 ns | 473.51 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha512-224.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha512-224.md
@@ -1,19 +1,19 @@
 ﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 128B         |     401.1 ns |     1.40 ns |     1.24 ns |         - |
-| TryComputeHash · SHA-512/224 · BouncyCastle       | 128B         |     488.2 ns |     2.18 ns |     1.82 ns |         - |
+| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 128B         |     407.1 ns |     2.05 ns |     1.81 ns |         - |
+| TryComputeHash · SHA-512/224 · BouncyCastle       | 128B         |     494.3 ns |     1.58 ns |     1.40 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 137B         |     402.5 ns |     1.58 ns |     1.40 ns |         - |
-| TryComputeHash · SHA-512/224 · BouncyCastle       | 137B         |     494.0 ns |     2.28 ns |     2.14 ns |         - |
+| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 137B         |     408.2 ns |     1.03 ns |     0.97 ns |         - |
+| TryComputeHash · SHA-512/224 · BouncyCastle       | 137B         |     499.7 ns |     0.61 ns |     0.51 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 1KB          |   1,779.7 ns |     7.66 ns |     6.79 ns |         - |
-| TryComputeHash · SHA-512/224 · BouncyCastle       | 1KB          |   2,118.4 ns |     9.91 ns |     8.27 ns |         - |
+| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 1KB          |   1,797.6 ns |     7.15 ns |     5.97 ns |         - |
+| TryComputeHash · SHA-512/224 · BouncyCastle       | 1KB          |   2,153.7 ns |     9.63 ns |     8.53 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 1025B        |   1,779.4 ns |     7.35 ns |     6.88 ns |         - |
-| TryComputeHash · SHA-512/224 · BouncyCastle       | 1025B        |   2,114.2 ns |     5.97 ns |     4.99 ns |         - |
+| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 1025B        |   1,828.9 ns |     7.60 ns |     7.11 ns |         - |
+| TryComputeHash · SHA-512/224 · BouncyCastle       | 1025B        |   2,159.0 ns |     9.67 ns |     7.55 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 8KB          |  12,700.5 ns |    18.89 ns |    14.75 ns |         - |
-| TryComputeHash · SHA-512/224 · BouncyCastle       | 8KB          |  15,158.1 ns |   143.06 ns |   126.82 ns |         - |
+| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 8KB          |  13,032.0 ns |   121.89 ns |   114.02 ns |         - |
+| TryComputeHash · SHA-512/224 · BouncyCastle       | 8KB          |  15,476.4 ns |    25.61 ns |    21.39 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 128KB        | 200,519.7 ns |   552.03 ns |   460.97 ns |         - |
-| TryComputeHash · SHA-512/224 · BouncyCastle       | 128KB        | 237,955.8 ns | 1,468.61 ns | 1,226.35 ns |         - |
+| TryComputeHash · SHA-512/224 · CryptoHives-Scalar | 128KB        | 203,571.7 ns | 1,062.15 ns |   886.95 ns |         - |
+| TryComputeHash · SHA-512/224 · BouncyCastle       | 128KB        | 243,230.4 ns | 1,406.86 ns | 1,315.97 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha512-256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha512-256.md
@@ -1,19 +1,19 @@
 ﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 128B         |     403.6 ns |     1.12 ns |     0.94 ns |         - |
-| TryComputeHash · SHA-512/256 · BouncyCastle       | 128B         |     492.8 ns |     1.65 ns |     1.46 ns |         - |
+| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 128B         |     416.1 ns |     5.31 ns |     4.97 ns |         - |
+| TryComputeHash · SHA-512/256 · BouncyCastle       | 128B         |     505.2 ns |     3.90 ns |     3.65 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 137B         |     403.5 ns |     1.89 ns |     1.77 ns |         - |
-| TryComputeHash · SHA-512/256 · BouncyCastle       | 137B         |     496.4 ns |     1.96 ns |     1.83 ns |         - |
+| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 137B         |     410.6 ns |     2.59 ns |     2.16 ns |         - |
+| TryComputeHash · SHA-512/256 · BouncyCastle       | 137B         |     505.2 ns |     2.58 ns |     2.42 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 1KB          |   1,775.1 ns |     3.78 ns |     3.54 ns |         - |
-| TryComputeHash · SHA-512/256 · BouncyCastle       | 1KB          |   2,123.0 ns |     7.49 ns |     6.64 ns |         - |
+| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 1KB          |   1,802.2 ns |     7.63 ns |     6.37 ns |         - |
+| TryComputeHash · SHA-512/256 · BouncyCastle       | 1KB          |   2,162.0 ns |    12.29 ns |    10.89 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 1025B        |   1,780.3 ns |    10.57 ns |     8.83 ns |         - |
-| TryComputeHash · SHA-512/256 · BouncyCastle       | 1025B        |   2,127.2 ns |    12.88 ns |    11.42 ns |         - |
+| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 1025B        |   1,796.8 ns |     8.02 ns |     7.50 ns |         - |
+| TryComputeHash · SHA-512/256 · BouncyCastle       | 1025B        |   2,129.5 ns |     9.90 ns |     9.26 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 8KB          |  12,874.8 ns |    51.41 ns |    45.57 ns |         - |
-| TryComputeHash · SHA-512/256 · BouncyCastle       | 8KB          |  15,136.2 ns |    53.83 ns |    47.72 ns |         - |
+| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 8KB          |  12,883.5 ns |    32.01 ns |    26.73 ns |         - |
+| TryComputeHash · SHA-512/256 · BouncyCastle       | 8KB          |  15,154.4 ns |    75.78 ns |    70.88 ns |         - |
 |                                                   |              |              |             |             |           |
-| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 128KB        | 200,539.1 ns |   555.20 ns |   463.62 ns |         - |
-| TryComputeHash · SHA-512/256 · BouncyCastle       | 128KB        | 238,810.6 ns | 2,871.01 ns | 2,397.42 ns |         - |
+| TryComputeHash · SHA-512/256 · CryptoHives-Scalar | 128KB        | 200,709.1 ns |   612.81 ns |   511.72 ns |         - |
+| TryComputeHash · SHA-512/256 · BouncyCastle       | 128KB        | 238,460.7 ns | 1,132.03 ns | 1,058.90 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sha512.md
@@ -1,25 +1,25 @@
-﻿| Description                                   | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|---------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHA-512 · OS Native          | 128B         |     343.1 ns |     1.98 ns |     1.85 ns |         - |
-| TryComputeHash · SHA-512 · CryptoHives-Scalar | 128B         |     403.8 ns |     1.93 ns |     1.80 ns |         - |
-| TryComputeHash · SHA-512 · BouncyCastle       | 128B         |     477.0 ns |     1.40 ns |     1.24 ns |         - |
-|                                               |              |              |             |             |           |
-| TryComputeHash · SHA-512 · OS Native          | 137B         |     342.6 ns |     1.78 ns |     1.67 ns |         - |
-| TryComputeHash · SHA-512 · CryptoHives-Scalar | 137B         |     404.8 ns |     1.47 ns |     1.38 ns |         - |
-| TryComputeHash · SHA-512 · BouncyCastle       | 137B         |     481.2 ns |     2.36 ns |     2.09 ns |         - |
-|                                               |              |              |             |             |           |
-| TryComputeHash · SHA-512 · OS Native          | 1KB          |   1,381.1 ns |     5.07 ns |     4.23 ns |         - |
-| TryComputeHash · SHA-512 · CryptoHives-Scalar | 1KB          |   1,777.7 ns |     6.12 ns |     5.11 ns |         - |
-| TryComputeHash · SHA-512 · BouncyCastle       | 1KB          |   2,105.2 ns |     7.22 ns |     6.40 ns |         - |
-|                                               |              |              |             |             |           |
-| TryComputeHash · SHA-512 · OS Native          | 1025B        |   1,386.4 ns |     5.57 ns |     4.35 ns |         - |
-| TryComputeHash · SHA-512 · CryptoHives-Scalar | 1025B        |   1,780.9 ns |     4.12 ns |     3.65 ns |         - |
-| TryComputeHash · SHA-512 · BouncyCastle       | 1025B        |   2,112.2 ns |     8.99 ns |     8.41 ns |         - |
-|                                               |              |              |             |             |           |
-| TryComputeHash · SHA-512 · OS Native          | 8KB          |   9,681.0 ns |    49.78 ns |    46.56 ns |         - |
-| TryComputeHash · SHA-512 · CryptoHives-Scalar | 8KB          |  12,750.1 ns |    44.94 ns |    42.03 ns |         - |
-| TryComputeHash · SHA-512 · BouncyCastle       | 8KB          |  15,131.4 ns |    80.20 ns |    71.09 ns |         - |
-|                                               |              |              |             |             |           |
-| TryComputeHash · SHA-512 · OS Native          | 128KB        | 152,166.2 ns |   941.87 ns |   834.94 ns |         - |
-| TryComputeHash · SHA-512 · CryptoHives-Scalar | 128KB        | 200,787.0 ns |   565.66 ns |   501.45 ns |         - |
-| TryComputeHash · SHA-512 · BouncyCastle       | 128KB        | 238,790.3 ns | 1,201.67 ns | 1,065.25 ns |         - |
+﻿| Description                                   | TestDataSize | Mean         | Error       | StdDev    | Allocated |
+|---------------------------------------------- |------------- |-------------:|------------:|----------:|----------:|
+| TryComputeHash · SHA-512 · OS Native          | 128B         |     344.4 ns |     1.39 ns |   1.23 ns |         - |
+| TryComputeHash · SHA-512 · CryptoHives-Scalar | 128B         |     408.0 ns |     1.62 ns |   1.51 ns |         - |
+| TryComputeHash · SHA-512 · BouncyCastle       | 128B         |     480.8 ns |     2.76 ns |   2.59 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-512 · OS Native          | 137B         |     344.8 ns |     1.55 ns |   1.45 ns |         - |
+| TryComputeHash · SHA-512 · CryptoHives-Scalar | 137B         |     404.4 ns |     1.68 ns |   1.49 ns |         - |
+| TryComputeHash · SHA-512 · BouncyCastle       | 137B         |     485.3 ns |     2.92 ns |   2.73 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-512 · OS Native          | 1KB          |   1,390.5 ns |     6.22 ns |   5.82 ns |         - |
+| TryComputeHash · SHA-512 · CryptoHives-Scalar | 1KB          |   1,780.3 ns |     7.24 ns |   6.77 ns |         - |
+| TryComputeHash · SHA-512 · BouncyCastle       | 1KB          |   2,110.8 ns |    14.47 ns |  13.53 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-512 · OS Native          | 1025B        |   1,384.1 ns |     5.23 ns |   4.37 ns |         - |
+| TryComputeHash · SHA-512 · CryptoHives-Scalar | 1025B        |   1,805.4 ns |     5.82 ns |   4.86 ns |         - |
+| TryComputeHash · SHA-512 · BouncyCastle       | 1025B        |   2,112.5 ns |    14.46 ns |  13.53 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-512 · OS Native          | 8KB          |   9,692.0 ns |    38.64 ns |  34.26 ns |         - |
+| TryComputeHash · SHA-512 · CryptoHives-Scalar | 8KB          |  12,937.2 ns |    31.58 ns |  26.37 ns |         - |
+| TryComputeHash · SHA-512 · BouncyCastle       | 8KB          |  15,138.5 ns |    67.20 ns |  62.86 ns |         - |
+|                                               |              |              |             |           |           |
+| TryComputeHash · SHA-512 · OS Native          | 128KB        | 152,027.2 ns |   433.78 ns | 384.53 ns |         - |
+| TryComputeHash · SHA-512 · CryptoHives-Scalar | 128KB        | 200,378.1 ns |   636.77 ns | 564.48 ns |         - |
+| TryComputeHash · SHA-512 · BouncyCastle       | 128KB        | 237,933.7 ns | 1,063.56 ns | 994.85 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/shake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/shake128.md
@@ -1,37 +1,37 @@
 ﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 128B         |     244.3 ns |     1.43 ns |     1.34 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 128B         |     313.1 ns |     0.83 ns |     0.78 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 128B         |     321.7 ns |     0.80 ns |     0.71 ns |         - |
-| TryComputeHash · SHAKE128 · BouncyCastle        | 128B         |     333.4 ns |     1.08 ns |     0.90 ns |         - |
-| TryComputeHash · SHAKE128 · OS Native           | 128B         |     357.8 ns |     1.36 ns |     1.14 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 128B         |     211.5 ns |     0.77 ns |     0.68 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 128B         |     284.3 ns |     0.87 ns |     0.77 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 128B         |     295.4 ns |     1.09 ns |     0.96 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle        | 128B         |     334.7 ns |     2.04 ns |     1.90 ns |         - |
+| TryComputeHash · SHAKE128 · OS Native           | 128B         |     372.0 ns |     2.15 ns |     1.90 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 137B         |     240.9 ns |     1.30 ns |     1.15 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 137B         |     311.8 ns |     0.95 ns |     0.84 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 137B         |     318.6 ns |     1.25 ns |     1.17 ns |         - |
-| TryComputeHash · SHAKE128 · BouncyCastle        | 137B         |     335.1 ns |     2.11 ns |     1.87 ns |         - |
-| TryComputeHash · SHAKE128 · OS Native           | 137B         |     358.1 ns |     1.59 ns |     1.49 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 137B         |     212.5 ns |     0.83 ns |     0.74 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 137B         |     283.9 ns |     0.78 ns |     0.73 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 137B         |     294.8 ns |     0.60 ns |     0.57 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle        | 137B         |     334.9 ns |     1.67 ns |     1.39 ns |         - |
+| TryComputeHash · SHAKE128 · OS Native           | 137B         |     358.3 ns |     1.48 ns |     1.31 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 1KB          |   1,491.5 ns |     8.63 ns |     8.07 ns |         - |
-| TryComputeHash · SHAKE128 · OS Native           | 1KB          |   1,782.0 ns |     3.48 ns |     2.72 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 1KB          |   1,983.3 ns |     4.91 ns |     4.35 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 1KB          |   2,031.8 ns |     7.21 ns |     6.75 ns |         - |
-| TryComputeHash · SHAKE128 · BouncyCastle        | 1KB          |   2,173.6 ns |     7.79 ns |     6.08 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 1KB          |   1,409.0 ns |     8.41 ns |     7.46 ns |         - |
+| TryComputeHash · SHAKE128 · OS Native           | 1KB          |   1,784.6 ns |    10.11 ns |     8.44 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 1KB          |   1,911.5 ns |     4.55 ns |     4.26 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 1KB          |   1,959.1 ns |     5.34 ns |     5.00 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle        | 1KB          |   2,174.9 ns |    13.93 ns |    13.03 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 1025B        |   1,486.2 ns |     5.87 ns |     5.49 ns |         - |
-| TryComputeHash · SHAKE128 · OS Native           | 1025B        |   1,789.8 ns |     9.10 ns |     8.07 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 1025B        |   1,985.1 ns |    10.65 ns |     9.96 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 1025B        |   2,031.5 ns |     7.15 ns |     6.69 ns |         - |
-| TryComputeHash · SHAKE128 · BouncyCastle        | 1025B        |   2,178.6 ns |     6.74 ns |     5.97 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 1025B        |   1,412.8 ns |    12.84 ns |    11.38 ns |         - |
+| TryComputeHash · SHAKE128 · OS Native           | 1025B        |   1,778.9 ns |     9.43 ns |     8.36 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 1025B        |   1,911.1 ns |     7.77 ns |     6.88 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 1025B        |   1,959.2 ns |     7.52 ns |     7.04 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle        | 1025B        |   2,181.5 ns |    10.44 ns |     8.72 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 8KB          |   9,813.7 ns |    46.52 ns |    43.51 ns |         - |
-| TryComputeHash · SHAKE128 · OS Native           | 8KB          |  11,775.1 ns |    66.56 ns |    59.01 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 8KB          |  13,225.3 ns |    25.39 ns |    22.51 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 8KB          |  13,614.0 ns |    17.24 ns |    13.46 ns |         - |
-| TryComputeHash · SHAKE128 · BouncyCastle        | 8KB          |  15,107.7 ns |    54.40 ns |    45.42 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 8KB          |   9,781.8 ns |    74.87 ns |    62.52 ns |         - |
+| TryComputeHash · SHAKE128 · OS Native           | 8KB          |  11,786.7 ns |    60.14 ns |    50.22 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 8KB          |  13,256.4 ns |    34.45 ns |    30.54 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 8KB          |  13,580.8 ns |    24.95 ns |    23.34 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle        | 8KB          |  15,162.3 ns |    60.70 ns |    56.78 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 128KB        | 155,994.3 ns |   751.81 ns |   703.24 ns |         - |
-| TryComputeHash · SHAKE128 · OS Native           | 128KB        | 186,054.0 ns | 1,249.99 ns | 1,169.24 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 128KB        | 209,970.5 ns |   358.27 ns |   335.12 ns |         - |
-| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 128KB        | 214,489.9 ns |   235.51 ns |   196.66 ns |         - |
-| TryComputeHash · SHAKE128 · BouncyCastle        | 128KB        | 240,833.7 ns |   599.23 ns |   500.39 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-Scalar  | 128KB        | 155,749.8 ns |   653.10 ns |   578.96 ns |         - |
+| TryComputeHash · SHAKE128 · OS Native           | 128KB        | 186,698.5 ns | 1,246.04 ns | 1,165.55 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX2    | 128KB        | 211,225.6 ns |   346.73 ns |   289.53 ns |         - |
+| TryComputeHash · SHAKE128 · CryptoHives-AVX512F | 128KB        | 216,516.2 ns |   330.58 ns |   276.05 ns |         - |
+| TryComputeHash · SHAKE128 · BouncyCastle        | 128KB        | 240,626.1 ns | 1,277.01 ns | 1,066.36 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/shake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/shake256.md
@@ -1,37 +1,37 @@
 ﻿| Description                                     | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 128B         |     250.8 ns |     1.30 ns |     1.21 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 128B         |     322.6 ns |     1.06 ns |     0.94 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 128B         |     329.3 ns |     0.84 ns |     0.65 ns |         - |
-| TryComputeHash · SHAKE256 · BouncyCastle        | 128B         |     331.9 ns |     0.71 ns |     0.63 ns |         - |
-| TryComputeHash · SHAKE256 · OS Native           | 128B         |     355.6 ns |     1.48 ns |     1.31 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 128B         |     210.4 ns |     1.00 ns |     0.89 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 128B         |     283.1 ns |     1.19 ns |     1.05 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 128B         |     291.8 ns |     1.23 ns |     1.09 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle        | 128B         |     334.8 ns |     1.40 ns |     1.24 ns |         - |
+| TryComputeHash · SHAKE256 · OS Native           | 128B         |     358.7 ns |     1.65 ns |     1.54 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 137B         |     505.8 ns |     3.29 ns |     3.08 ns |         - |
-| TryComputeHash · SHAKE256 · OS Native           | 137B         |     589.7 ns |     2.95 ns |     2.76 ns |         - |
-| TryComputeHash · SHAKE256 · BouncyCastle        | 137B         |     631.5 ns |     2.13 ns |     1.89 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 137B         |     649.0 ns |     1.96 ns |     1.73 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 137B         |     666.2 ns |     2.16 ns |     1.92 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 137B         |     414.0 ns |     1.82 ns |     1.61 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 137B         |     552.0 ns |     1.66 ns |     1.39 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 137B         |     574.9 ns |     1.67 ns |     1.48 ns |         - |
+| TryComputeHash · SHAKE256 · OS Native           | 137B         |     593.8 ns |     2.00 ns |     1.77 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle        | 137B         |     630.5 ns |     3.93 ns |     3.49 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 1KB          |   1,662.4 ns |     8.24 ns |     7.71 ns |         - |
-| TryComputeHash · SHAKE256 · OS Native           | 1KB          |   2,015.4 ns |    13.69 ns |    12.13 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 1KB          |   2,225.8 ns |     4.11 ns |     3.84 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 1KB          |   2,285.7 ns |     5.37 ns |     5.03 ns |         - |
-| TryComputeHash · SHAKE256 · BouncyCastle        | 1KB          |   2,469.9 ns |    10.41 ns |     9.74 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 1KB          |   1,594.5 ns |     8.95 ns |     7.48 ns |         - |
+| TryComputeHash · SHAKE256 · OS Native           | 1KB          |   2,016.4 ns |    18.46 ns |    17.27 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 1KB          |   2,162.6 ns |     5.45 ns |     4.83 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 1KB          |   2,226.9 ns |     7.13 ns |     6.67 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle        | 1KB          |   2,470.8 ns |    13.88 ns |    12.99 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 1025B        |   1,657.8 ns |     5.78 ns |     4.83 ns |         - |
-| TryComputeHash · SHAKE256 · OS Native           | 1025B        |   2,018.5 ns |    28.19 ns |    24.99 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 1025B        |   2,225.6 ns |     6.81 ns |     6.04 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 1025B        |   2,283.6 ns |     5.12 ns |     4.54 ns |         - |
-| TryComputeHash · SHAKE256 · BouncyCastle        | 1025B        |   2,468.2 ns |     8.75 ns |     7.76 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 1025B        |   1,594.0 ns |     3.29 ns |     2.57 ns |         - |
+| TryComputeHash · SHAKE256 · OS Native           | 1025B        |   2,011.9 ns |    16.41 ns |    14.54 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 1025B        |   2,166.6 ns |     7.58 ns |     7.09 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 1025B        |   2,234.1 ns |     7.33 ns |     6.86 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle        | 1025B        |   2,477.7 ns |    17.32 ns |    16.20 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 8KB          |  12,134.8 ns |    51.88 ns |    48.53 ns |         - |
-| TryComputeHash · SHAKE256 · OS Native           | 8KB          |  14,468.6 ns |    29.52 ns |    24.65 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 8KB          |  16,456.5 ns |    97.00 ns |    85.99 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 8KB          |  16,829.1 ns |    36.37 ns |    32.24 ns |         - |
-| TryComputeHash · SHAKE256 · BouncyCastle        | 8KB          |  18,620.0 ns |   115.57 ns |   102.45 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 8KB          |  12,088.1 ns |    63.53 ns |    53.05 ns |         - |
+| TryComputeHash · SHAKE256 · OS Native           | 8KB          |  14,568.9 ns |   125.42 ns |   104.73 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 8KB          |  16,425.4 ns |    46.99 ns |    36.69 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 8KB          |  16,857.3 ns |    62.00 ns |    58.00 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle        | 8KB          |  18,701.8 ns |   124.88 ns |   116.81 ns |         - |
 |                                                 |              |              |             |             |           |
-| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 128KB        | 190,275.0 ns |   764.58 ns |   715.18 ns |         - |
-| TryComputeHash · SHAKE256 · OS Native           | 128KB        | 227,408.5 ns | 1,409.07 ns | 1,176.64 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 128KB        | 258,405.2 ns |   916.83 ns |   715.80 ns |         - |
-| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 128KB        | 264,475.1 ns |   774.73 ns |   724.68 ns |         - |
-| TryComputeHash · SHAKE256 · BouncyCastle        | 128KB        | 294,377.0 ns | 1,238.14 ns | 1,158.16 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-Scalar  | 128KB        | 190,905.8 ns | 1,249.47 ns | 1,168.75 ns |         - |
+| TryComputeHash · SHAKE256 · OS Native           | 128KB        | 228,440.6 ns | 1,289.09 ns | 1,205.82 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX2    | 128KB        | 259,720.4 ns | 1,149.17 ns | 1,074.94 ns |         - |
+| TryComputeHash · SHAKE256 · CryptoHives-AVX512F | 128KB        | 266,703.3 ns |   703.89 ns |   658.42 ns |         - |
+| TryComputeHash · SHAKE256 · BouncyCastle        | 128KB        | 294,674.4 ns | 1,641.42 ns | 1,535.38 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sm3.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sm3.md
@@ -1,19 +1,19 @@
 ﻿| Description                               | TestDataSize | Mean         | Error       | StdDev      | Allocated |
 |------------------------------------------ |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · SM3 · CryptoHives-Scalar | 128B         |     690.8 ns |     2.63 ns |     2.46 ns |         - |
-| TryComputeHash · SM3 · BouncyCastle       | 128B         |     789.6 ns |     3.31 ns |     3.09 ns |         - |
+| TryComputeHash · SM3 · CryptoHives-Scalar | 128B         |     691.8 ns |     1.63 ns |     1.52 ns |         - |
+| TryComputeHash · SM3 · BouncyCastle       | 128B         |     780.5 ns |     4.64 ns |     4.34 ns |         - |
 |                                           |              |              |             |             |           |
-| TryComputeHash · SM3 · CryptoHives-Scalar | 137B         |     698.7 ns |     3.89 ns |     3.45 ns |         - |
-| TryComputeHash · SM3 · BouncyCastle       | 137B         |     789.0 ns |     1.20 ns |     1.00 ns |         - |
+| TryComputeHash · SM3 · CryptoHives-Scalar | 137B         |     695.5 ns |     2.23 ns |     2.09 ns |         - |
+| TryComputeHash · SM3 · BouncyCastle       | 137B         |     781.5 ns |     3.03 ns |     2.83 ns |         - |
 |                                           |              |              |             |             |           |
-| TryComputeHash · SM3 · CryptoHives-Scalar | 1KB          |   3,861.6 ns |     8.64 ns |     8.08 ns |         - |
-| TryComputeHash · SM3 · BouncyCastle       | 1KB          |   4,409.1 ns |    15.87 ns |    14.07 ns |         - |
+| TryComputeHash · SM3 · CryptoHives-Scalar | 1KB          |   3,870.8 ns |    13.02 ns |    11.54 ns |         - |
+| TryComputeHash · SM3 · BouncyCastle       | 1KB          |   4,358.4 ns |    11.60 ns |    10.85 ns |         - |
 |                                           |              |              |             |             |           |
-| TryComputeHash · SM3 · CryptoHives-Scalar | 1025B        |   3,855.9 ns |    16.79 ns |    14.88 ns |         - |
-| TryComputeHash · SM3 · BouncyCastle       | 1025B        |   4,414.5 ns |    20.47 ns |    18.15 ns |         - |
+| TryComputeHash · SM3 · CryptoHives-Scalar | 1025B        |   3,876.9 ns |    18.02 ns |    15.04 ns |         - |
+| TryComputeHash · SM3 · BouncyCastle       | 1025B        |   4,366.9 ns |    16.04 ns |    13.40 ns |         - |
 |                                           |              |              |             |             |           |
-| TryComputeHash · SM3 · CryptoHives-Scalar | 8KB          |  29,266.0 ns |    95.57 ns |    74.61 ns |         - |
-| TryComputeHash · SM3 · BouncyCastle       | 8KB          |  32,888.8 ns |    90.25 ns |    80.00 ns |         - |
+| TryComputeHash · SM3 · CryptoHives-Scalar | 8KB          |  29,200.2 ns |   166.39 ns |   155.64 ns |         - |
+| TryComputeHash · SM3 · BouncyCastle       | 8KB          |  33,422.9 ns |   120.08 ns |   106.45 ns |         - |
 |                                           |              |              |             |             |           |
-| TryComputeHash · SM3 · CryptoHives-Scalar | 128KB        | 465,270.1 ns |   676.16 ns |   564.62 ns |         - |
-| TryComputeHash · SM3 · BouncyCastle       | 128KB        | 521,319.2 ns | 1,230.84 ns | 1,091.11 ns |         - |
+| TryComputeHash · SM3 · CryptoHives-Scalar | 128KB        | 462,994.6 ns | 1,390.99 ns | 1,233.08 ns |         - |
+| TryComputeHash · SM3 · BouncyCastle       | 128KB        | 532,056.9 ns | 2,589.70 ns | 2,295.70 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sm4-cbc.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/sm4-cbc.md
@@ -1,25 +1,25 @@
-﻿| Description                            | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|--------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| Decrypt · SM4-CBC (CryptoHives-Scalar) | 128B         |     1.059 μs | 0.0023 μs | 0.0022 μs |         - |
-| Decrypt · SM4-CBC (BouncyCastle)       | 128B         |     1.288 μs | 0.0015 μs | 0.0013 μs |      40 B |
-|                                        |              |              |           |           |           |
-| Encrypt · SM4-CBC (CryptoHives-Scalar) | 128B         |     1.089 μs | 0.0016 μs | 0.0015 μs |         - |
-| Encrypt · SM4-CBC (BouncyCastle)       | 128B         |     1.304 μs | 0.0016 μs | 0.0015 μs |      40 B |
-|                                        |              |              |           |           |           |
-| Decrypt · SM4-CBC (CryptoHives-Scalar) | 1KB          |     7.552 μs | 0.0092 μs | 0.0081 μs |         - |
-| Decrypt · SM4-CBC (BouncyCastle)       | 1KB          |     8.139 μs | 0.0091 μs | 0.0085 μs |      40 B |
-|                                        |              |              |           |           |           |
-| Encrypt · SM4-CBC (CryptoHives-Scalar) | 1KB          |     7.815 μs | 0.0095 μs | 0.0084 μs |         - |
-| Encrypt · SM4-CBC (BouncyCastle)       | 1KB          |     8.289 μs | 0.0165 μs | 0.0154 μs |      40 B |
-|                                        |              |              |           |           |           |
-| Decrypt · SM4-CBC (CryptoHives-Scalar) | 8KB          |    59.732 μs | 0.0968 μs | 0.0906 μs |         - |
-| Decrypt · SM4-CBC (BouncyCastle)       | 8KB          |    62.854 μs | 0.0865 μs | 0.0809 μs |      40 B |
-|                                        |              |              |           |           |           |
-| Encrypt · SM4-CBC (CryptoHives-Scalar) | 8KB          |    61.540 μs | 0.0574 μs | 0.0537 μs |         - |
-| Encrypt · SM4-CBC (BouncyCastle)       | 8KB          |    64.092 μs | 0.1438 μs | 0.1345 μs |      40 B |
-|                                        |              |              |           |           |           |
-| Decrypt · SM4-CBC (CryptoHives-Scalar) | 128KB        |   950.801 μs | 1.1701 μs | 1.0372 μs |         - |
-| Decrypt · SM4-CBC (BouncyCastle)       | 128KB        | 1,000.849 μs | 1.3062 μs | 1.2218 μs |      40 B |
-|                                        |              |              |           |           |           |
-| Encrypt · SM4-CBC (CryptoHives-Scalar) | 128KB        |   981.308 μs | 1.5298 μs | 1.3562 μs |         - |
-| Encrypt · SM4-CBC (BouncyCastle)       | 128KB        | 1,020.790 μs | 1.3841 μs | 1.2270 μs |      40 B |
+﻿| Description                            | TestDataSize | Mean           | Error       | StdDev      | Allocated |
+|--------------------------------------- |------------- |---------------:|------------:|------------:|----------:|
+| Decrypt · SM4-CBC (CryptoHives-Scalar) | 128B         |       792.2 ns |     2.61 ns |     2.45 ns |         - |
+| Decrypt · SM4-CBC (BouncyCastle)       | 128B         |     1,292.3 ns |     3.98 ns |     3.53 ns |      40 B |
+|                                        |              |                |             |             |           |
+| Encrypt · SM4-CBC (CryptoHives-Scalar) | 128B         |       862.4 ns |     1.36 ns |     1.20 ns |         - |
+| Encrypt · SM4-CBC (BouncyCastle)       | 128B         |     1,309.3 ns |     3.76 ns |     3.52 ns |      40 B |
+|                                        |              |                |             |             |           |
+| Decrypt · SM4-CBC (CryptoHives-Scalar) | 1KB          |     5,604.7 ns |    11.61 ns |    10.86 ns |         - |
+| Decrypt · SM4-CBC (BouncyCastle)       | 1KB          |     8,139.6 ns |    12.51 ns |    11.09 ns |      40 B |
+|                                        |              |                |             |             |           |
+| Encrypt · SM4-CBC (CryptoHives-Scalar) | 1KB          |     6,187.6 ns |    10.73 ns |     9.51 ns |         - |
+| Encrypt · SM4-CBC (BouncyCastle)       | 1KB          |     8,289.3 ns |    12.37 ns |    10.33 ns |      40 B |
+|                                        |              |                |             |             |           |
+| Decrypt · SM4-CBC (CryptoHives-Scalar) | 8KB          |    44,187.6 ns |   142.25 ns |   126.10 ns |         - |
+| Decrypt · SM4-CBC (BouncyCastle)       | 8KB          |    63,006.5 ns |   175.02 ns |   163.72 ns |      40 B |
+|                                        |              |                |             |             |           |
+| Encrypt · SM4-CBC (CryptoHives-Scalar) | 8KB          |    49,049.6 ns |   104.41 ns |    97.66 ns |         - |
+| Encrypt · SM4-CBC (BouncyCastle)       | 8KB          |    64,173.3 ns |   190.27 ns |   177.98 ns |      40 B |
+|                                        |              |                |             |             |           |
+| Decrypt · SM4-CBC (CryptoHives-Scalar) | 128KB        |   705,026.4 ns | 2,455.70 ns | 2,297.06 ns |         - |
+| Decrypt · SM4-CBC (BouncyCastle)       | 128KB        | 1,000,424.7 ns | 2,507.68 ns | 2,094.03 ns |      40 B |
+|                                        |              |                |             |             |           |
+| Encrypt · SM4-CBC (CryptoHives-Scalar) | 128KB        |   777,629.4 ns | 1,589.16 ns | 1,486.50 ns |         - |
+| Encrypt · SM4-CBC (BouncyCastle)       | 128KB        | 1,024,598.9 ns | 2,702.42 ns | 2,527.85 ns |      40 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/streebog256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/streebog256.md
@@ -1,25 +1,25 @@
 ﻿| Description                                        | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |--------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 128B         |     2.387 μs | 0.0057 μs | 0.0050 μs |         - |
-| TryComputeHash · Streebog-256 · OpenGost           | 128B         |     3.455 μs | 0.0207 μs | 0.0172 μs |     408 B |
-| TryComputeHash · Streebog-256 · BouncyCastle       | 128B         |     4.276 μs | 0.0219 μs | 0.0205 μs |         - |
+| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 128B         |     2.377 μs | 0.0042 μs | 0.0037 μs |         - |
+| TryComputeHash · Streebog-256 · OpenGost           | 128B         |     3.467 μs | 0.0319 μs | 0.0283 μs |     408 B |
+| TryComputeHash · Streebog-256 · BouncyCastle       | 128B         |     4.329 μs | 0.0325 μs | 0.0288 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 137B         |     2.415 μs | 0.0041 μs | 0.0034 μs |         - |
-| TryComputeHash · Streebog-256 · OpenGost           | 137B         |     3.453 μs | 0.0151 μs | 0.0141 μs |     408 B |
-| TryComputeHash · Streebog-256 · BouncyCastle       | 137B         |     4.316 μs | 0.0796 μs | 0.0706 μs |         - |
+| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 137B         |     2.410 μs | 0.0062 μs | 0.0055 μs |         - |
+| TryComputeHash · Streebog-256 · OpenGost           | 137B         |     3.474 μs | 0.0428 μs | 0.0400 μs |     408 B |
+| TryComputeHash · Streebog-256 · BouncyCastle       | 137B         |     4.289 μs | 0.0175 μs | 0.0164 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 1KB          |     9.191 μs | 0.0225 μs | 0.0210 μs |         - |
-| TryComputeHash · Streebog-256 · OpenGost           | 1KB          |    12.788 μs | 0.0508 μs | 0.0475 μs |     408 B |
-| TryComputeHash · Streebog-256 · BouncyCastle       | 1KB          |    16.401 μs | 0.0298 μs | 0.0265 μs |         - |
+| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 1KB          |     9.155 μs | 0.0312 μs | 0.0292 μs |         - |
+| TryComputeHash · Streebog-256 · OpenGost           | 1KB          |    12.800 μs | 0.0952 μs | 0.0890 μs |     408 B |
+| TryComputeHash · Streebog-256 · BouncyCastle       | 1KB          |    16.386 μs | 0.0905 μs | 0.0847 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 1025B        |     9.151 μs | 0.0242 μs | 0.0214 μs |         - |
-| TryComputeHash · Streebog-256 · OpenGost           | 1025B        |    12.816 μs | 0.0760 μs | 0.0674 μs |     408 B |
-| TryComputeHash · Streebog-256 · BouncyCastle       | 1025B        |    16.257 μs | 0.1049 μs | 0.0930 μs |         - |
+| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 1025B        |     9.154 μs | 0.0201 μs | 0.0167 μs |         - |
+| TryComputeHash · Streebog-256 · OpenGost           | 1025B        |    12.823 μs | 0.0670 μs | 0.0594 μs |     408 B |
+| TryComputeHash · Streebog-256 · BouncyCastle       | 1025B        |    16.240 μs | 0.0796 μs | 0.0706 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 8KB          |    63.177 μs | 0.0906 μs | 0.0803 μs |         - |
-| TryComputeHash · Streebog-256 · OpenGost           | 8KB          |    87.512 μs | 0.5581 μs | 0.5221 μs |     408 B |
-| TryComputeHash · Streebog-256 · BouncyCastle       | 8KB          |   112.292 μs | 0.7803 μs | 0.6092 μs |         - |
+| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 8KB          |    62.222 μs | 0.2465 μs | 0.2058 μs |         - |
+| TryComputeHash · Streebog-256 · OpenGost           | 8KB          |    87.600 μs | 0.6162 μs | 0.5764 μs |     408 B |
+| TryComputeHash · Streebog-256 · BouncyCastle       | 8KB          |   114.729 μs | 0.6431 μs | 0.5701 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 128KB        |   992.181 μs | 2.6164 μs | 2.3193 μs |         - |
-| TryComputeHash · Streebog-256 · OpenGost           | 128KB        | 1,364.872 μs | 3.3761 μs | 2.8192 μs |     408 B |
-| TryComputeHash · Streebog-256 · BouncyCastle       | 128KB        | 1,754.045 μs | 7.3392 μs | 6.8651 μs |         - |
+| TryComputeHash · Streebog-256 · CryptoHives-Scalar | 128KB        |   997.488 μs | 3.9279 μs | 3.4820 μs |         - |
+| TryComputeHash · Streebog-256 · OpenGost           | 128KB        | 1,371.904 μs | 6.9799 μs | 5.8285 μs |     408 B |
+| TryComputeHash · Streebog-256 · BouncyCastle       | 128KB        | 1,754.677 μs | 9.3372 μs | 8.2771 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/streebog512.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/streebog512.md
@@ -1,25 +1,25 @@
 ﻿| Description                                        | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |--------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 128B         |     2.466 μs | 0.0056 μs | 0.0050 μs |         - |
-| TryComputeHash · Streebog-512 · OpenGost           | 128B         |     3.362 μs | 0.0197 μs | 0.0175 μs |     176 B |
-| TryComputeHash · Streebog-512 · BouncyCastle       | 128B         |     4.258 μs | 0.0115 μs | 0.0102 μs |         - |
+| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 128B         |     2.390 μs | 0.0035 μs | 0.0029 μs |         - |
+| TryComputeHash · Streebog-512 · OpenGost           | 128B         |     3.376 μs | 0.0190 μs | 0.0158 μs |     176 B |
+| TryComputeHash · Streebog-512 · BouncyCastle       | 128B         |     4.256 μs | 0.0256 μs | 0.0227 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 137B         |     2.420 μs | 0.0055 μs | 0.0048 μs |         - |
-| TryComputeHash · Streebog-512 · OpenGost           | 137B         |     3.375 μs | 0.0112 μs | 0.0099 μs |     176 B |
-| TryComputeHash · Streebog-512 · BouncyCastle       | 137B         |     4.250 μs | 0.0240 μs | 0.0212 μs |         - |
+| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 137B         |     2.421 μs | 0.0103 μs | 0.0091 μs |         - |
+| TryComputeHash · Streebog-512 · OpenGost           | 137B         |     3.375 μs | 0.0242 μs | 0.0214 μs |     176 B |
+| TryComputeHash · Streebog-512 · BouncyCastle       | 137B         |     4.289 μs | 0.0171 μs | 0.0143 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 1KB          |     9.159 μs | 0.0214 μs | 0.0167 μs |         - |
-| TryComputeHash · Streebog-512 · OpenGost           | 1KB          |    12.683 μs | 0.0842 μs | 0.0788 μs |     176 B |
-| TryComputeHash · Streebog-512 · BouncyCastle       | 1KB          |    16.248 μs | 0.0586 μs | 0.0520 μs |         - |
+| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 1KB          |     9.164 μs | 0.0256 μs | 0.0227 μs |         - |
+| TryComputeHash · Streebog-512 · OpenGost           | 1KB          |    12.747 μs | 0.0955 μs | 0.0798 μs |     176 B |
+| TryComputeHash · Streebog-512 · BouncyCastle       | 1KB          |    16.172 μs | 0.0685 μs | 0.0572 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 1025B        |     8.915 μs | 0.0264 μs | 0.0234 μs |         - |
-| TryComputeHash · Streebog-512 · OpenGost           | 1025B        |    12.711 μs | 0.0733 μs | 0.0612 μs |     176 B |
-| TryComputeHash · Streebog-512 · BouncyCastle       | 1025B        |    16.725 μs | 0.0491 μs | 0.0383 μs |         - |
+| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 1025B        |     9.142 μs | 0.0206 μs | 0.0182 μs |         - |
+| TryComputeHash · Streebog-512 · OpenGost           | 1025B        |    12.743 μs | 0.0854 μs | 0.0799 μs |     176 B |
+| TryComputeHash · Streebog-512 · BouncyCastle       | 1025B        |    16.312 μs | 0.1198 μs | 0.1121 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 8KB          |    62.599 μs | 0.1031 μs | 0.0914 μs |         - |
-| TryComputeHash · Streebog-512 · OpenGost           | 8KB          |    87.086 μs | 0.3249 μs | 0.2881 μs |     176 B |
-| TryComputeHash · Streebog-512 · BouncyCastle       | 8KB          |   112.003 μs | 0.3082 μs | 0.2574 μs |         - |
+| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 8KB          |    62.810 μs | 0.1245 μs | 0.1040 μs |         - |
+| TryComputeHash · Streebog-512 · OpenGost           | 8KB          |    87.574 μs | 0.6647 μs | 0.6217 μs |     176 B |
+| TryComputeHash · Streebog-512 · BouncyCastle       | 8KB          |   111.897 μs | 0.4154 μs | 0.3682 μs |         - |
 |                                                    |              |              |           |           |           |
-| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 128KB        |   989.583 μs | 3.2331 μs | 3.0242 μs |         - |
-| TryComputeHash · Streebog-512 · OpenGost           | 128KB        | 1,371.227 μs | 6.6644 μs | 6.2339 μs |     176 B |
-| TryComputeHash · Streebog-512 · BouncyCastle       | 128KB        | 1,752.479 μs | 7.1976 μs | 6.3805 μs |         - |
+| TryComputeHash · Streebog-512 · CryptoHives-Scalar | 128KB        |   988.685 μs | 4.5749 μs | 3.5718 μs |         - |
+| TryComputeHash · Streebog-512 · OpenGost           | 128KB        | 1,374.754 μs | 7.6146 μs | 7.1227 μs |     176 B |
+| TryComputeHash · Streebog-512 · BouncyCastle       | 128KB        | 1,759.552 μs | 8.0487 μs | 7.5287 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/turboshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/turboshake128.md
@@ -1,49 +1,49 @@
 ﻿| Description                                             | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |-------------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 128B         |     151.7 ns |   0.94 ns |   0.83 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 128B         |     176.8 ns |   0.61 ns |   0.54 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 128B         |     182.4 ns |   0.78 ns |   0.69 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 128B         |     119.1 ns |   0.72 ns |   0.63 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 128B         |     154.8 ns |   0.44 ns |   0.39 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 128B         |     163.1 ns |   0.45 ns |   0.37 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 137B         |     149.9 ns |   0.95 ns |   0.89 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 137B         |     173.0 ns |   0.27 ns |   0.22 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 137B         |     178.7 ns |   0.81 ns |   0.68 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 137B         |     119.4 ns |   0.89 ns |   0.83 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 137B         |     154.4 ns |   0.69 ns |   0.61 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 137B         |     163.2 ns |   0.46 ns |   0.41 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 1KB          |     845.6 ns |   3.66 ns |   3.05 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 1KB          |   1,080.8 ns |   2.94 ns |   2.75 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 1KB          |   1,109.9 ns |   2.67 ns |   2.36 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 1KB          |     762.8 ns |   5.62 ns |   4.98 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 1KB          |   1,000.7 ns |   4.06 ns |   3.60 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 1KB          |   1,038.3 ns |   3.47 ns |   2.90 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 1025B        |     845.4 ns |   3.18 ns |   2.48 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 1025B        |   1,081.5 ns |   2.38 ns |   2.11 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 1025B        |   1,114.2 ns |  12.40 ns |   9.68 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 1025B        |     763.5 ns |   3.03 ns |   2.83 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 1025B        |   1,002.0 ns |   5.25 ns |   4.38 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 1025B        |   1,033.4 ns |   2.88 ns |   2.55 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 8KB          |   5,347.6 ns |  24.86 ns |  19.41 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 8KB          |   6,913.9 ns |  15.77 ns |  13.98 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 8KB          |   7,095.9 ns |   8.43 ns |   7.47 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 8KB          |   5,289.0 ns |  29.19 ns |  27.30 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 8KB          |   6,923.6 ns |   8.63 ns |   7.65 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 8KB          |   7,105.6 ns |  15.76 ns |  13.97 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 128KB        |  84,307.3 ns | 603.65 ns | 564.65 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 128KB        | 109,448.8 ns | 202.59 ns | 179.59 ns |         - |
-| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 128KB        | 112,349.2 ns | 239.13 ns | 199.68 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-Scalar  | 128KB        |  84,106.8 ns | 750.98 ns | 627.10 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX2    | 128KB        | 110,095.9 ns | 203.00 ns | 189.88 ns |         - |
+| TryComputeHash · TurboSHAKE128-32 · CryptoHives-AVX512F | 128KB        | 112,980.3 ns | 293.98 ns | 274.99 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 128B         |     173.6 ns |   1.18 ns |   0.99 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 128B         |     196.2 ns |   0.35 ns |   0.29 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 128B         |     201.4 ns |   0.63 ns |   0.59 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 128B         |     119.9 ns |   0.84 ns |   0.70 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 128B         |     155.3 ns |   0.27 ns |   0.25 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 128B         |     164.3 ns |   0.47 ns |   0.44 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 137B         |     170.9 ns |   1.29 ns |   1.21 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 137B         |     193.4 ns |   0.82 ns |   0.73 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 137B         |     198.3 ns |   0.71 ns |   0.67 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 137B         |     120.6 ns |   0.93 ns |   0.87 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 137B         |     155.9 ns |   0.65 ns |   0.54 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 137B         |     162.8 ns |   0.51 ns |   0.43 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 1KB          |     875.4 ns |   8.60 ns |   7.62 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 1KB          |   1,111.0 ns |  16.54 ns |  14.66 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 1KB          |   1,134.6 ns |   4.07 ns |   3.61 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 1KB          |     764.3 ns |   3.38 ns |   3.16 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 1KB          |   1,016.8 ns |   2.50 ns |   2.34 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 1KB          |   1,034.5 ns |   2.38 ns |   2.23 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 1025B        |     872.2 ns |   5.83 ns |   5.17 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 1025B        |   1,110.3 ns |  13.94 ns |  11.64 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 1025B        |   1,144.5 ns |  12.68 ns |  11.86 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 1025B        |     768.2 ns |   8.98 ns |   7.50 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 1025B        |   1,000.6 ns |   1.28 ns |   1.07 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 1025B        |   1,034.6 ns |   2.25 ns |   2.11 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 8KB          |   5,425.2 ns |  97.28 ns |  91.00 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 8KB          |   6,942.0 ns |  24.53 ns |  22.94 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 8KB          |   7,144.5 ns |  17.04 ns |  15.10 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 8KB          |   5,291.0 ns |  27.63 ns |  24.50 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 8KB          |   6,940.7 ns |  18.42 ns |  15.38 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 8KB          |   7,114.8 ns |  12.38 ns |  11.58 ns |         - |
 |                                                         |              |              |           |           |           |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 128KB        |  84,421.0 ns | 563.16 ns | 470.26 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 128KB        | 109,878.2 ns | 486.09 ns | 405.91 ns |         - |
-| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 128KB        | 112,573.5 ns | 491.35 ns | 410.30 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-Scalar  | 128KB        |  84,065.2 ns | 286.24 ns | 267.75 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX2    | 128KB        | 110,253.2 ns | 224.19 ns | 198.74 ns |         - |
+| TryComputeHash · TurboSHAKE128-64 · CryptoHives-AVX512F | 128KB        | 113,255.5 ns | 167.26 ns | 148.27 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/turboshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/turboshake256.md
@@ -1,25 +1,25 @@
-﻿| Description                                          | TestDataSize | Mean         | Error       | StdDev      | Allocated |
-|----------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 128B         |     164.5 ns |     3.26 ns |     3.05 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 128B         |     188.3 ns |     3.61 ns |     3.20 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 128B         |     189.0 ns |     0.55 ns |     0.46 ns |         - |
-|                                                      |              |              |             |             |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 137B         |     324.2 ns |     5.38 ns |     4.77 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 137B         |     380.7 ns |     6.25 ns |     6.69 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 137B         |     393.6 ns |     6.88 ns |     6.09 ns |         - |
-|                                                      |              |              |             |             |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 1KB          |     934.8 ns |     4.04 ns |     3.58 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 1KB          |   1,197.9 ns |     7.65 ns |     6.78 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 1KB          |   1,241.1 ns |     6.74 ns |     5.97 ns |         - |
-|                                                      |              |              |             |             |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 1025B        |     946.0 ns |    15.45 ns |    14.45 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 1025B        |   1,199.4 ns |    10.63 ns |     9.42 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 1025B        |   1,238.3 ns |     4.32 ns |     3.61 ns |         - |
-|                                                      |              |              |             |             |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 8KB          |   6,609.3 ns |    61.99 ns |    51.77 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 8KB          |   8,584.7 ns |   118.81 ns |    99.21 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 8KB          |   8,981.9 ns |   145.58 ns |   129.05 ns |         - |
-|                                                      |              |              |             |             |           |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 128KB        | 103,795.5 ns | 1,827.37 ns | 1,709.33 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 128KB        | 133,820.7 ns |   407.37 ns |   361.13 ns |         - |
-| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 128KB        | 139,277.3 ns | 1,547.14 ns | 1,371.50 ns |         - |
+﻿| Description                                          | TestDataSize | Mean         | Error     | StdDev    | Allocated |
+|----------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 128B         |     118.2 ns |   0.39 ns |   0.34 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 128B         |     152.5 ns |   0.33 ns |   0.31 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 128B         |     160.4 ns |   0.49 ns |   0.41 ns |         - |
+|                                                      |              |              |           |           |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 137B         |     224.6 ns |   1.05 ns |   0.98 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 137B         |     292.4 ns |   0.70 ns |   0.65 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 137B         |     310.8 ns |   0.77 ns |   0.65 ns |         - |
+|                                                      |              |              |           |           |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 1KB          |     861.5 ns |   3.24 ns |   3.03 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 1KB          |   1,126.8 ns |   1.84 ns |   1.53 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 1KB          |   1,173.7 ns |   3.68 ns |   3.44 ns |         - |
+|                                                      |              |              |           |           |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 1025B        |     860.2 ns |   2.05 ns |   1.82 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 1025B        |   1,128.6 ns |   2.92 ns |   2.44 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 1025B        |   1,176.5 ns |   3.41 ns |   3.02 ns |         - |
+|                                                      |              |              |           |           |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 8KB          |   6,501.0 ns |  31.46 ns |  29.43 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 8KB          |   8,505.7 ns |  24.96 ns |  23.34 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 8KB          |   8,812.6 ns |  16.56 ns |  14.68 ns |         - |
+|                                                      |              |              |           |           |           |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-Scalar  | 128KB        | 102,407.1 ns | 362.07 ns | 302.35 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX2    | 128KB        | 134,221.3 ns | 386.34 ns | 342.48 ns |         - |
+| TryComputeHash · TurboSHAKE256 · CryptoHives-AVX512F | 128KB        | 139,002.7 ns | 356.00 ns | 315.59 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/whirlpool.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/whirlpool.md
@@ -1,25 +1,25 @@
-﻿| Description                                     | TestDataSize | Mean         | Error      | StdDev      | Allocated |
-|------------------------------------------------ |------------- |-------------:|-----------:|------------:|----------:|
-| TryComputeHash · Whirlpool · CryptoHives-Scalar | 128B         |     1.363 μs |  0.0051 μs |   0.0045 μs |         - |
-| TryComputeHash · Whirlpool · Hashify .NET       | 128B         |     2.073 μs |  0.0400 μs |   0.0428 μs |    6336 B |
-| TryComputeHash · Whirlpool · BouncyCastle       | 128B         |     5.083 μs |  0.0369 μs |   0.0345 μs |      56 B |
-|                                                 |              |              |            |             |           |
-| TryComputeHash · Whirlpool · CryptoHives-Scalar | 137B         |     1.351 μs |  0.0070 μs |   0.0062 μs |         - |
-| TryComputeHash · Whirlpool · Hashify .NET       | 137B         |     2.036 μs |  0.0272 μs |   0.0213 μs |    6328 B |
-| TryComputeHash · Whirlpool · BouncyCastle       | 137B         |     5.072 μs |  0.0323 μs |   0.0286 μs |      56 B |
-|                                                 |              |              |            |             |           |
-| TryComputeHash · Whirlpool · CryptoHives-Scalar | 1KB          |     7.711 μs |  0.1541 μs |   0.1441 μs |         - |
-| TryComputeHash · Whirlpool · Hashify .NET       | 1KB          |    10.358 μs |  0.1190 μs |   0.0993 μs |   12032 B |
-| TryComputeHash · Whirlpool · BouncyCastle       | 1KB          |    31.534 μs |  0.2556 μs |   0.1996 μs |      56 B |
-|                                                 |              |              |            |             |           |
-| TryComputeHash · Whirlpool · CryptoHives-Scalar | 1025B        |     7.546 μs |  0.0538 μs |   0.0477 μs |         - |
-| TryComputeHash · Whirlpool · Hashify .NET       | 1025B        |    10.442 μs |  0.1020 μs |   0.0954 μs |   12040 B |
-| TryComputeHash · Whirlpool · BouncyCastle       | 1025B        |    31.855 μs |  0.6147 μs |   0.5449 μs |      56 B |
-|                                                 |              |              |            |             |           |
-| TryComputeHash · Whirlpool · CryptoHives-Scalar | 8KB          |    57.666 μs |  0.3466 μs |   0.2894 μs |         - |
-| TryComputeHash · Whirlpool · Hashify .NET       | 8KB          |    76.735 μs |  0.6326 μs |   0.5917 μs |   58624 B |
-| TryComputeHash · Whirlpool · BouncyCastle       | 8KB          |   240.761 μs |  2.8153 μs |   2.3509 μs |      56 B |
-|                                                 |              |              |            |             |           |
-| TryComputeHash · Whirlpool · CryptoHives-Scalar | 128KB        |   925.019 μs | 11.5015 μs |   9.6043 μs |         - |
-| TryComputeHash · Whirlpool · Hashify .NET       | 128KB        | 1,281.524 μs | 24.5294 μs |  27.2644 μs |  857372 B |
-| TryComputeHash · Whirlpool · BouncyCastle       | 128KB        | 3,901.330 μs | 71.6113 μs | 104.9670 μs |      56 B |
+﻿| Description                                     | TestDataSize | Mean         | Error      | StdDev     | Allocated |
+|------------------------------------------------ |------------- |-------------:|-----------:|-----------:|----------:|
+| TryComputeHash · Whirlpool · CryptoHives-Scalar | 128B         |     1.379 μs |  0.0061 μs |  0.0051 μs |         - |
+| TryComputeHash · Whirlpool · Hashify .NET       | 128B         |     2.033 μs |  0.0197 μs |  0.0174 μs |    6336 B |
+| TryComputeHash · Whirlpool · BouncyCastle       | 128B         |     5.086 μs |  0.0412 μs |  0.0344 μs |      56 B |
+|                                                 |              |              |            |            |           |
+| TryComputeHash · Whirlpool · CryptoHives-Scalar | 137B         |     1.348 μs |  0.0053 μs |  0.0044 μs |         - |
+| TryComputeHash · Whirlpool · Hashify .NET       | 137B         |     2.026 μs |  0.0182 μs |  0.0161 μs |    6328 B |
+| TryComputeHash · Whirlpool · BouncyCastle       | 137B         |     5.090 μs |  0.0509 μs |  0.0476 μs |      56 B |
+|                                                 |              |              |            |            |           |
+| TryComputeHash · Whirlpool · CryptoHives-Scalar | 1KB          |     7.629 μs |  0.0608 μs |  0.0569 μs |         - |
+| TryComputeHash · Whirlpool · Hashify .NET       | 1KB          |    10.342 μs |  0.1014 μs |  0.0949 μs |   12032 B |
+| TryComputeHash · Whirlpool · BouncyCastle       | 1KB          |    31.173 μs |  0.1905 μs |  0.1782 μs |      56 B |
+|                                                 |              |              |            |            |           |
+| TryComputeHash · Whirlpool · CryptoHives-Scalar | 1025B        |     7.522 μs |  0.0406 μs |  0.0380 μs |         - |
+| TryComputeHash · Whirlpool · Hashify .NET       | 1025B        |    10.320 μs |  0.0812 μs |  0.0760 μs |   12040 B |
+| TryComputeHash · Whirlpool · BouncyCastle       | 1025B        |    31.374 μs |  0.2503 μs |  0.2341 μs |      56 B |
+|                                                 |              |              |            |            |           |
+| TryComputeHash · Whirlpool · CryptoHives-Scalar | 8KB          |    56.757 μs |  0.2586 μs |  0.2292 μs |         - |
+| TryComputeHash · Whirlpool · Hashify .NET       | 8KB          |    76.504 μs |  0.6803 μs |  0.6030 μs |   58624 B |
+| TryComputeHash · Whirlpool · BouncyCastle       | 8KB          |   240.925 μs |  1.8231 μs |  1.7053 μs |      56 B |
+|                                                 |              |              |            |            |           |
+| TryComputeHash · Whirlpool · CryptoHives-Scalar | 128KB        |   909.667 μs |  2.7528 μs |  2.4403 μs |         - |
+| TryComputeHash · Whirlpool · Hashify .NET       | 128KB        | 1,265.003 μs |  9.5233 μs |  8.4421 μs |  857372 B |
+| TryComputeHash · Whirlpool · BouncyCastle       | 128KB        | 3,807.944 μs | 20.7161 μs | 19.3779 μs |      56 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xchacha20-poly1305.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xchacha20-poly1305.md
@@ -1,41 +1,41 @@
-﻿| Description                                       | TestDataSize | Mean         | Error     | StdDev    | Allocated |
-|-------------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     553.1 ns |   0.90 ns |   0.84 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     601.3 ns |   0.68 ns |   0.53 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128B         |     909.7 ns |   1.84 ns |   1.72 ns |      48 B |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |   1,088.9 ns |   2.09 ns |   1.96 ns |         - |
-|                                                   |              |              |           |           |           |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     496.9 ns |   1.08 ns |   1.01 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     571.8 ns |   0.93 ns |   0.87 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128B         |     868.8 ns |   0.85 ns |   0.75 ns |      48 B |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |   1,049.0 ns |   1.69 ns |   1.50 ns |         - |
-|                                                   |              |              |           |           |           |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,468.4 ns |   2.00 ns |   1.77 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,928.4 ns |   2.85 ns |   2.66 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   4,044.4 ns |   5.64 ns |   5.28 ns |      72 B |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,673.9 ns |   9.18 ns |   8.14 ns |         - |
-|                                                   |              |              |           |           |           |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,424.9 ns |   1.89 ns |   1.77 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,888.4 ns |   1.97 ns |   1.84 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   4,015.7 ns |  11.00 ns |  10.29 ns |      72 B |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,632.1 ns |   6.85 ns |   5.72 ns |         - |
-|                                                   |              |              |           |           |           |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,871.9 ns |  10.92 ns |  10.22 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,533.7 ns |  15.80 ns |  14.78 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  28,924.8 ns |  48.89 ns |  45.73 ns |      72 B |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  33,398.1 ns |  89.04 ns |  78.93 ns |         - |
-|                                                   |              |              |           |           |           |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,812.9 ns |  16.73 ns |  15.65 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,487.5 ns |  18.97 ns |  17.74 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  28,991.2 ns |  52.43 ns |  49.04 ns |      72 B |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  33,341.5 ns |  72.12 ns |  67.46 ns |         - |
-|                                                   |              |              |           |           |           |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 135,633.8 ns | 263.95 ns | 246.90 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 194,129.7 ns | 114.30 ns | 101.32 ns |         - |
-| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 460,198.9 ns | 747.37 ns | 699.09 ns |      72 B |
-| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 525,478.9 ns | 933.12 ns | 872.84 ns |         - |
-|                                                   |              |              |           |           |           |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 135,635.0 ns | 263.60 ns | 246.57 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 194,255.7 ns | 179.69 ns | 168.09 ns |         - |
-| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 457,220.5 ns | 872.94 ns | 816.55 ns |      72 B |
-| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 525,335.5 ns | 904.41 ns | 845.98 ns |         - |
+﻿| Description                                       | TestDataSize | Mean         | Error       | StdDev      | Allocated |
+|-------------------------------------------------- |------------- |-------------:|------------:|------------:|----------:|
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     551.9 ns |     1.92 ns |     1.79 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     618.3 ns |     1.46 ns |     1.22 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128B         |     909.9 ns |     2.38 ns |     2.11 ns |      48 B |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |   1,092.6 ns |     3.97 ns |     3.72 ns |         - |
+|                                                   |              |              |             |             |           |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128B         |     489.9 ns |     1.69 ns |     1.50 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128B         |     564.9 ns |     1.63 ns |     1.53 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128B         |     870.5 ns |     2.57 ns |     2.40 ns |      48 B |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128B         |   1,065.2 ns |    12.29 ns |    11.50 ns |         - |
+|                                                   |              |              |             |             |           |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,471.9 ns |     3.54 ns |     3.31 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,944.4 ns |     4.55 ns |     4.25 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   4,052.2 ns |    15.09 ns |    14.12 ns |      72 B |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,689.3 ns |     9.95 ns |     8.82 ns |         - |
+|                                                   |              |              |             |             |           |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 1KB          |   1,449.3 ns |     3.69 ns |     3.27 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 1KB          |   1,890.9 ns |     2.76 ns |     2.58 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 1KB          |   4,011.0 ns |    15.61 ns |    14.61 ns |      72 B |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 1KB          |   4,641.2 ns |    17.11 ns |    16.00 ns |         - |
+|                                                   |              |              |             |             |           |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,902.7 ns |    27.83 ns |    24.67 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,549.1 ns |    24.66 ns |    21.86 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  29,255.7 ns |    84.43 ns |    78.97 ns |      72 B |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  33,486.7 ns |   112.23 ns |   104.98 ns |         - |
+|                                                   |              |              |             |             |           |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 8KB          |   8,827.2 ns |    17.23 ns |    16.12 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 8KB          |  12,497.0 ns |    15.73 ns |    14.71 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 8KB          |  29,102.1 ns |   107.45 ns |    95.25 ns |      72 B |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 8KB          |  33,491.0 ns |   181.38 ns |   160.79 ns |         - |
+|                                                   |              |              |             |             |           |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 135,896.0 ns |   296.21 ns |   277.07 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 194,242.9 ns |   379.20 ns |   354.70 ns |         - |
+| Decrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 459,540.5 ns | 1,289.56 ns | 1,143.17 ns |      72 B |
+| Decrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 528,010.4 ns | 1,441.38 ns | 1,348.27 ns |         - |
+|                                                   |              |              |             |             |           |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-AVX2)   | 128KB        | 135,850.3 ns |   314.75 ns |   279.02 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-SSSE3)  | 128KB        | 194,470.6 ns |   417.31 ns |   369.94 ns |         - |
+| Encrypt · XChaCha20-Poly1305 (NaCl.Core)          | 128KB        | 462,093.2 ns | 1,652.95 ns | 1,546.17 ns |      72 B |
+| Encrypt · XChaCha20-Poly1305 (CryptoHives-Scalar) | 128KB        | 525,017.3 ns | 1,013.39 ns |   846.22 ns |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-asconxof128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-asconxof128.md
@@ -1,13 +1,13 @@
 ﻿| Description                                       | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |-------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 128B         |   7.617 μs | 0.0555 μs | 0.0463 μs |         - |
-| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 128B         |  10.120 μs | 0.0544 μs | 0.0482 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 128B         |   7.569 μs | 0.0377 μs | 0.0334 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 128B         |  10.106 μs | 0.0504 μs | 0.0471 μs |         - |
 |                                                   |              |            |           |           |           |
-| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 1KB          |  10.752 μs | 0.1171 μs | 0.1096 μs |         - |
-| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 1KB          |  14.313 μs | 0.0877 μs | 0.0821 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 1KB          |  10.677 μs | 0.0357 μs | 0.0317 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 1KB          |  14.268 μs | 0.0549 μs | 0.0514 μs |         - |
 |                                                   |              |            |           |           |           |
-| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 8KB          |  35.594 μs | 0.1476 μs | 0.1309 μs |         - |
-| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 8KB          |  47.583 μs | 0.1639 μs | 0.1453 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 8KB          |  35.436 μs | 0.1393 μs | 0.1163 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 8KB          |  47.829 μs | 0.5449 μs | 0.5097 μs |         - |
 |                                                   |              |            |           |           |           |
-| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 128KB        | 461.053 μs | 1.3541 μs | 1.2667 μs |         - |
-| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 128KB        | 620.832 μs | 3.1524 μs | 2.9488 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · CryptoHives-Scalar | 128KB        | 461.761 μs | 2.5039 μs | 2.3421 μs |         - |
+| AbsorbSqueeze · Ascon-XOF128 · BouncyCastle       | 128KB        | 617.427 μs | 2.5594 μs | 2.2689 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-blake3.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-blake3.md
@@ -1,21 +1,21 @@
 ﻿| Description                                 | TestDataSize | Mean         | Error     | StdDev    | Allocated |
 |-------------------------------------------- |------------- |-------------:|----------:|----------:|----------:|
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128B         |     1.565 μs | 0.0020 μs | 0.0017 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 128B         |     2.321 μs | 0.0128 μs | 0.0120 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128B         |     9.962 μs | 0.0273 μs | 0.0242 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128B         |    19.492 μs | 0.0631 μs | 0.0590 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128B         |     1.589 μs | 0.0025 μs | 0.0020 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 128B         |     2.319 μs | 0.0134 μs | 0.0112 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128B         |    10.061 μs | 0.0372 μs | 0.0330 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128B         |    19.848 μs | 0.0409 μs | 0.0363 μs |      56 B |
 |                                             |              |              |           |           |           |
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 1KB          |     2.140 μs | 0.0261 μs | 0.0244 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 1KB          |     3.195 μs | 0.0078 μs | 0.0073 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 1KB          |    14.071 μs | 0.1196 μs | 0.1060 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 1KB          |    28.866 μs | 0.2060 μs | 0.1826 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 1KB          |     2.153 μs | 0.0076 μs | 0.0064 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 1KB          |     3.173 μs | 0.0103 μs | 0.0086 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 1KB          |    14.158 μs | 0.0395 μs | 0.0369 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 1KB          |    28.901 μs | 0.0898 μs | 0.0796 μs |      56 B |
 |                                             |              |              |           |           |           |
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 8KB          |     6.598 μs | 0.0166 μs | 0.0156 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 8KB          |     9.803 μs | 0.0639 μs | 0.0534 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 8KB          |    47.740 μs | 0.5916 μs | 0.5534 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 8KB          |    98.091 μs | 0.3920 μs | 0.3667 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 8KB          |     6.659 μs | 0.0145 μs | 0.0121 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 8KB          |     9.696 μs | 0.0301 μs | 0.0251 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 8KB          |    46.804 μs | 0.1287 μs | 0.1141 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 8KB          |   103.228 μs | 0.1771 μs | 0.1570 μs |      56 B |
 |                                             |              |              |           |           |           |
-| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128KB        |    83.161 μs | 0.2063 μs | 0.1829 μs |         - |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 128KB        |   124.423 μs | 0.7720 μs | 0.7221 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128KB        |   602.926 μs | 3.0293 μs | 2.6854 μs |      24 B |
-| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128KB        | 1,368.268 μs | 6.3637 μs | 5.9526 μs |      56 B |
+| AbsorbSqueeze · BLAKE3 · Blake3Native       | 128KB        |    84.006 μs | 0.1822 μs | 0.1615 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Ssse3  | 128KB        |   123.646 μs | 0.3508 μs | 0.3281 μs |         - |
+| AbsorbSqueeze · BLAKE3 · CryptoHives-Scalar | 128KB        |   606.850 μs | 2.6969 μs | 2.3908 μs |         - |
+| AbsorbSqueeze · BLAKE3 · BouncyCastle       | 128KB        | 1,369.993 μs | 3.2120 μs | 3.0045 μs |      56 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-cshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-cshake128.md
@@ -1,13 +1,13 @@
 ﻿| Description                                    | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |----------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128B         |   2.771 μs | 0.0147 μs | 0.0123 μs |         - |
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128B         |   4.057 μs | 0.0173 μs | 0.0162 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128B         |   2.607 μs | 0.0144 μs | 0.0135 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128B         |   4.013 μs | 0.0173 μs | 0.0135 μs |         - |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 1KB          |   4.479 μs | 0.0302 μs | 0.0268 μs |         - |
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 1KB          |   5.997 μs | 0.0348 μs | 0.0308 μs |    1152 B |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 1KB          |   3.763 μs | 0.0138 μs | 0.0115 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 1KB          |   5.939 μs | 0.0213 μs | 0.0178 μs |    1152 B |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 8KB          |  17.140 μs | 0.0922 μs | 0.0817 μs |         - |
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 8KB          |  19.437 μs | 0.1043 μs | 0.0975 μs |    9216 B |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 8KB          |  11.874 μs | 0.0497 μs | 0.0415 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 8KB          |  19.493 μs | 0.1138 μs | 0.1065 μs |    9216 B |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128KB        | 236.129 μs | 1.1667 μs | 1.0913 μs |         - |
-| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128KB        | 260.616 μs | 4.1441 μs | 4.0700 μs |  149760 B |
+| AbsorbSqueeze · cSHAKE128 · CryptoHives-Scalar | 128KB        | 152.646 μs | 0.5885 μs | 0.5217 μs |         - |
+| AbsorbSqueeze · cSHAKE128 · BouncyCastle       | 128KB        | 253.871 μs | 0.5608 μs | 0.4379 μs |  149760 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-cshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-cshake256.md
@@ -1,13 +1,13 @@
 ﻿| Description                                    | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |----------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128B         |   3.316 μs | 0.0112 μs | 0.0104 μs |         - |
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128B         |   4.915 μs | 0.0330 μs | 0.0309 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128B         |   3.183 μs | 0.0157 μs | 0.0139 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128B         |   4.908 μs | 0.0226 μs | 0.0211 μs |         - |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 1KB          |   5.245 μs | 0.0358 μs | 0.0299 μs |         - |
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 1KB          |   7.151 μs | 0.0306 μs | 0.0287 μs |    1120 B |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 1KB          |   4.525 μs | 0.0328 μs | 0.0307 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 1KB          |   7.109 μs | 0.0296 μs | 0.0247 μs |    1120 B |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 8KB          |  19.923 μs | 0.0970 μs | 0.0860 μs |         - |
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 8KB          |  24.214 μs | 0.1118 μs | 0.1046 μs |    9600 B |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 8KB          |  14.678 μs | 0.0494 μs | 0.0462 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 8KB          |  24.327 μs | 0.0797 μs | 0.0665 μs |    9600 B |
 |                                                |              |            |           |           |           |
-| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128KB        | 270.663 μs | 0.9881 μs | 0.8759 μs |         - |
-| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128KB        | 316.950 μs | 1.3381 μs | 1.1862 μs |  154080 B |
+| AbsorbSqueeze · cSHAKE256 · CryptoHives-Scalar | 128KB        | 187.876 μs | 0.5233 μs | 0.4370 μs |         - |
+| AbsorbSqueeze · cSHAKE256 · BouncyCastle       | 128KB        | 314.991 μs | 1.1409 μs | 1.0114 μs |  154080 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kmac128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kmac128.md
@@ -1,17 +1,17 @@
 ﻿| Description                                   | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |---------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 128B         |   3.170 μs | 0.0142 μs | 0.0125 μs |         - |
-| AbsorbSqueeze · KMAC-128 · OS Native          | 128B         |   3.890 μs | 0.0322 μs | 0.0302 μs |      32 B |
-| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 128B         |   5.028 μs | 0.0288 μs | 0.0270 μs |     128 B |
+| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 128B         |   3.022 μs | 0.0170 μs | 0.0159 μs |         - |
+| AbsorbSqueeze · KMAC-128 · OS Native          | 128B         |   3.862 μs | 0.0205 μs | 0.0191 μs |      32 B |
+| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 128B         |   5.017 μs | 0.0343 μs | 0.0268 μs |     128 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 1KB          |   4.900 μs | 0.0208 μs | 0.0195 μs |         - |
-| AbsorbSqueeze · KMAC-128 · OS Native          | 1KB          |   5.302 μs | 0.0269 μs | 0.0252 μs |      32 B |
-| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 1KB          |   6.951 μs | 0.0212 μs | 0.0177 μs |    1280 B |
+| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 1KB          |   4.181 μs | 0.0280 μs | 0.0262 μs |         - |
+| AbsorbSqueeze · KMAC-128 · OS Native          | 1KB          |   5.284 μs | 0.0226 μs | 0.0200 μs |      32 B |
+| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 1KB          |   6.924 μs | 0.0334 μs | 0.0279 μs |    1280 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · KMAC-128 · OS Native          | 8KB          |  15.408 μs | 0.1204 μs | 0.1006 μs |      32 B |
-| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 8KB          |  17.548 μs | 0.2162 μs | 0.1805 μs |         - |
-| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 8KB          |  20.523 μs | 0.1073 μs | 0.0951 μs |    9344 B |
+| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 8KB          |  12.274 μs | 0.0641 μs | 0.0600 μs |         - |
+| AbsorbSqueeze · KMAC-128 · OS Native          | 8KB          |  15.270 μs | 0.0874 μs | 0.0775 μs |      32 B |
+| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 8KB          |  20.427 μs | 0.1068 μs | 0.0946 μs |    9344 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · KMAC-128 · OS Native          | 128KB        | 190.766 μs | 1.2287 μs | 1.1493 μs |      32 B |
-| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 128KB        | 235.551 μs | 1.1747 μs | 0.9809 μs |         - |
-| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 128KB        | 257.764 μs | 2.5554 μs | 2.3903 μs |  149888 B |
+| AbsorbSqueeze · KMAC-128 · CryptoHives-Scalar | 128KB        | 152.990 μs | 0.5088 μs | 0.4249 μs |         - |
+| AbsorbSqueeze · KMAC-128 · OS Native          | 128KB        | 189.590 μs | 1.5164 μs | 1.3443 μs |      32 B |
+| AbsorbSqueeze · KMAC-128 · BouncyCastle       | 128KB        | 256.960 μs | 1.3968 μs | 1.3066 μs |  149888 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kmac256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kmac256.md
@@ -1,17 +1,17 @@
 ﻿| Description                                   | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |---------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 128B         |   3.730 μs | 0.0133 μs | 0.0118 μs |         - |
-| AbsorbSqueeze · KMAC-256 · OS Native          | 128B         |   4.564 μs | 0.0347 μs | 0.0308 μs |      32 B |
-| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 128B         |   5.897 μs | 0.0309 μs | 0.0289 μs |     128 B |
+| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 128B         |   3.589 μs | 0.0173 μs | 0.0162 μs |         - |
+| AbsorbSqueeze · KMAC-256 · OS Native          | 128B         |   4.552 μs | 0.0292 μs | 0.0273 μs |      32 B |
+| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 128B         |   5.860 μs | 0.0349 μs | 0.0291 μs |     128 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 1KB          |   5.645 μs | 0.0391 μs | 0.0366 μs |         - |
-| AbsorbSqueeze · KMAC-256 · OS Native          | 1KB          |   6.226 μs | 0.0247 μs | 0.0231 μs |      32 B |
-| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 1KB          |   8.128 μs | 0.0365 μs | 0.0342 μs |    1248 B |
+| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 1KB          |   4.951 μs | 0.0415 μs | 0.0368 μs |         - |
+| AbsorbSqueeze · KMAC-256 · OS Native          | 1KB          |   6.203 μs | 0.0586 μs | 0.0548 μs |      32 B |
+| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 1KB          |   8.091 μs | 0.0433 μs | 0.0384 μs |    1248 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · KMAC-256 · OS Native          | 8KB          |  18.814 μs | 0.1609 μs | 0.1343 μs |      32 B |
-| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 8KB          |  20.334 μs | 0.0754 μs | 0.0668 μs |         - |
-| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 8KB          |  25.184 μs | 0.1988 μs | 0.1762 μs |    9728 B |
+| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 8KB          |  15.154 μs | 0.0687 μs | 0.0574 μs |         - |
+| AbsorbSqueeze · KMAC-256 · OS Native          | 8KB          |  18.749 μs | 0.1252 μs | 0.1171 μs |      32 B |
+| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 8KB          |  25.168 μs | 0.1201 μs | 0.1065 μs |    9728 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · KMAC-256 · OS Native          | 128KB        | 232.120 μs | 1.1318 μs | 0.8836 μs |      32 B |
-| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 128KB        | 271.349 μs | 2.8158 μs | 2.6339 μs |         - |
-| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 128KB        | 317.745 μs | 1.6789 μs | 1.5705 μs |  154208 B |
+| AbsorbSqueeze · KMAC-256 · CryptoHives-Scalar | 128KB        | 189.391 μs | 1.7310 μs | 1.4454 μs |         - |
+| AbsorbSqueeze · KMAC-256 · OS Native          | 128KB        | 231.744 μs | 1.2464 μs | 1.1658 μs |      32 B |
+| AbsorbSqueeze · KMAC-256 · BouncyCastle       | 128KB        | 317.308 μs | 1.1747 μs | 1.0414 μs |  154208 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kt128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kt128.md
@@ -1,9 +1,9 @@
-﻿| Description                                | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128B         |   1.572 μs | 0.0064 μs | 0.0060 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 1KB          |   2.737 μs | 0.0108 μs | 0.0096 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 8KB          |  11.565 μs | 0.1482 μs | 0.1314 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128KB        | 163.455 μs | 1.8829 μs | 1.7612 μs |         - |
+﻿| Description                                | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128B         |  1.446 μs | 0.0102 μs | 0.0091 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 1KB          |  2.052 μs | 0.0197 μs | 0.0165 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 8KB          |  6.303 μs | 0.0305 μs | 0.0270 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT128 · CryptoHives-Scalar | 128KB        | 80.207 μs | 0.4070 μs | 0.3608 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kt256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-kt256.md
@@ -1,9 +1,9 @@
-﻿| Description                                | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128B         |   1.861 μs | 0.0081 μs | 0.0068 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 1KB          |   3.130 μs | 0.0110 μs | 0.0103 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 8KB          |  13.134 μs | 0.2468 μs | 0.2061 μs |         - |
-|                                            |              |            |           |           |           |
-| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128KB        | 183.260 μs | 3.5883 μs | 3.8394 μs |         - |
+﻿| Description                                | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128B         |  1.740 μs | 0.0101 μs | 0.0090 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 1KB          |  2.443 μs | 0.0137 μs | 0.0121 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 8KB          |  7.772 μs | 0.0719 μs | 0.0673 μs |         - |
+|                                            |              |           |           |           |           |
+| AbsorbSqueeze · KT256 · CryptoHives-Scalar | 128KB        | 98.379 μs | 0.5654 μs | 0.5013 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-shake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-shake128.md
@@ -1,17 +1,17 @@
 ﻿| Description                                   | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |---------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128B         |   2.772 μs | 0.0403 μs | 0.0358 μs |         - |
-| AbsorbSqueeze · SHAKE128 · OS Native          | 128B         |   3.292 μs | 0.0311 μs | 0.0291 μs |         - |
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128B         |   4.087 μs | 0.0755 μs | 0.0707 μs |         - |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128B         |   2.614 μs | 0.0200 μs | 0.0187 μs |         - |
+| AbsorbSqueeze · SHAKE128 · OS Native          | 128B         |   3.266 μs | 0.0343 μs | 0.0304 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128B         |   4.038 μs | 0.0191 μs | 0.0178 μs |         - |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 1KB          |   4.544 μs | 0.0827 μs | 0.1015 μs |         - |
-| AbsorbSqueeze · SHAKE128 · OS Native          | 1KB          |   4.796 μs | 0.0936 μs | 0.1485 μs |         - |
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 1KB          |   6.017 μs | 0.0746 μs | 0.0698 μs |    1152 B |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 1KB          |   3.779 μs | 0.0222 μs | 0.0208 μs |         - |
+| AbsorbSqueeze · SHAKE128 · OS Native          | 1KB          |   4.681 μs | 0.0289 μs | 0.0256 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 1KB          |   5.980 μs | 0.0512 μs | 0.0428 μs |    1152 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE128 · OS Native          | 8KB          |  15.039 μs | 0.2545 μs | 0.2256 μs |         - |
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 8KB          |  17.317 μs | 0.3356 μs | 0.3446 μs |         - |
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 8KB          |  19.959 μs | 0.3989 μs | 0.4749 μs |    9216 B |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 8KB          |  11.886 μs | 0.0459 μs | 0.0407 μs |         - |
+| AbsorbSqueeze · SHAKE128 · OS Native          | 8KB          |  14.797 μs | 0.1038 μs | 0.0920 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 8KB          |  19.520 μs | 0.1391 μs | 0.1301 μs |    9216 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE128 · OS Native          | 128KB        | 191.658 μs | 2.5788 μs | 2.4122 μs |         - |
-| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128KB        | 236.344 μs | 2.7841 μs | 2.6043 μs |         - |
-| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128KB        | 255.234 μs | 2.1568 μs | 1.8011 μs |  149760 B |
+| AbsorbSqueeze · SHAKE128 · CryptoHives-Scalar | 128KB        | 153.131 μs | 1.0075 μs | 0.8931 μs |         - |
+| AbsorbSqueeze · SHAKE128 · OS Native          | 128KB        | 189.887 μs | 2.2975 μs | 2.0367 μs |         - |
+| AbsorbSqueeze · SHAKE128 · BouncyCastle       | 128KB        | 255.651 μs | 1.5554 μs | 1.4549 μs |  149760 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-shake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-shake256.md
@@ -1,17 +1,17 @@
 ﻿| Description                                   | TestDataSize | Mean       | Error     | StdDev    | Allocated |
 |---------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128B         |   3.334 μs | 0.0331 μs | 0.0293 μs |         - |
-| AbsorbSqueeze · SHAKE256 · OS Native          | 128B         |   3.973 μs | 0.0520 μs | 0.0486 μs |         - |
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128B         |   4.922 μs | 0.0312 μs | 0.0277 μs |         - |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128B         |   3.186 μs | 0.0215 μs | 0.0191 μs |         - |
+| AbsorbSqueeze · SHAKE256 · OS Native          | 128B         |   3.944 μs | 0.0127 μs | 0.0099 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128B         |   4.901 μs | 0.0081 μs | 0.0067 μs |         - |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 1KB          |   5.257 μs | 0.0373 μs | 0.0348 μs |         - |
-| AbsorbSqueeze · SHAKE256 · OS Native          | 1KB          |   5.689 μs | 0.1099 μs | 0.1028 μs |         - |
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 1KB          |   7.159 μs | 0.0623 μs | 0.0520 μs |    1120 B |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 1KB          |   4.524 μs | 0.0355 μs | 0.0314 μs |         - |
+| AbsorbSqueeze · SHAKE256 · OS Native          | 1KB          |   5.571 μs | 0.0262 μs | 0.0232 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 1KB          |   7.125 μs | 0.0222 μs | 0.0173 μs |    1120 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE256 · OS Native          | 8KB          |  18.236 μs | 0.1301 μs | 0.1086 μs |         - |
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 8KB          |  20.167 μs | 0.3372 μs | 0.3312 μs |         - |
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 8KB          |  24.317 μs | 0.1946 μs | 0.1820 μs |    9600 B |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 8KB          |  14.719 μs | 0.0980 μs | 0.0917 μs |         - |
+| AbsorbSqueeze · SHAKE256 · OS Native          | 8KB          |  18.053 μs | 0.1019 μs | 0.0851 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 8KB          |  24.047 μs | 0.0980 μs | 0.0819 μs |    9600 B |
 |                                               |              |            |           |           |           |
-| AbsorbSqueeze · SHAKE256 · OS Native          | 128KB        | 234.121 μs | 1.7088 μs | 1.5148 μs |         - |
-| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128KB        | 273.913 μs | 5.2669 μs | 4.9266 μs |         - |
-| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128KB        | 319.335 μs | 2.0836 μs | 1.9490 μs |  154080 B |
+| AbsorbSqueeze · SHAKE256 · CryptoHives-Scalar | 128KB        | 188.333 μs | 1.0793 μs | 1.0096 μs |         - |
+| AbsorbSqueeze · SHAKE256 · OS Native          | 128KB        | 231.843 μs | 0.9705 μs | 0.8104 μs |         - |
+| AbsorbSqueeze · SHAKE256 · BouncyCastle       | 128KB        | 315.808 μs | 1.1781 μs | 0.9838 μs |  154080 B |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-turboshake128.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-turboshake128.md
@@ -1,9 +1,9 @@
-﻿| Description                                        | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|--------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128B         |   1.556 μs | 0.0210 μs | 0.0186 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 1KB          |   2.719 μs | 0.0237 μs | 0.0222 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 8KB          |  11.463 μs | 0.0669 μs | 0.0593 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128KB        | 163.264 μs | 1.8864 μs | 1.7645 μs |         - |
+﻿| Description                                        | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|--------------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128B         |  1.426 μs | 0.0107 μs | 0.0100 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 1KB          |  2.034 μs | 0.0186 μs | 0.0164 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 8KB          |  6.282 μs | 0.0429 μs | 0.0401 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE128 · CryptoHives-Scalar | 128KB        | 80.315 μs | 0.4244 μs | 0.3763 μs |         - |

--- a/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-turboshake256.md
+++ b/docfx/packages/security/cryptography/benchmarks/windows-x64-amd-ryzen-5-7600x/xof-turboshake256.md
@@ -1,9 +1,9 @@
-﻿| Description                                        | TestDataSize | Mean       | Error     | StdDev    | Allocated |
-|--------------------------------------------------- |------------- |-----------:|----------:|----------:|----------:|
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128B         |   1.835 μs | 0.0107 μs | 0.0095 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 1KB          |   3.122 μs | 0.0373 μs | 0.0349 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 8KB          |  12.941 μs | 0.0959 μs | 0.0850 μs |         - |
-|                                                    |              |            |           |           |           |
-| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128KB        | 180.906 μs | 1.8520 μs | 1.7324 μs |         - |
+﻿| Description                                        | TestDataSize | Mean      | Error     | StdDev    | Allocated |
+|--------------------------------------------------- |------------- |----------:|----------:|----------:|----------:|
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128B         |  1.717 μs | 0.0097 μs | 0.0090 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 1KB          |  2.430 μs | 0.0173 μs | 0.0162 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 8KB          |  7.766 μs | 0.0752 μs | 0.0628 μs |         - |
+|                                                    |              |           |           |           |           |
+| AbsorbSqueeze · TurboSHAKE256 · CryptoHives-Scalar | 128KB        | 98.384 μs | 0.4645 μs | 0.3879 μs |         - |

--- a/scripts/run-benchmarks.ps1
+++ b/scripts/run-benchmarks.ps1
@@ -55,7 +55,7 @@ param(
         "KuznyechikCbc", "KalynaCbc128", "KalynaCbc256",
         "SeedCbc",
         # Group aliases (run multiple benchmarks)
-        "SHA2", "SHA3", "Keccak", "SHAKE", "cSHAKE", "KT", "TurboSHAKE",
+        "SHA2", "SHA3", "Keccak", "KeccakCore", "SHAKE", "cSHAKE", "KT", "TurboSHAKE",
         "BLAKE2", "BLAKE2b", "BLAKE2s", "BLAKE",
         "Legacy", "RegionalHash", "Kupyna", "LSH", "Ascon", "KMAC",
         "XOF", "KeccakXOF", "BlakeXOF", "MacXOF", "AsconXOF",
@@ -119,7 +119,7 @@ if (-not $Project -or $PSBoundParameters.Count -eq 0) {
     Write-Host "   - Family — many individual algorithms + group aliases (SHA2, SHA3, etc.) — none (null)  "
     Write-Host "   - Filter — one or more string globs applied to full benchmark name — \"*\"  "
     Write-Host "   - Framework — net10.0 | net8.0 | net48 — net10.0  "
-    Write-Host "   - Runtimes — comma list (e.g. \"net10.0,net8.0\") — \"net10.0\"  "
+    Write-Host "   - Runtimes — comma list (e.g. \"net10.0, net8.0\") — \"net10.0\"  "
     Write-Host "   - Configuration — Release | Debug — Release  "
     Write-Host "   - Verbosity — q | m | n | d | diag — n  "
     Write-Host "   - List — switch (show benchmarks) — off  "
@@ -141,138 +141,139 @@ if ($PSBoundParameters.Count -gt 0 -and -not $Project) {
 # Individual algorithm to benchmark category mapping
 $AlgorithmBenchmarkMap = @{
     # SHA-2
-    "SHA224"      = "SHA224"
-    "SHA256"      = "SHA256"
-    "SHA384"      = "SHA384"
-    "SHA512"      = "SHA512"
-    "SHA512_224"  = "SHA512_224"
-    "SHA512_256"  = "SHA512_256"
+    "SHA224"            = "SHA224"
+    "SHA256"            = "SHA256"
+    "SHA384"            = "SHA384"
+    "SHA512"            = "SHA512"
+    "SHA512_224"        = "SHA512_224"
+    "SHA512_256"        = "SHA512_256"
     # SHA-3
-    "SHA3_224"    = "SHA3_224"
-    "SHA3_256"    = "SHA3_256"
-    "SHA3_384"    = "SHA3_384"
-    "SHA3_512"    = "SHA3_512"
+    "SHA3_224"          = "SHA3_224"
+    "SHA3_256"          = "SHA3_256"
+    "SHA3_384"          = "SHA3_384"
+    "SHA3_512"          = "SHA3_512"
     # Keccak
-    "Keccak256"   = "Keccak256"
-    "Keccak384"   = "Keccak384"
-    "Keccak512"   = "Keccak512"
+    "Keccak256"         = "Keccak256"
+    "Keccak384"         = "Keccak384"
+    "Keccak512"         = "Keccak512"
     # SHAKE
-    "Shake128"    = "Shake128"
-    "Shake256"    = "Shake256"
+    "Shake128"          = "Shake128"
+    "Shake256"          = "Shake256"
     # cSHAKE
-    "CShake128"   = "CShake128"
-    "CShake256"   = "CShake256"
+    "CShake128"         = "CShake128"
+    "CShake256"         = "CShake256"
     # KT
-    "KT128"       = "KT128"
-    "KT256"       = "KT256"
+    "KT128"             = "KT128"
+    "KT256"             = "KT256"
     # TurboSHAKE
-    "TurboShake128" = "TurboShake128"
-    "TurboShake256" = "TurboShake256"
+    "TurboShake128"     = "TurboShake128"
+    "TurboShake256"     = "TurboShake256"
     # BLAKE2b
-    "Blake2b256"  = "Blake2b256"
-    "Blake2b512"  = "Blake2b512"
+    "Blake2b256"        = "Blake2b256"
+    "Blake2b512"        = "Blake2b512"
     # BLAKE2s
-    "Blake2s128"  = "Blake2s128"
-    "Blake2s256"  = "Blake2s256"
+    "Blake2s128"        = "Blake2s128"
+    "Blake2s256"        = "Blake2s256"
     # BLAKE3
-    "Blake3"      = "Blake3"
+    "Blake3"            = "Blake3"
     # Legacy
-    "MD5"         = "MD5"
-    "SHA1"        = "SHA1"
+    "MD5"               = "MD5"
+    "SHA1"              = "SHA1"
     # Regional Hash
-    "SM3"         = "SM3"
-    "Streebog256" = "Streebog256"
-    "Streebog512" = "Streebog512"
-    "Whirlpool"   = "Whirlpool"
-    "Ripemd160"   = "Ripemd160"
+    "SM3"               = "SM3"
+    "Streebog256"       = "Streebog256"
+    "Streebog512"       = "Streebog512"
+    "Whirlpool"         = "Whirlpool"
+    "Ripemd160"         = "Ripemd160"
     # Kupyna (DSTU 7564)
-    "Kupyna256"   = "Kupyna256"
-    "Kupyna384"   = "Kupyna384"
-    "Kupyna512"   = "Kupyna512"
+    "Kupyna256"         = "Kupyna256"
+    "Kupyna384"         = "Kupyna384"
+    "Kupyna512"         = "Kupyna512"
     # LSH (KS X 3262)
-    "Lsh256_256"  = "Lsh256_256"
-    "Lsh512_256"  = "Lsh512_256"
-    "Lsh512_512"  = "Lsh512_512"
+    "Lsh256_256"        = "Lsh256_256"
+    "Lsh512_256"        = "Lsh512_256"
+    "Lsh512_512"        = "Lsh512_512"
     # Ascon
-    "AsconHash256" = "AsconHash256"
-    "AsconXof128" = "AsconXof128"
+    "AsconHash256"      = "AsconHash256"
+    "AsconXof128"       = "AsconXof128"
     # KMAC
-    "KMac128"     = "KMac128"
-    "KMac256"     = "KMac256"
+    "KMac128"           = "KMac128"
+    "KMac256"           = "KMac256"
     # XOF (Absorb/Squeeze)
-    "Shake128Xof"      = "Shake128Xof"
-    "Shake256Xof"      = "Shake256Xof"
-    "CShake128Xof"     = "CShake128Xof"
-    "CShake256Xof"     = "CShake256Xof"
-    "TurboShake128Xof" = "TurboShake128Xof"
-    "TurboShake256Xof" = "TurboShake256Xof"
-    "KT128Xof"         = "KT128Xof"
-    "KT256Xof"         = "KT256Xof"
-    "KMac128Xof"       = "KMac128Xof"
-    "KMac256Xof"       = "KMac256Xof"
-    "Blake3Xof"        = "Blake3Xof"
-    "AsconXof128Xof"   = "AsconXof128Xof"
+    "Shake128Xof"       = "Shake128Xof"
+    "Shake256Xof"       = "Shake256Xof"
+    "CShake128Xof"      = "CShake128Xof"
+    "CShake256Xof"      = "CShake256Xof"
+    "TurboShake128Xof"  = "TurboShake128Xof"
+    "TurboShake256Xof"  = "TurboShake256Xof"
+    "KT128Xof"          = "KT128Xof"
+    "KT256Xof"          = "KT256Xof"
+    "KMac128Xof"        = "KMac128Xof"
+    "KMac256Xof"        = "KMac256Xof"
+    "Blake3Xof"         = "Blake3Xof"
+    "AsconXof128Xof"    = "AsconXof128Xof"
     # Ciphers - AES-GCM
-    "AesGcm128"   = "AesGcm128"
-    "AesGcm192"   = "AesGcm192"
-    "AesGcm256"   = "AesGcm256"
+    "AesGcm128"         = "AesGcm128"
+    "AesGcm192"         = "AesGcm192"
+    "AesGcm256"         = "AesGcm256"
     # Ciphers - AES-CCM
-    "AesCcm128"   = "AesCcm128"
-    "AesCcm256"   = "AesCcm256"
+    "AesCcm128"         = "AesCcm128"
+    "AesCcm256"         = "AesCcm256"
     # Ciphers - AES-CBC
-    "AesCbc128"   = "AesCbc128"
-    "AesCbc256"   = "AesCbc256"
+    "AesCbc128"         = "AesCbc128"
+    "AesCbc256"         = "AesCbc256"
     # Ciphers - ChaCha
-    "ChaCha20"    = "ChaCha20"
-    "ChaCha20Poly1305" = "ChaCha20Poly1305"
+    "ChaCha20"          = "ChaCha20"
+    "ChaCha20Poly1305"  = "ChaCha20Poly1305"
     "XChaCha20Poly1305" = "XChaCha20Poly1305"
     # Ciphers - Regional
-    "Sm4Cbc"      = "Sm4Cbc"
-    "AriaCbc128"  = "AriaCbc128"
-    "AriaCbc256"  = "AriaCbc256"
-    "CamelliaCbc128" = "CamelliaCbc128"
-    "CamelliaCbc192" = "CamelliaCbc192"
-    "CamelliaCbc256" = "CamelliaCbc256"
-    "KuznyechikCbc" = "KuznyechikCbc"
-    "KalynaCbc128" = "KalynaCbc128"
-    "KalynaCbc256" = "KalynaCbc256"
-    "SeedCbc"     = "SeedCbc"
+    "Sm4Cbc"            = "Sm4Cbc"
+    "AriaCbc128"        = "AriaCbc128"
+    "AriaCbc256"        = "AriaCbc256"
+    "CamelliaCbc128"    = "CamelliaCbc128"
+    "CamelliaCbc192"    = "CamelliaCbc192"
+    "CamelliaCbc256"    = "CamelliaCbc256"
+    "KuznyechikCbc"     = "KuznyechikCbc"
+    "KalynaCbc128"      = "KalynaCbc128"
+    "KalynaCbc256"      = "KalynaCbc256"
+    "SeedCbc"           = "SeedCbc"
     # Group Aliases
-    "All"         = "Hash"
+    "All"               = "Hash"
 }
 
 # Group aliases expand to multiple individual benchmarks
 $GroupAliases = @{
-    "SHA2"        = @("SHA224", "SHA256", "SHA384", "SHA512", "SHA512_224", "SHA512_256")
-    "SHA3"        = @("SHA3_224", "SHA3_256", "SHA3_384", "SHA3_512")
-    "Keccak"      = @("Keccak256", "Keccak384", "Keccak512")
-    "SHAKE"       = @("Shake128", "Shake256")
-    "cSHAKE"      = @("CShake128", "CShake256")
-    "KT"          = @("KT128", "KT256")
-    "TurboSHAKE"  = @("TurboShake128", "TurboShake256")
-    "BLAKE2"      = @("Blake2b256", "Blake2b512", "Blake2s256", "Blake2s128")
-    "BLAKE2b"     = @("Blake2b256", "Blake2b512")
-    "BLAKE2s"     = @("Blake2s256", "Blake2s128")
-    "BLAKE"       = @("Blake3", "Blake2s256", "Blake2b256", "Blake2s128", "Blake2b512")
-    "Legacy"      = @("MD5", "SHA1")
-    "RegionalHash"= @("SM3", "Streebog256", "Streebog512", "Whirlpool", "Ripemd160", "Kupyna256", "Kupyna384", "Kupyna512", "Lsh256_256", "Lsh512_256", "Lsh512_512")
-    "Kupyna"      = @("Kupyna256", "Kupyna384", "Kupyna512")
-    "LSH"         = @("Lsh256_256", "Lsh512_256", "Lsh512_512")
-    "Ascon"       = @("AsconHash256", "AsconXof128")
-    "KMAC"        = @("KMac128", "KMac256")
-    "XOF"         = @("Shake128Xof", "Shake256Xof", "CShake128Xof", "CShake256Xof", "TurboShake128Xof", "TurboShake256Xof", "KT128Xof", "KT256Xof", "KMac128Xof", "KMac256Xof", "Blake3Xof", "AsconXof128Xof")
-    "KeccakXOF"   = @("Shake128Xof", "Shake256Xof", "CShake128Xof", "CShake256Xof", "TurboShake128Xof", "TurboShake256Xof", "KT128Xof", "KT256Xof")
-    "BlakeXOF"    = @("Blake3Xof")
-    "MacXOF"      = @("KMac128Xof", "KMac256Xof")
-    "AsconXOF"    = @("AsconXof128Xof")
-    "AES-GCM"     = @("AesGcm128", "AesGcm192", "AesGcm256")
-    "AES-CCM"     = @("AesCcm128", "AesCcm256")
-    "AES-CBC"     = @("AesCbc128", "AesCbc256")
-    "ChaCha"      = @("ChaCha20", "ChaCha20Poly1305", "XChaCha20Poly1305")
+    "SHA2"           = @("SHA224", "SHA256", "SHA384", "SHA512", "SHA512_224", "SHA512_256")
+    "SHA3"           = @("SHA3_224", "SHA3_256", "SHA3_384", "SHA3_512")
+    "Keccak"         = @("Keccak256", "Keccak384", "Keccak512")
+    "SHAKE"          = @("Shake128", "Shake256")
+    "cSHAKE"         = @("CShake128", "CShake256")
+    "KT"             = @("KT128", "KT256")
+    "TurboSHAKE"     = @("TurboShake128", "TurboShake256")
+    "KeccakCore"     = @("SHA3_224", "SHA3_256", "SHA3_384", "SHA3_512", "Keccak256", "Keccak384", "Keccak512", "Shake128", "Shake256", "CShake128", "CShake256", "KT128", "KT256", "TurboShake128", "TurboShake256")
+    "BLAKE2"         = @("Blake2b256", "Blake2b512", "Blake2s256", "Blake2s128")
+    "BLAKE2b"        = @("Blake2b256", "Blake2b512")
+    "BLAKE2s"        = @("Blake2s256", "Blake2s128")
+    "BLAKE"          = @("Blake3", "Blake2s256", "Blake2b256", "Blake2s128", "Blake2b512")
+    "Legacy"         = @("MD5", "SHA1")
+    "RegionalHash"   = @("SM3", "Streebog256", "Streebog512", "Whirlpool", "Ripemd160", "Kupyna256", "Kupyna384", "Kupyna512", "Lsh256_256", "Lsh512_256", "Lsh512_512")
+    "Kupyna"         = @("Kupyna256", "Kupyna384", "Kupyna512")
+    "LSH"            = @("Lsh256_256", "Lsh512_256", "Lsh512_512")
+    "Ascon"          = @("AsconHash256", "AsconXof128")
+    "KMAC"           = @("KMac128", "KMac256")
+    "XOF"            = @("Shake128Xof", "Shake256Xof", "CShake128Xof", "CShake256Xof", "TurboShake128Xof", "TurboShake256Xof", "KT128Xof", "KT256Xof", "KMac128Xof", "KMac256Xof", "Blake3Xof", "AsconXof128Xof")
+    "KeccakXOF"      = @("Shake128Xof", "Shake256Xof", "CShake128Xof", "CShake256Xof", "TurboShake128Xof", "TurboShake256Xof", "KT128Xof", "KT256Xof")
+    "BlakeXOF"       = @("Blake3Xof")
+    "MacXOF"         = @("KMac128Xof", "KMac256Xof")
+    "AsconXOF"       = @("AsconXof128Xof")
+    "AES-GCM"        = @("AesGcm128", "AesGcm192", "AesGcm256")
+    "AES-CCM"        = @("AesCcm128", "AesCcm256")
+    "AES-CBC"        = @("AesCbc128", "AesCbc256")
+    "ChaCha"         = @("ChaCha20", "ChaCha20Poly1305", "XChaCha20Poly1305")
     "RegionalCipher" = @("Sm4Cbc", "AriaCbc128", "AriaCbc256", "CamelliaCbc128", "CamelliaCbc192", "CamelliaCbc256", "KuznyechikCbc", "KalynaCbc128", "KalynaCbc256", "SeedCbc")
-    "AEAD"        = @("AesGcm128", "AesGcm192", "AesGcm256", "AesCcm128", "AesCcm256", "ChaCha20Poly1305", "XChaCha20Poly1305")
-    "Cipher"      = @("AesGcm128", "AesGcm192", "AesGcm256", "AesCcm128", "AesCcm256", "AesCbc128", "AesCbc256", "ChaCha20", "ChaCha20Poly1305", "XChaCha20Poly1305", "Sm4Cbc", "AriaCbc128", "AriaCbc256", "CamelliaCbc128", "CamelliaCbc192", "CamelliaCbc256", "KuznyechikCbc", "KalynaCbc128", "KalynaCbc256", "SeedCbc")
-    "SimdArm"     = @("SHA256", "Blake2b256", "Blake2b512", "Blake2s128", "Blake2s256", "Blake3", "AesGcm128", "AesGcm192", "AesGcm256", "AesCcm128", "AesCcm256", "AesCbc128", "AesCbc256", "ChaCha20", "ChaCha20Poly1305", "XChaCha20Poly1305")
+    "AEAD"           = @("AesGcm128", "AesGcm192", "AesGcm256", "AesCcm128", "AesCcm256", "ChaCha20Poly1305", "XChaCha20Poly1305")
+    "Cipher"         = @("AesGcm128", "AesGcm192", "AesGcm256", "AesCcm128", "AesCcm256", "AesCbc128", "AesCbc256", "ChaCha20", "ChaCha20Poly1305", "XChaCha20Poly1305", "Sm4Cbc", "AriaCbc128", "AriaCbc256", "CamelliaCbc128", "CamelliaCbc192", "CamelliaCbc256", "KuznyechikCbc", "KalynaCbc128", "KalynaCbc256", "SeedCbc")
+    "SimdArm"        = @("SHA256", "Blake2b256", "Blake2b512", "Blake2s128", "Blake2s256", "Blake3", "AesGcm128", "AesGcm192", "AesGcm256", "AesCcm128", "AesCcm256", "AesCbc128", "AesCbc256", "ChaCha20", "ChaCha20Poly1305", "XChaCha20Poly1305")
 }
 
 # 'All' should run all hash and cipher benchmarks (convenience alias)
@@ -318,7 +319,8 @@ if ($Project -eq "Cryptography" -and $Family) {
                 $benchmarkClasses += $AlgorithmBenchmarkMap[$alg]
             }
         }
-    } else {
+    }
+    else {
         $algKey = $AlgorithmBenchmarkMap.Keys | Where-Object { $_.ToLower() -eq $lowerFamily } | Select-Object -First 1
         if ($algKey) {
             $benchmarkClasses += $AlgorithmBenchmarkMap[$algKey]
@@ -350,7 +352,8 @@ Write-Host "  Runtimes:      $Runtimes"
 Write-Host "  Configuration: $Configuration"
 try {
     $resolvedTestProject = (Resolve-Path -LiteralPath $testProject -ErrorAction Stop).Path
-} catch {
+}
+catch {
     $resolvedTestProject = $testProject
 }
 Write-Host "  Path:          $resolvedTestProject"
@@ -391,6 +394,7 @@ if ($Project -eq "Cryptography" -and $Help) {
     Write-Host "  -Family SHA2       runs: SHA224, SHA256, SHA384, SHA512, SHA512_224, SHA512_256"
     Write-Host "  -Family SHA3       runs: SHA3_224, SHA3_256, SHA3_384, SHA3_512"
     Write-Host "  -Family Keccak     runs: Keccak256, Keccak384, Keccak512"
+    Write-Host "  -Family KeccakCore runs: Keccak, SHA3, SHAKE, cSHAKE, TurboSHAKE, KT (all Keccak-core algorithms)"
     Write-Host "  -Family SHAKE      runs: Shake128, Shake256"
     Write-Host "  -Family cSHAKE     runs: CShake128, CShake256"
     Write-Host "  -Family KT         runs: KT128, KT256"
@@ -438,7 +442,8 @@ $dotnetArgs = @(
 
 if ($List) {
     $dotnetArgs += "--list"
-} else {
+}
+else {
     # Add filter patterns - multiple patterns are space-separated after --filter
     $dotnetArgs += "--filter"
     if ($filterPatterns.Count -gt 0) {
@@ -446,7 +451,8 @@ if ($List) {
             # Cast to string to avoid PowerShell wildcard expansion when splatting arguments
             $dotnetArgs += [string]$pattern
         }
-    } else {
+    }
+    else {
         foreach ($pattern in $filterArgs) {
             $dotnetArgs += [string]$pattern
         }

--- a/src/Security/Cryptography/Cipher/Aria/AriaCore.cs
+++ b/src/Security/Cryptography/Cipher/Aria/AriaCore.cs
@@ -193,33 +193,57 @@ internal static class AriaCore
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     public static void EncryptBlock(ReadOnlySpan<byte> input, Span<byte> output, ReadOnlySpan<byte> roundKeys, int nr)
     {
-        Span<byte> state = stackalloc byte[16];
-        Span<byte> temp = stackalloc byte[16];
-        input.Slice(0, 16).CopyTo(state);
+        byte x0 = input[0]; byte x1 = input[1]; byte x2 = input[2]; byte x3 = input[3];
+        byte x4 = input[4]; byte x5 = input[5]; byte x6 = input[6]; byte x7 = input[7];
+        byte x8 = input[8]; byte x9 = input[9]; byte x10 = input[10]; byte x11 = input[11];
+        byte x12 = input[12]; byte x13 = input[13]; byte x14 = input[14]; byte x15 = input[15];
 
-        for (int r = 1; r <= nr; r++)
+        int rkOffset = 0;
+        for (int r = 1; r <= nr; r++, rkOffset += 16)
         {
-            // XOR round key
-            for (int i = 0; i < 16; i++)
-                state[i] ^= roundKeys[(r - 1) * 16 + i];
+            x0 ^= roundKeys[rkOffset]; x1 ^= roundKeys[rkOffset + 1];
+            x2 ^= roundKeys[rkOffset + 2]; x3 ^= roundKeys[rkOffset + 3];
+            x4 ^= roundKeys[rkOffset + 4]; x5 ^= roundKeys[rkOffset + 5];
+            x6 ^= roundKeys[rkOffset + 6]; x7 ^= roundKeys[rkOffset + 7];
+            x8 ^= roundKeys[rkOffset + 8]; x9 ^= roundKeys[rkOffset + 9];
+            x10 ^= roundKeys[rkOffset + 10]; x11 ^= roundKeys[rkOffset + 11];
+            x12 ^= roundKeys[rkOffset + 12]; x13 ^= roundKeys[rkOffset + 13];
+            x14 ^= roundKeys[rkOffset + 14]; x15 ^= roundKeys[rkOffset + 15];
 
-            // Substitution layer
-            if (r % 2 == 1)
-                SubstLayerOdd(state);
+            if ((r & 1) != 0)
+            {
+                SubstLayerOdd(ref x0, ref x1, ref x2, ref x3, ref x4, ref x5, ref x6, ref x7,
+                    ref x8, ref x9, ref x10, ref x11, ref x12, ref x13, ref x14, ref x15);
+            }
             else
-                SubstLayerEven(state);
+            {
+                SubstLayerEven(ref x0, ref x1, ref x2, ref x3, ref x4, ref x5, ref x6, ref x7,
+                    ref x8, ref x9, ref x10, ref x11, ref x12, ref x13, ref x14, ref x15);
+            }
 
-            // Diffusion layer (not on final round)
             if (r < nr)
             {
-                DiffuseA(state, temp);
-                temp.CopyTo(state);
+                DiffuseA(ref x0, ref x1, ref x2, ref x3, ref x4, ref x5, ref x6, ref x7,
+                    ref x8, ref x9, ref x10, ref x11, ref x12, ref x13, ref x14, ref x15);
             }
         }
 
-        // XOR final round key
-        for (int i = 0; i < 16; i++)
-            output[i] = (byte)(state[i] ^ roundKeys[nr * 16 + i]);
+        output[0] = (byte)(x0 ^ roundKeys[rkOffset]);
+        output[1] = (byte)(x1 ^ roundKeys[rkOffset + 1]);
+        output[2] = (byte)(x2 ^ roundKeys[rkOffset + 2]);
+        output[3] = (byte)(x3 ^ roundKeys[rkOffset + 3]);
+        output[4] = (byte)(x4 ^ roundKeys[rkOffset + 4]);
+        output[5] = (byte)(x5 ^ roundKeys[rkOffset + 5]);
+        output[6] = (byte)(x6 ^ roundKeys[rkOffset + 6]);
+        output[7] = (byte)(x7 ^ roundKeys[rkOffset + 7]);
+        output[8] = (byte)(x8 ^ roundKeys[rkOffset + 8]);
+        output[9] = (byte)(x9 ^ roundKeys[rkOffset + 9]);
+        output[10] = (byte)(x10 ^ roundKeys[rkOffset + 10]);
+        output[11] = (byte)(x11 ^ roundKeys[rkOffset + 11]);
+        output[12] = (byte)(x12 ^ roundKeys[rkOffset + 12]);
+        output[13] = (byte)(x13 ^ roundKeys[rkOffset + 13]);
+        output[14] = (byte)(x14 ^ roundKeys[rkOffset + 14]);
+        output[15] = (byte)(x15 ^ roundKeys[rkOffset + 15]);
     }
 
     /// <summary>
@@ -242,6 +266,19 @@ internal static class AriaCore
         x[12] = SB1[x[12]]; x[13] = SB2[x[13]]; x[14] = SB3[x[14]]; x[15] = SB4[x[15]];
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SubstLayerOdd(
+        ref byte x0, ref byte x1, ref byte x2, ref byte x3,
+        ref byte x4, ref byte x5, ref byte x6, ref byte x7,
+        ref byte x8, ref byte x9, ref byte x10, ref byte x11,
+        ref byte x12, ref byte x13, ref byte x14, ref byte x15)
+    {
+        x0 = SB1[x0]; x1 = SB2[x1]; x2 = SB3[x2]; x3 = SB4[x3];
+        x4 = SB1[x4]; x5 = SB2[x5]; x6 = SB3[x6]; x7 = SB4[x7];
+        x8 = SB1[x8]; x9 = SB2[x9]; x10 = SB3[x10]; x11 = SB4[x11];
+        x12 = SB1[x12]; x13 = SB2[x13]; x14 = SB3[x14]; x15 = SB4[x15];
+    }
+
     // Even-round substitution: SB3, SB4, SB1, SB2 pattern
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SubstLayerEven(Span<byte> x)
@@ -252,25 +289,63 @@ internal static class AriaCore
         x[12] = SB3[x[12]]; x[13] = SB4[x[13]]; x[14] = SB1[x[14]]; x[15] = SB2[x[15]];
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SubstLayerEven(
+        ref byte x0, ref byte x1, ref byte x2, ref byte x3,
+        ref byte x4, ref byte x5, ref byte x6, ref byte x7,
+        ref byte x8, ref byte x9, ref byte x10, ref byte x11,
+        ref byte x12, ref byte x13, ref byte x14, ref byte x15)
+    {
+        x0 = SB3[x0]; x1 = SB4[x1]; x2 = SB1[x2]; x3 = SB2[x3];
+        x4 = SB3[x4]; x5 = SB4[x5]; x6 = SB1[x6]; x7 = SB2[x7];
+        x8 = SB3[x8]; x9 = SB4[x9]; x10 = SB1[x10]; x11 = SB2[x11];
+        x12 = SB3[x12]; x13 = SB4[x13]; x14 = SB1[x14]; x15 = SB2[x15];
+    }
+
     // Diffusion layer A (binary matrix from RFC 5794)
     private static void DiffuseA(ReadOnlySpan<byte> x, Span<byte> y)
     {
-        y[0] = (byte)(x[3] ^ x[4] ^ x[6] ^ x[8] ^ x[9] ^ x[13] ^ x[14]);
-        y[1] = (byte)(x[2] ^ x[5] ^ x[7] ^ x[8] ^ x[9] ^ x[12] ^ x[15]);
-        y[2] = (byte)(x[1] ^ x[4] ^ x[6] ^ x[10] ^ x[11] ^ x[12] ^ x[15]);
-        y[3] = (byte)(x[0] ^ x[5] ^ x[7] ^ x[10] ^ x[11] ^ x[13] ^ x[14]);
-        y[4] = (byte)(x[0] ^ x[2] ^ x[5] ^ x[8] ^ x[11] ^ x[14] ^ x[15]);
-        y[5] = (byte)(x[1] ^ x[3] ^ x[4] ^ x[9] ^ x[10] ^ x[14] ^ x[15]);
-        y[6] = (byte)(x[0] ^ x[2] ^ x[7] ^ x[9] ^ x[10] ^ x[12] ^ x[13]);
-        y[7] = (byte)(x[1] ^ x[3] ^ x[6] ^ x[8] ^ x[11] ^ x[12] ^ x[13]);
-        y[8] = (byte)(x[0] ^ x[1] ^ x[4] ^ x[7] ^ x[10] ^ x[13] ^ x[15]);
-        y[9] = (byte)(x[0] ^ x[1] ^ x[5] ^ x[6] ^ x[11] ^ x[12] ^ x[14]);
-        y[10] = (byte)(x[2] ^ x[3] ^ x[5] ^ x[6] ^ x[8] ^ x[13] ^ x[15]);
-        y[11] = (byte)(x[2] ^ x[3] ^ x[4] ^ x[7] ^ x[9] ^ x[12] ^ x[14]);
-        y[12] = (byte)(x[1] ^ x[2] ^ x[6] ^ x[7] ^ x[9] ^ x[11] ^ x[12]);
-        y[13] = (byte)(x[0] ^ x[3] ^ x[6] ^ x[7] ^ x[8] ^ x[10] ^ x[13]);
-        y[14] = (byte)(x[0] ^ x[3] ^ x[4] ^ x[5] ^ x[9] ^ x[11] ^ x[14]);
-        y[15] = (byte)(x[1] ^ x[2] ^ x[4] ^ x[5] ^ x[8] ^ x[10] ^ x[15]);
+        byte x0 = x[0]; byte x1 = x[1]; byte x2 = x[2]; byte x3 = x[3];
+        byte x4 = x[4]; byte x5 = x[5]; byte x6 = x[6]; byte x7 = x[7];
+        byte x8 = x[8]; byte x9 = x[9]; byte x10 = x[10]; byte x11 = x[11];
+        byte x12 = x[12]; byte x13 = x[13]; byte x14 = x[14]; byte x15 = x[15];
+
+        DiffuseA(ref x0, ref x1, ref x2, ref x3, ref x4, ref x5, ref x6, ref x7,
+            ref x8, ref x9, ref x10, ref x11, ref x12, ref x13, ref x14, ref x15);
+
+        y[0] = x0; y[1] = x1; y[2] = x2; y[3] = x3;
+        y[4] = x4; y[5] = x5; y[6] = x6; y[7] = x7;
+        y[8] = x8; y[9] = x9; y[10] = x10; y[11] = x11;
+        y[12] = x12; y[13] = x13; y[14] = x14; y[15] = x15;
+    }
+
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    private static void DiffuseA(
+        ref byte x0, ref byte x1, ref byte x2, ref byte x3,
+        ref byte x4, ref byte x5, ref byte x6, ref byte x7,
+        ref byte x8, ref byte x9, ref byte x10, ref byte x11,
+        ref byte x12, ref byte x13, ref byte x14, ref byte x15)
+    {
+        byte y0 = (byte)(x3 ^ x4 ^ x6 ^ x8 ^ x9 ^ x13 ^ x14);
+        byte y1 = (byte)(x2 ^ x5 ^ x7 ^ x8 ^ x9 ^ x12 ^ x15);
+        byte y2 = (byte)(x1 ^ x4 ^ x6 ^ x10 ^ x11 ^ x12 ^ x15);
+        byte y3 = (byte)(x0 ^ x5 ^ x7 ^ x10 ^ x11 ^ x13 ^ x14);
+        byte y4 = (byte)(x0 ^ x2 ^ x5 ^ x8 ^ x11 ^ x14 ^ x15);
+        byte y5 = (byte)(x1 ^ x3 ^ x4 ^ x9 ^ x10 ^ x14 ^ x15);
+        byte y6 = (byte)(x0 ^ x2 ^ x7 ^ x9 ^ x10 ^ x12 ^ x13);
+        byte y7 = (byte)(x1 ^ x3 ^ x6 ^ x8 ^ x11 ^ x12 ^ x13);
+        byte y8 = (byte)(x0 ^ x1 ^ x4 ^ x7 ^ x10 ^ x13 ^ x15);
+        byte y9 = (byte)(x0 ^ x1 ^ x5 ^ x6 ^ x11 ^ x12 ^ x14);
+        byte y10 = (byte)(x2 ^ x3 ^ x5 ^ x6 ^ x8 ^ x13 ^ x15);
+        byte y11 = (byte)(x2 ^ x3 ^ x4 ^ x7 ^ x9 ^ x12 ^ x14);
+        x12 = (byte)(x1 ^ x2 ^ x6 ^ x7 ^ x9 ^ x11 ^ x12);
+        x13 = (byte)(x0 ^ x3 ^ x6 ^ x7 ^ x8 ^ x10 ^ x13);
+        x14 = (byte)(x0 ^ x3 ^ x4 ^ x5 ^ x9 ^ x11 ^ x14);
+        x15 = (byte)(x1 ^ x2 ^ x4 ^ x5 ^ x8 ^ x10 ^ x15);
+
+        x0 = y0; x1 = y1; x2 = y2; x3 = y3;
+        x4 = y4; x5 = y5; x6 = y6; x7 = y7;
+        x8 = y8; x9 = y9; x10 = y10; x11 = y11;
     }
 
     // FO: Odd round function (substitution layer 1 + diffusion)

--- a/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
@@ -71,6 +71,27 @@ internal abstract class BlockCipherTransform : ICipherTransform
     public bool CanReuseTransform => true;
 
     /// <summary>
+    /// Gets a value indicating whether this transform is encrypting (<see langword="true"/>)
+    /// or decrypting (<see langword="false"/>).
+    /// </summary>
+    protected bool IsEncrypting => _encrypting;
+
+    /// <summary>
+    /// Gets the current cipher mode of operation.
+    /// </summary>
+    protected CipherMode CurrentMode => _mode;
+
+    /// <summary>
+    /// Gets a <see cref="Span{T}"/> over the current CBC feedback register.
+    /// </summary>
+    /// <remarks>
+    /// Subclasses may read and update this span directly when implementing a
+    /// bulk CBC override of <see cref="TransformBlock(ReadOnlySpan{byte},Span{byte})"/> to avoid per-block
+    /// virtual dispatch and intermediate buffer overhead.
+    /// </remarks>
+    protected Span<byte> FeedbackSpan => _feedback;
+
+    /// <summary>
     /// Encrypts a single 16-byte block.
     /// </summary>
     /// <param name="input">The 16-byte plaintext block.</param>

--- a/src/Security/Cryptography/Cipher/Camellia/CamelliaCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/Camellia/CamelliaCipherTransform.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Cipher;
 
 using System;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
 /// <summary>
@@ -34,6 +35,61 @@ internal sealed class CamelliaCipherTransform : BlockCipherTransform
     {
         _subkeys = new ulong[CamelliaCore.MaxSubkeys];
         _rounds = CamelliaCore.ExpandKey(key, _subkeys);
+    }
+
+    /// <inheritdoc/>
+    public override int TransformBlock(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        // Only the hot CBC path is overridden here; all other modes fall through to the base
+        // class, which handles them correctly. This avoids per-block virtual dispatch,
+        // per-block stackalloc, and byte-by-byte XOR by operating directly on ulong pairs.
+        int blocks = input.Length / 16;
+        if (CurrentMode != CipherMode.CBC || input.Length < 16 || output.Length < blocks * 16)
+            return base.TransformBlock(input, output);
+        ReadOnlySpan<ulong> sk = _subkeys;
+        int rds = _rounds;
+        Span<byte> fb = FeedbackSpan;
+
+        if (IsEncrypting)
+        {
+            ulong fbk0 = BinaryPrimitives.ReadUInt64BigEndian(fb);
+            ulong fbk1 = BinaryPrimitives.ReadUInt64BigEndian(fb.Slice(8));
+            for (int i = 0; i < blocks; i++)
+            {
+                ReadOnlySpan<byte> inBlk = input.Slice(i * 16, 16);
+                Span<byte> outBlk = output.Slice(i * 16, 16);
+                ulong d1 = BinaryPrimitives.ReadUInt64BigEndian(inBlk) ^ fbk0;
+                ulong d2 = BinaryPrimitives.ReadUInt64BigEndian(inBlk.Slice(8)) ^ fbk1;
+                CamelliaCore.EncryptBlock(d1, d2, out ulong r1, out ulong r2, sk, rds);
+                BinaryPrimitives.WriteUInt64BigEndian(outBlk, r1);
+                BinaryPrimitives.WriteUInt64BigEndian(outBlk.Slice(8), r2);
+                fbk0 = r1;
+                fbk1 = r2;
+            }
+            BinaryPrimitives.WriteUInt64BigEndian(fb, fbk0);
+            BinaryPrimitives.WriteUInt64BigEndian(fb.Slice(8), fbk1);
+        }
+        else
+        {
+            ulong fbk0 = BinaryPrimitives.ReadUInt64BigEndian(fb);
+            ulong fbk1 = BinaryPrimitives.ReadUInt64BigEndian(fb.Slice(8));
+            for (int i = 0; i < blocks; i++)
+            {
+                ReadOnlySpan<byte> inBlk = input.Slice(i * 16, 16);
+                Span<byte> outBlk = output.Slice(i * 16, 16);
+                ulong in0 = BinaryPrimitives.ReadUInt64BigEndian(inBlk);
+                ulong in1 = BinaryPrimitives.ReadUInt64BigEndian(inBlk.Slice(8));
+                CamelliaCore.DecryptBlock(in0, in1, out ulong r1, out ulong r2, sk, rds);
+                BinaryPrimitives.WriteUInt64BigEndian(outBlk, r1 ^ fbk0);
+                BinaryPrimitives.WriteUInt64BigEndian(outBlk.Slice(8), r2 ^ fbk1);
+                fbk0 = in0;
+                fbk1 = in1;
+            }
+            BinaryPrimitives.WriteUInt64BigEndian(fb, fbk0);
+            BinaryPrimitives.WriteUInt64BigEndian(fb.Slice(8), fbk1);
+        }
+
+        return blocks * 16;
     }
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Cipher/Camellia/CamelliaCore.cs
+++ b/src/Security/Cryptography/Cipher/Camellia/CamelliaCore.cs
@@ -136,7 +136,7 @@ internal static class CamelliaCore
             _sp1[i] = (s1 << 56) | (s1 << 48) | (s1 << 40) | (s1 << 24) | s1;
             _sp2[i] = (s2 << 48) | (s2 << 40) | (s2 << 32) | (s2 << 24) | (s2 << 16);
             _sp3[i] = (s3 << 56) | (s3 << 40) | (s3 << 32) | (s3 << 16) | (s3 << 8);
-            _sp4[i] = (s4 << 56) | (s4 << 48) | (s4 << 32) | (s4 << 8)  | s4;
+            _sp4[i] = (s4 << 56) | (s4 << 48) | (s4 << 32) | (s4 << 8) | s4;
             _sp5[i] = (s2 << 48) | (s2 << 40) | (s2 << 32) | (s2 << 16) | (s2 << 8) | s2;
             _sp6[i] = (s3 << 56) | (s3 << 40) | (s3 << 32) | (s3 << 24) | (s3 << 8) | s3;
             _sp7[i] = (s4 << 56) | (s4 << 48) | (s4 << 32) | (s4 << 24) | (s4 << 16) | s4;
@@ -436,7 +436,7 @@ internal static class CamelliaCore
              ^ Unsafe.Add(ref r4, (byte)(x >> 32))
              ^ Unsafe.Add(ref r5, (byte)(x >> 24))
              ^ Unsafe.Add(ref r6, (byte)(x >> 16))
-             ^ Unsafe.Add(ref r7, (byte)(x >>  8))
+             ^ Unsafe.Add(ref r7, (byte)(x >> 8))
              ^ Unsafe.Add(ref r8, (byte)x);
     }
 

--- a/src/Security/Cryptography/Cipher/Camellia/CamelliaCore.cs
+++ b/src/Security/Cryptography/Cipher/Camellia/CamelliaCore.cs
@@ -414,14 +414,12 @@ internal static class CamelliaCore
     /// Each byte of <c>input ^ key</c> is looked up in a precomputed SP-box table
     /// that combines the S-box and the P-function column for that byte position.
     /// The eight 64-bit table values are XOR-folded to produce the F-function output.
-    /// <see cref="MemoryMarshal.GetArrayDataReference"/> combined with
-    /// <see cref="Unsafe.Add{T}(ref T, int)"/> is used to bypass redundant JIT bounds checks,
-    /// since the index is always a <see cref="byte"/> in [0, 255] and each table has exactly 256 entries.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ulong F(ulong input, ulong key)
     {
         ulong x = input ^ key;
+#if NET6_0_OR_GREATER
         ref ulong r1 = ref MemoryMarshal.GetArrayDataReference(_sp1);
         ref ulong r2 = ref MemoryMarshal.GetArrayDataReference(_sp2);
         ref ulong r3 = ref MemoryMarshal.GetArrayDataReference(_sp3);
@@ -438,6 +436,27 @@ internal static class CamelliaCore
              ^ Unsafe.Add(ref r6, (byte)(x >> 16))
              ^ Unsafe.Add(ref r7, (byte)(x >> 8))
              ^ Unsafe.Add(ref r8, (byte)x);
+#else
+        // Fallback implementation for .NET Framework: use safe array indexing.
+        // This avoids MemoryMarshal / Unsafe APIs not available on older TFMs.
+        int b1 = (int)((x >> 56) & 0xFF);
+        int b2 = (int)((x >> 48) & 0xFF);
+        int b3 = (int)((x >> 40) & 0xFF);
+        int b4 = (int)((x >> 32) & 0xFF);
+        int b5 = (int)((x >> 24) & 0xFF);
+        int b6 = (int)((x >> 16) & 0xFF);
+        int b7 = (int)((x >> 8) & 0xFF);
+        int b8 = (int)(x & 0xFF);
+
+        return _sp1[b1]
+             ^ _sp2[b2]
+             ^ _sp3[b3]
+             ^ _sp4[b4]
+             ^ _sp5[b5]
+             ^ _sp6[b6]
+             ^ _sp7[b7]
+             ^ _sp8[b8];
+#endif
     }
 
     /// <summary>

--- a/src/Security/Cryptography/Cipher/Camellia/CamelliaCore.cs
+++ b/src/Security/Cryptography/Cipher/Camellia/CamelliaCore.cs
@@ -5,7 +5,9 @@ namespace CryptoHives.Foundation.Security.Cryptography.Cipher;
 
 using System;
 using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 /// <summary>
 /// Core Camellia block cipher operations shared by all key sizes.
@@ -17,6 +19,17 @@ using System.Runtime.CompilerServices;
 /// It uses an 18-round Feistel network for 128-bit keys and a 24-round Feistel
 /// network for 192- and 256-bit keys, with FL/FL⁻¹ key-dependent functions
 /// inserted every 6 rounds.
+/// </para>
+/// <para>
+/// <b>Implementation notes:</b>
+/// <list type="bullet">
+///   <item><description>
+///     The F-function is accelerated with 8 precomputed 256-entry SP-box tables
+///     (16 KB total). Each entry folds an S-box lookup together with that byte
+///     position's column of the P-function into a single 64-bit value, reducing
+///     per-round work to 8 table lookups and 7 XOR operations.
+///   </description></item>
+/// </list>
 /// </para>
 /// </remarks>
 internal static class CamelliaCore
@@ -48,28 +61,88 @@ internal static class CamelliaCore
     private const ulong Sigma5 = 0x10E527FADE682D1D;
     private const ulong Sigma6 = 0xB05688C2B3E6C1FD;
 
-    /// <summary>
-    /// SBOX1 lookup table from RFC 3713 Appendix A.
-    /// </summary>
-    private static ReadOnlySpan<byte> Sbox1 =>
-    [
-        112, 130,  44, 236, 179,  39, 192, 229, 228, 133,  87,  53, 234,  12, 174,  65,
-         35, 239, 107, 147,  69,  25, 165,  33, 237,  14,  79,  78,  29, 101, 146, 189,
-        134, 184, 175, 143, 124, 235,  31, 206,  62,  48, 220,  95,  94, 197,  11,  26,
-        166, 225,  57, 202, 213,  71,  93,  61, 217,   1,  90, 214,  81,  86, 108,  77,
-        139,  13, 154, 102, 251, 204, 176,  45, 116,  18,  43,  32, 240, 177, 132, 153,
-        223,  76, 203, 194,  52, 126, 118,   5, 109, 183, 169,  49, 209,  23,   4, 215,
-         20,  88,  58,  97, 222,  27,  17,  28,  50,  15, 156,  22,  83,  24, 242,  34,
-        254,  68, 207, 178, 195, 181, 122, 145,  36,   8, 232, 168,  96, 252, 105,  80,
-        170, 208, 160, 125, 161, 137,  98, 151,  84,  91,  30, 149, 224, 255, 100, 210,
-         16, 196,   0,  72, 163, 247, 117, 219, 138,   3, 230, 218,   9,  63, 221, 148,
-        135,  92, 131,   2, 205,  74, 144,  51, 115, 103, 246, 243, 157, 127, 191, 226,
-         82, 155, 216,  38, 200,  55, 198,  59, 129, 150, 111,  75,  19, 190,  99,  46,
-        233, 121, 167, 140, 159, 110, 188, 142,  41, 245, 249, 182,  47, 253, 180,  89,
-        120, 152,   6, 106, 231,  70, 113, 186, 212,  37, 171,  66, 136, 162, 141, 250,
-        114,   7, 185,  85, 248, 238, 172,  10,  54,  73,  42, 104,  60,  56, 241, 164,
-         64,  40, 211, 123, 187, 201,  67, 193,  21, 227, 173, 244, 119, 199, 128, 158,
-    ];
+    // ========================================================================
+    // SP-box tables for the F-function
+    // ========================================================================
+    //
+    // Each of the 8 tables has 256 ulong entries. Entry SP_n[b] combines:
+    //   - the S-box applied to the raw input byte b for position n, and
+    //   - the P-function column contribution for that position.
+    //
+    // The P-function from RFC 3713 defines which of y1..y8 each t_n feeds:
+    //   t1 (SBOX1): y1,y2,y3,y5,y8     → shifts 56,48,40,24, 0
+    //   t2 (SBOX2): y2,y3,y4,y5,y6     → shifts 48,40,32,24,16
+    //   t3 (SBOX3): y1,y3,y4,y6,y7     → shifts 56,40,32,16, 8
+    //   t4 (SBOX4): y1,y2,y4,y7,y8     → shifts 56,48,32, 8, 0
+    //   t5 (SBOX2): y2,y3,y4,y6,y7,y8  → shifts 48,40,32,16, 8, 0
+    //   t6 (SBOX3): y1,y3,y4,y5,y7,y8  → shifts 56,40,32,24, 8, 0
+    //   t7 (SBOX4): y1,y2,y4,y5,y6,y8  → shifts 56,48,32,24,16, 0
+    //   t8 (SBOX1): y1,y2,y3,y5,y6,y7  → shifts 56,48,40,24,16, 8
+    //
+    // S-box variants (RFC 3713, Section 2.4.1):
+    //   SBOX1[b] = sbox1[b]
+    //   SBOX2[b] = RotL8(sbox1[b], 1)
+    //   SBOX3[b] = RotL8(sbox1[b], 7)
+    //   SBOX4[b] = sbox1[RotL8(b, 1)]
+
+    private static readonly ulong[] _sp1;
+    private static readonly ulong[] _sp2;
+    private static readonly ulong[] _sp3;
+    private static readonly ulong[] _sp4;
+    private static readonly ulong[] _sp5;
+    private static readonly ulong[] _sp6;
+    private static readonly ulong[] _sp7;
+    private static readonly ulong[] _sp8;
+
+    [SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "All 8 SP tables share a single 256-iteration initialization loop for efficiency.")]
+    static CamelliaCore()
+    {
+        _sp1 = new ulong[256];
+        _sp2 = new ulong[256];
+        _sp3 = new ulong[256];
+        _sp4 = new ulong[256];
+        _sp5 = new ulong[256];
+        _sp6 = new ulong[256];
+        _sp7 = new ulong[256];
+        _sp8 = new ulong[256];
+
+        ReadOnlySpan<byte> sbox1 =
+        [
+            112, 130,  44, 236, 179,  39, 192, 229, 228, 133,  87,  53, 234,  12, 174,  65,
+             35, 239, 107, 147,  69,  25, 165,  33, 237,  14,  79,  78,  29, 101, 146, 189,
+            134, 184, 175, 143, 124, 235,  31, 206,  62,  48, 220,  95,  94, 197,  11,  26,
+            166, 225,  57, 202, 213,  71,  93,  61, 217,   1,  90, 214,  81,  86, 108,  77,
+            139,  13, 154, 102, 251, 204, 176,  45, 116,  18,  43,  32, 240, 177, 132, 153,
+            223,  76, 203, 194,  52, 126, 118,   5, 109, 183, 169,  49, 209,  23,   4, 215,
+             20,  88,  58,  97, 222,  27,  17,  28,  50,  15, 156,  22,  83,  24, 242,  34,
+            254,  68, 207, 178, 195, 181, 122, 145,  36,   8, 232, 168,  96, 252, 105,  80,
+            170, 208, 160, 125, 161, 137,  98, 151,  84,  91,  30, 149, 224, 255, 100, 210,
+             16, 196,   0,  72, 163, 247, 117, 219, 138,   3, 230, 218,   9,  63, 221, 148,
+            135,  92, 131,   2, 205,  74, 144,  51, 115, 103, 246, 243, 157, 127, 191, 226,
+             82, 155, 216,  38, 200,  55, 198,  59, 129, 150, 111,  75,  19, 190,  99,  46,
+            233, 121, 167, 140, 159, 110, 188, 142,  41, 245, 249, 182,  47, 253, 180,  89,
+            120, 152,   6, 106, 231,  70, 113, 186, 212,  37, 171,  66, 136, 162, 141, 250,
+            114,   7, 185,  85, 248, 238, 172,  10,  54,  73,  42, 104,  60,  56, 241, 164,
+             64,  40, 211, 123, 187, 201,  67, 193,  21, 227, 173, 244, 119, 199, 128, 158,
+        ];
+
+        for (int i = 0; i < 256; i++)
+        {
+            ulong s1 = sbox1[i];
+            ulong s2 = (ulong)((s1 << 1) | (s1 >> 7)) & 0xFF;   // RotL8(s1, 1)
+            ulong s3 = (ulong)((s1 << 7) | (s1 >> 1)) & 0xFF;   // RotL8(s1, 7)
+            ulong s4 = sbox1[(byte)((i << 1) | (i >> 7))];       // SBOX4: sbox1[RotL8(i,1)]
+
+            _sp1[i] = (s1 << 56) | (s1 << 48) | (s1 << 40) | (s1 << 24) | s1;
+            _sp2[i] = (s2 << 48) | (s2 << 40) | (s2 << 32) | (s2 << 24) | (s2 << 16);
+            _sp3[i] = (s3 << 56) | (s3 << 40) | (s3 << 32) | (s3 << 16) | (s3 << 8);
+            _sp4[i] = (s4 << 56) | (s4 << 48) | (s4 << 32) | (s4 << 8)  | s4;
+            _sp5[i] = (s2 << 48) | (s2 << 40) | (s2 << 32) | (s2 << 16) | (s2 << 8) | s2;
+            _sp6[i] = (s3 << 56) | (s3 << 40) | (s3 << 32) | (s3 << 24) | (s3 << 8) | s3;
+            _sp7[i] = (s4 << 56) | (s4 << 48) | (s4 << 32) | (s4 << 24) | (s4 << 16) | s4;
+            _sp8[i] = (s1 << 56) | (s1 << 48) | (s1 << 40) | (s1 << 24) | (s1 << 16) | (s1 << 8);
+        }
+    }
 
     /// <summary>
     /// Expands a cipher key into the subkey array used by encrypt/decrypt.
@@ -145,7 +218,23 @@ internal static class CamelliaCore
     {
         ulong d1 = BinaryPrimitives.ReadUInt64BigEndian(input);
         ulong d2 = BinaryPrimitives.ReadUInt64BigEndian(input.Slice(8));
+        EncryptBlock(d1, d2, out ulong r1, out ulong r2, subkeys, rounds);
+        BinaryPrimitives.WriteUInt64BigEndian(output, r1);
+        BinaryPrimitives.WriteUInt64BigEndian(output.Slice(8), r2);
+    }
 
+    /// <summary>
+    /// Encrypts a block supplied as two 64-bit halves, producing two 64-bit halves.
+    /// </summary>
+    /// <param name="d1">High 64 bits of plaintext (big-endian byte order).</param>
+    /// <param name="d2">Low 64 bits of plaintext (big-endian byte order).</param>
+    /// <param name="r1">High 64 bits of ciphertext (big-endian byte order).</param>
+    /// <param name="r2">Low 64 bits of ciphertext (big-endian byte order).</param>
+    /// <param name="subkeys">The expanded encryption subkeys.</param>
+    /// <param name="rounds">The number of rounds (18 or 24).</param>
+    internal static void EncryptBlock(ulong d1, ulong d2, out ulong r1, out ulong r2,
+        ReadOnlySpan<ulong> subkeys, int rounds)
+    {
         // Pre-whitening
         d1 ^= subkeys[0];
         d2 ^= subkeys[1];
@@ -188,8 +277,8 @@ internal static class CamelliaCore
         }
 
         // Output D2 || D1
-        BinaryPrimitives.WriteUInt64BigEndian(output, d2);
-        BinaryPrimitives.WriteUInt64BigEndian(output.Slice(8), d1);
+        r1 = d2;
+        r2 = d1;
     }
 
     /// <summary>
@@ -204,7 +293,23 @@ internal static class CamelliaCore
     {
         ulong d1 = BinaryPrimitives.ReadUInt64BigEndian(input);
         ulong d2 = BinaryPrimitives.ReadUInt64BigEndian(input.Slice(8));
+        DecryptBlock(d1, d2, out ulong r1, out ulong r2, subkeys, rounds);
+        BinaryPrimitives.WriteUInt64BigEndian(output, r1);
+        BinaryPrimitives.WriteUInt64BigEndian(output.Slice(8), r2);
+    }
 
+    /// <summary>
+    /// Decrypts a block supplied as two 64-bit halves, producing two 64-bit halves.
+    /// </summary>
+    /// <param name="d1">High 64 bits of ciphertext (big-endian byte order).</param>
+    /// <param name="d2">Low 64 bits of ciphertext (big-endian byte order).</param>
+    /// <param name="r1">High 64 bits of plaintext (big-endian byte order).</param>
+    /// <param name="r2">Low 64 bits of plaintext (big-endian byte order).</param>
+    /// <param name="subkeys">The expanded encryption subkeys (same array as for encryption).</param>
+    /// <param name="rounds">The number of rounds (18 or 24).</param>
+    internal static void DecryptBlock(ulong d1, ulong d2, out ulong r1, out ulong r2,
+        ReadOnlySpan<ulong> subkeys, int rounds)
+    {
         if (rounds == 24)
         {
             // Pre-whitening with kw3, kw4
@@ -268,8 +373,8 @@ internal static class CamelliaCore
         }
 
         // Output D2 || D1
-        BinaryPrimitives.WriteUInt64BigEndian(output, d2);
-        BinaryPrimitives.WriteUInt64BigEndian(output.Slice(8), d1);
+        r1 = d2;
+        r2 = d1;
     }
 
     /// <summary>
@@ -305,32 +410,34 @@ internal static class CamelliaCore
     /// <summary>
     /// Camellia F-function: applies S-boxes and the P-function mixing layer.
     /// </summary>
+    /// <remarks>
+    /// Each byte of <c>input ^ key</c> is looked up in a precomputed SP-box table
+    /// that combines the S-box and the P-function column for that byte position.
+    /// The eight 64-bit table values are XOR-folded to produce the F-function output.
+    /// <see cref="MemoryMarshal.GetArrayDataReference"/> combined with
+    /// <see cref="Unsafe.Add{T}(ref T, int)"/> is used to bypass redundant JIT bounds checks,
+    /// since the index is always a <see cref="byte"/> in [0, 255] and each table has exactly 256 entries.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ulong F(ulong input, ulong key)
     {
         ulong x = input ^ key;
-
-        byte t1 = Sbox1[(byte)(x >> 56)];
-        byte t2 = RotateLeft8(Sbox1[(byte)(x >> 48)], 1);  // SBOX2
-        byte t3 = RotateLeft8(Sbox1[(byte)(x >> 40)], 7);  // SBOX3
-        byte t4 = Sbox1[RotateLeft8((byte)(x >> 32), 1)];  // SBOX4
-        byte t5 = RotateLeft8(Sbox1[(byte)(x >> 24)], 1);  // SBOX2
-        byte t6 = RotateLeft8(Sbox1[(byte)(x >> 16)], 7);  // SBOX3
-        byte t7 = Sbox1[RotateLeft8((byte)(x >> 8), 1)];   // SBOX4
-        byte t8 = Sbox1[(byte)x];
-
-        // P-function
-        byte y1 = (byte)(t1 ^ t3 ^ t4 ^ t6 ^ t7 ^ t8);
-        byte y2 = (byte)(t1 ^ t2 ^ t4 ^ t5 ^ t7 ^ t8);
-        byte y3 = (byte)(t1 ^ t2 ^ t3 ^ t5 ^ t6 ^ t8);
-        byte y4 = (byte)(t2 ^ t3 ^ t4 ^ t5 ^ t6 ^ t7);
-        byte y5 = (byte)(t1 ^ t2 ^ t6 ^ t7 ^ t8);
-        byte y6 = (byte)(t2 ^ t3 ^ t5 ^ t7 ^ t8);
-        byte y7 = (byte)(t3 ^ t4 ^ t5 ^ t6 ^ t8);
-        byte y8 = (byte)(t1 ^ t4 ^ t5 ^ t6 ^ t7);
-
-        return ((ulong)y1 << 56) | ((ulong)y2 << 48) | ((ulong)y3 << 40) | ((ulong)y4 << 32)
-             | ((ulong)y5 << 24) | ((ulong)y6 << 16) | ((ulong)y7 << 8) | y8;
+        ref ulong r1 = ref MemoryMarshal.GetArrayDataReference(_sp1);
+        ref ulong r2 = ref MemoryMarshal.GetArrayDataReference(_sp2);
+        ref ulong r3 = ref MemoryMarshal.GetArrayDataReference(_sp3);
+        ref ulong r4 = ref MemoryMarshal.GetArrayDataReference(_sp4);
+        ref ulong r5 = ref MemoryMarshal.GetArrayDataReference(_sp5);
+        ref ulong r6 = ref MemoryMarshal.GetArrayDataReference(_sp6);
+        ref ulong r7 = ref MemoryMarshal.GetArrayDataReference(_sp7);
+        ref ulong r8 = ref MemoryMarshal.GetArrayDataReference(_sp8);
+        return Unsafe.Add(ref r1, (byte)(x >> 56))
+             ^ Unsafe.Add(ref r2, (byte)(x >> 48))
+             ^ Unsafe.Add(ref r3, (byte)(x >> 40))
+             ^ Unsafe.Add(ref r4, (byte)(x >> 32))
+             ^ Unsafe.Add(ref r5, (byte)(x >> 24))
+             ^ Unsafe.Add(ref r6, (byte)(x >> 16))
+             ^ Unsafe.Add(ref r7, (byte)(x >>  8))
+             ^ Unsafe.Add(ref r8, (byte)x);
     }
 
     /// <summary>
@@ -365,12 +472,6 @@ internal static class CamelliaCore
         y2 ^= RotateLeft32(y1 & k1, 1);
 
         return ((ulong)y1 << 32) | y2;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static byte RotateLeft8(byte value, int shift)
-    {
-        return (byte)((value << shift) | (value >> (8 - shift)));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Security/Cryptography/Cipher/Kalyna/KalynaCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/KalynaCipherTransform.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Cipher;
 
 using System;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
 /// <summary>
@@ -11,9 +12,7 @@ using System.Runtime.CompilerServices;
 /// </summary>
 internal sealed class KalynaCipherTransform : BlockCipherTransform
 {
-    private readonly byte[] _roundKeys;
-    private readonly int _rounds;
-    private readonly bool _encrypting;
+    private KalynaCore _core;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KalynaCipherTransform"/> class.
@@ -21,28 +20,80 @@ internal sealed class KalynaCipherTransform : BlockCipherTransform
     public KalynaCipherTransform(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv, bool encrypting, CipherMode mode, PaddingMode padding)
         : base(iv, encrypting, mode, padding)
     {
-        _encrypting = encrypting;
-        _roundKeys = new byte[15 * 16]; // Max: 14 rounds + 1 = 15 round keys
-        _rounds = KalynaCore.ExpandKey(key, _roundKeys);
+        _core = KalynaCore.Create(key);
+    }
+
+    /// <inheritdoc/>
+    public override int TransformBlock(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        // Only the hot CBC path is overridden here; all other modes fall through to the base
+        // class. This avoids per-block virtual dispatch, per-block stackalloc, and byte-by-byte
+        // XOR by operating directly on ulong pairs in little-endian byte order.
+        int blocks = input.Length / 16;
+        if (CurrentMode != CipherMode.CBC || input.Length < 16 || output.Length < blocks * 16)
+            return base.TransformBlock(input, output);
+        Span<byte> fb = FeedbackSpan;
+
+        if (IsEncrypting)
+        {
+            ulong fbk0 = BinaryPrimitives.ReadUInt64LittleEndian(fb);
+            ulong fbk1 = BinaryPrimitives.ReadUInt64LittleEndian(fb.Slice(8));
+            for (int i = 0; i < blocks; i++)
+            {
+                ReadOnlySpan<byte> inBlk = input.Slice(i * 16, 16);
+                Span<byte> outBlk = output.Slice(i * 16, 16);
+                ulong w0 = BinaryPrimitives.ReadUInt64LittleEndian(inBlk) ^ fbk0;
+                ulong w1 = BinaryPrimitives.ReadUInt64LittleEndian(inBlk.Slice(8)) ^ fbk1;
+                _core.EncryptBlock(ref w0, ref w1);
+                BinaryPrimitives.WriteUInt64LittleEndian(outBlk, w0);
+                BinaryPrimitives.WriteUInt64LittleEndian(outBlk.Slice(8), w1);
+                fbk0 = w0;
+                fbk1 = w1;
+            }
+            BinaryPrimitives.WriteUInt64LittleEndian(fb, fbk0);
+            BinaryPrimitives.WriteUInt64LittleEndian(fb.Slice(8), fbk1);
+        }
+        else
+        {
+            ulong fbk0 = BinaryPrimitives.ReadUInt64LittleEndian(fb);
+            ulong fbk1 = BinaryPrimitives.ReadUInt64LittleEndian(fb.Slice(8));
+            for (int i = 0; i < blocks; i++)
+            {
+                ReadOnlySpan<byte> inBlk = input.Slice(i * 16, 16);
+                Span<byte> outBlk = output.Slice(i * 16, 16);
+                ulong in0 = BinaryPrimitives.ReadUInt64LittleEndian(inBlk);
+                ulong in1 = BinaryPrimitives.ReadUInt64LittleEndian(inBlk.Slice(8));
+                ulong w0 = in0, w1 = in1;
+                _core.DecryptBlock(ref w0, ref w1);
+                BinaryPrimitives.WriteUInt64LittleEndian(outBlk, w0 ^ fbk0);
+                BinaryPrimitives.WriteUInt64LittleEndian(outBlk.Slice(8), w1 ^ fbk1);
+                fbk0 = in0;
+                fbk1 = in1;
+            }
+            BinaryPrimitives.WriteUInt64LittleEndian(fb, fbk0);
+            BinaryPrimitives.WriteUInt64LittleEndian(fb.Slice(8), fbk1);
+        }
+
+        return blocks * 16;
     }
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     protected override void EncryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
-        KalynaCore.EncryptBlock(input, output, _roundKeys, _rounds);
+        _core.EncryptBlock(input, output);
     }
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     protected override void DecryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
-        KalynaCore.DecryptBlock(input, output, _roundKeys, _rounds);
+        _core.DecryptBlock(input, output);
     }
 
     /// <inheritdoc/>
     protected override void ClearState()
     {
-        Array.Clear(_roundKeys, 0, _roundKeys.Length);
+        _core = default;
     }
 }

--- a/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
@@ -5,7 +5,9 @@ namespace CryptoHives.Foundation.Security.Cryptography.Cipher;
 
 using System;
 using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 /// <summary>
 /// Core Kalyna (DSTU 7624:2014) block cipher operations for 128-bit block size.
@@ -13,13 +15,18 @@ using System.Runtime.CompilerServices;
 /// <remarks>
 /// Kalyna is the Ukrainian national standard block cipher. This implementation
 /// supports 128-bit blocks with 128-bit or 256-bit keys (10 or 14 rounds).
+/// State is stored as a pair of 64-bit words in little-endian byte order,
+/// matching the DSTU 7624:2014 specification.
 /// </remarks>
-internal static class KalynaCore
+[SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "Forward and inverse T-tables share a single initialization loop for efficiency.")]
+internal unsafe struct KalynaCore
 {
     public const int BlockSizeBytes = 16;
 
-    // Number of 64-bit words in a 128-bit block
     private const int NumWords = 2;
+
+    private fixed ulong _roundKeys[30]; // MaxRoundKeyCount: 15 round keys × 2 ulongs (up to 14 rounds)
+    private int _rounds;
 
     // S-boxes from DSTU 7624:2014
     private static ReadOnlySpan<byte> S0 =>
@@ -102,65 +109,310 @@ internal static class KalynaCore
         0x64, 0x6D, 0xDC, 0xF0, 0x59, 0xA9, 0x4C, 0x17, 0x7F, 0x91, 0xB8, 0xC9, 0x57, 0x1B, 0xE0, 0x61
     ];
 
-    // Inverse S-boxes (computed from S0-S3)
+    // Inverse S-boxes (IS_i[y] = x such that S_i[x] = y)
     private static readonly byte[] IS0 = ComputeInverse(S0);
     private static readonly byte[] IS1 = ComputeInverse(S1);
     private static readonly byte[] IS2 = ComputeInverse(S2);
     private static readonly byte[] IS3 = ComputeInverse(S3);
 
-#if NOT_USED
-    // MDS matrix for MixColumns (8x8 matrix over GF(2^8))
-#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
-    private static readonly byte[,] MdsMatrix =
-    {
-        { 0x01, 0x01, 0x05, 0x01, 0x08, 0x06, 0x07, 0x04 },
-        { 0x04, 0x01, 0x01, 0x05, 0x01, 0x08, 0x06, 0x07 },
-        { 0x07, 0x04, 0x01, 0x01, 0x05, 0x01, 0x08, 0x06 },
-        { 0x06, 0x07, 0x04, 0x01, 0x01, 0x05, 0x01, 0x08 },
-        { 0x08, 0x06, 0x07, 0x04, 0x01, 0x01, 0x05, 0x01 },
-        { 0x01, 0x08, 0x06, 0x07, 0x04, 0x01, 0x01, 0x05 },
-        { 0x05, 0x01, 0x08, 0x06, 0x07, 0x04, 0x01, 0x01 },
-        { 0x01, 0x05, 0x01, 0x08, 0x06, 0x07, 0x04, 0x01 },
-    };
+    // Forward T-tables: TF_c[x] encodes all 8 MDS output bytes when input byte at column
+    // position c equals x. Byte r of TF_c[x] = GfMul(base[(c-r+8)%8], S[c%4][x]).
+    // Combines SubBytes + ShiftRows + MixColumns in a single 8-byte lookup per input byte.
+    // base = [01, 01, 05, 01, 08, 06, 07, 04] (forward MDS circulant row)
+    private static readonly ulong[] TF0 = new ulong[256];
+    private static readonly ulong[] TF1 = new ulong[256];
+    private static readonly ulong[] TF2 = new ulong[256];
+    private static readonly ulong[] TF3 = new ulong[256];
+    private static readonly ulong[] TF4 = new ulong[256];
+    private static readonly ulong[] TF5 = new ulong[256];
+    private static readonly ulong[] TF6 = new ulong[256];
+    private static readonly ulong[] TF7 = new ulong[256];
 
-    private static readonly byte[,] InvMdsMatrix =
-    {
-        { 0xAD, 0x95, 0x76, 0xA8, 0x2F, 0x49, 0xD7, 0xCA },
-        { 0xCA, 0xAD, 0x95, 0x76, 0xA8, 0x2F, 0x49, 0xD7 },
-        { 0xD7, 0xCA, 0xAD, 0x95, 0x76, 0xA8, 0x2F, 0x49 },
-        { 0x49, 0xD7, 0xCA, 0xAD, 0x95, 0x76, 0xA8, 0x2F },
-        { 0x2F, 0x49, 0xD7, 0xCA, 0xAD, 0x95, 0x76, 0xA8 },
-        { 0xA8, 0x2F, 0x49, 0xD7, 0xCA, 0xAD, 0x95, 0x76 },
-        { 0x76, 0xA8, 0x2F, 0x49, 0xD7, 0xCA, 0xAD, 0x95 },
-        { 0x95, 0x76, 0xA8, 0x2F, 0x49, 0xD7, 0xCA, 0xAD },
-    };
-#pragma warning restore CA1814
-#endif
+    // Inverse T-tables (partial): TI_c[x] encodes all 8 inverse-MDS output bytes without
+    // folding in InvSubBytes (IS0[0] ≠ 0 breaks superposition after the linear layer).
+    // Byte r of TI_c[x] = GfMul(invBase[(c-r+8)%8], x). InvShiftRows and InvSubBytes
+    // are applied separately in DecryptBlock.
+    // invBase = [AD, 95, 76, A8, 2F, 49, D7, CA] (inverse MDS circulant row)
+    private static readonly ulong[] TI0 = new ulong[256];
+    private static readonly ulong[] TI1 = new ulong[256];
+    private static readonly ulong[] TI2 = new ulong[256];
+    private static readonly ulong[] TI3 = new ulong[256];
+    private static readonly ulong[] TI4 = new ulong[256];
+    private static readonly ulong[] TI5 = new ulong[256];
+    private static readonly ulong[] TI6 = new ulong[256];
+    private static readonly ulong[] TI7 = new ulong[256];
 
-    // Precomputed GF(2^8) multiplication tables for forward MDS constants
+    // Precomputed GF(2^8) multiplication tables for forward MDS constants (used in key expansion)
     private static readonly byte[] Gf04 = ComputeGfMulTable(0x04);
     private static readonly byte[] Gf05 = ComputeGfMulTable(0x05);
     private static readonly byte[] Gf06 = ComputeGfMulTable(0x06);
     private static readonly byte[] Gf07 = ComputeGfMulTable(0x07);
     private static readonly byte[] Gf08 = ComputeGfMulTable(0x08);
 
-    // Precomputed GF(2^8) multiplication tables for inverse MDS constants
-    private static readonly byte[] Gf2F = ComputeGfMulTable(0x2F);
-    private static readonly byte[] Gf49 = ComputeGfMulTable(0x49);
-    private static readonly byte[] Gf76 = ComputeGfMulTable(0x76);
-    private static readonly byte[] Gf95 = ComputeGfMulTable(0x95);
-    private static readonly byte[] GfA8 = ComputeGfMulTable(0xA8);
-    private static readonly byte[] GfAD = ComputeGfMulTable(0xAD);
-    private static readonly byte[] GfCA = ComputeGfMulTable(0xCA);
-    private static readonly byte[] GfD7 = ComputeGfMulTable(0xD7);
+    static KalynaCore()
+    {
+        // Forward MDS circulant base row: [01, 01, 05, 01, 08, 06, 07, 04]
+        // Column position c uses S-box S[c%4]: S0, S1, S2, S3, S0, S1, S2, S3.
+        ReadOnlySpan<byte> fwdBase = [0x01, 0x01, 0x05, 0x01, 0x08, 0x06, 0x07, 0x04];
+        ulong[][] tf = [TF0, TF1, TF2, TF3, TF4, TF5, TF6, TF7];
+        for (int c = 0; c < 8; c++)
+        {
+            ulong[] table = tf[c];
+            for (int x = 0; x < 256; x++)
+            {
+                byte sx = (c & 3) switch { 0 => S0[x], 1 => S1[x], 2 => S2[x], _ => S3[x] };
+                ulong entry = 0;
+                for (int r = 0; r < 8; r++)
+                    entry |= (ulong)GfMul(fwdBase[(c - r + 8) & 7], sx) << (r * 8);
+                table[x] = entry;
+            }
+        }
+
+        // Inverse MDS circulant base row: [AD, 95, 76, A8, 2F, 49, D7, CA]
+        // No S-box applied — InvSubBytes is handled separately in DecryptBlock.
+        ReadOnlySpan<byte> invBase = [0xAD, 0x95, 0x76, 0xA8, 0x2F, 0x49, 0xD7, 0xCA];
+        ulong[][] ti = [TI0, TI1, TI2, TI3, TI4, TI5, TI6, TI7];
+        for (int c = 0; c < 8; c++)
+        {
+            ulong[] table = ti[c];
+            for (int x = 0; x < 256; x++)
+            {
+                ulong entry = 0;
+                for (int r = 0; r < 8; r++)
+                    entry |= (ulong)GfMul(invBase[(c - r + 8) & 7], (byte)x) << (r * 8);
+                table[x] = entry;
+            }
+        }
+    }
 
     /// <summary>
-    /// Expands a Kalyna cipher key into round keys.
+    /// Creates and initializes a new <see cref="KalynaCore"/> with expanded round keys.
     /// </summary>
     /// <param name="key">The cipher key (16 or 32 bytes for 128-bit block).</param>
-    /// <param name="roundKeys">Output buffer for round keys.</param>
-    /// <returns>Number of rounds (10 for 128-bit key, 14 for 256-bit key).</returns>
-    public static int ExpandKey(ReadOnlySpan<byte> key, Span<byte> roundKeys)
+    /// <returns>An initialized <see cref="KalynaCore"/> ready for use.</returns>
+    /// <exception cref="ArgumentException">Thrown when the key length is invalid.</exception>
+    internal static KalynaCore Create(ReadOnlySpan<byte> key)
+    {
+        Span<byte> rkBytes = stackalloc byte[15 * 16];
+        int nr = ExpandKey(key, rkBytes);
+
+        KalynaCore core = default;
+        core._rounds = nr;
+
+        KalynaCore* pCore = &core;
+        ulong* rk = pCore->_roundKeys;
+        for (int i = 0; i <= nr; i++)
+        {
+            rk[i * 2]     = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16));
+            rk[i * 2 + 1] = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16 + 8));
+        }
+
+        return core;
+    }
+
+    /// <summary>
+    /// Encrypts a single 16-byte block using Kalyna.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    internal void EncryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        ulong w0 = BinaryPrimitives.ReadUInt64LittleEndian(input);
+        ulong w1 = BinaryPrimitives.ReadUInt64LittleEndian(input.Slice(8));
+        EncryptBlock(ref w0, ref w1);
+        BinaryPrimitives.WriteUInt64LittleEndian(output, w0);
+        BinaryPrimitives.WriteUInt64LittleEndian(output.Slice(8), w1);
+    }
+
+    /// <summary>
+    /// Encrypts a block given as a ulong pair (little-endian), updating the values in-place.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    internal void EncryptBlock(ref ulong w0, ref ulong w1)
+    {
+        fixed (KalynaCore* pCore = &this)
+        {
+            ulong* rk = pCore->_roundKeys;
+            int nr = _rounds;
+
+            ref ulong rf0 = ref MemoryMarshal.GetArrayDataReference(TF0);
+            ref ulong rf1 = ref MemoryMarshal.GetArrayDataReference(TF1);
+            ref ulong rf2 = ref MemoryMarshal.GetArrayDataReference(TF2);
+            ref ulong rf3 = ref MemoryMarshal.GetArrayDataReference(TF3);
+            ref ulong rf4 = ref MemoryMarshal.GetArrayDataReference(TF4);
+            ref ulong rf5 = ref MemoryMarshal.GetArrayDataReference(TF5);
+            ref ulong rf6 = ref MemoryMarshal.GetArrayDataReference(TF6);
+            ref ulong rf7 = ref MemoryMarshal.GetArrayDataReference(TF7);
+
+            // Pre-whitening: modular addition with round key 0
+            ulong s0 = w0 + rk[0];
+            ulong s1 = w1 + rk[1];
+
+            for (int r = 1; r < nr; r++)
+            {
+                ulong n0 = Unsafe.Add(ref rf0, (byte)s0)
+                         ^ Unsafe.Add(ref rf1, (byte)(s0 >> 8))
+                         ^ Unsafe.Add(ref rf2, (byte)(s0 >> 16))
+                         ^ Unsafe.Add(ref rf3, (byte)(s0 >> 24))
+                         ^ Unsafe.Add(ref rf4, (byte)(s1 >> 32))
+                         ^ Unsafe.Add(ref rf5, (byte)(s1 >> 40))
+                         ^ Unsafe.Add(ref rf6, (byte)(s1 >> 48))
+                         ^ Unsafe.Add(ref rf7, (byte)(s1 >> 56));
+                ulong n1 = Unsafe.Add(ref rf0, (byte)s1)
+                         ^ Unsafe.Add(ref rf1, (byte)(s1 >> 8))
+                         ^ Unsafe.Add(ref rf2, (byte)(s1 >> 16))
+                         ^ Unsafe.Add(ref rf3, (byte)(s1 >> 24))
+                         ^ Unsafe.Add(ref rf4, (byte)(s0 >> 32))
+                         ^ Unsafe.Add(ref rf5, (byte)(s0 >> 40))
+                         ^ Unsafe.Add(ref rf6, (byte)(s0 >> 48))
+                         ^ Unsafe.Add(ref rf7, (byte)(s0 >> 56));
+                s0 = n0 ^ rk[r * 2];
+                s1 = n1 ^ rk[r * 2 + 1];
+            }
+
+            // Last round: T-table then post-whitening with modular addition
+            ulong m0 = Unsafe.Add(ref rf0, (byte)s0)
+                     ^ Unsafe.Add(ref rf1, (byte)(s0 >> 8))
+                     ^ Unsafe.Add(ref rf2, (byte)(s0 >> 16))
+                     ^ Unsafe.Add(ref rf3, (byte)(s0 >> 24))
+                     ^ Unsafe.Add(ref rf4, (byte)(s1 >> 32))
+                     ^ Unsafe.Add(ref rf5, (byte)(s1 >> 40))
+                     ^ Unsafe.Add(ref rf6, (byte)(s1 >> 48))
+                     ^ Unsafe.Add(ref rf7, (byte)(s1 >> 56));
+            ulong m1 = Unsafe.Add(ref rf0, (byte)s1)
+                     ^ Unsafe.Add(ref rf1, (byte)(s1 >> 8))
+                     ^ Unsafe.Add(ref rf2, (byte)(s1 >> 16))
+                     ^ Unsafe.Add(ref rf3, (byte)(s1 >> 24))
+                     ^ Unsafe.Add(ref rf4, (byte)(s0 >> 32))
+                     ^ Unsafe.Add(ref rf5, (byte)(s0 >> 40))
+                     ^ Unsafe.Add(ref rf6, (byte)(s0 >> 48))
+                     ^ Unsafe.Add(ref rf7, (byte)(s0 >> 56));
+            w0 = m0 + rk[nr * 2];
+            w1 = m1 + rk[nr * 2 + 1];
+        }
+    }
+
+    /// <summary>
+    /// Decrypts a single 16-byte block using Kalyna.
+    /// </summary>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    internal void DecryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        ulong w0 = BinaryPrimitives.ReadUInt64LittleEndian(input);
+        ulong w1 = BinaryPrimitives.ReadUInt64LittleEndian(input.Slice(8));
+        DecryptBlock(ref w0, ref w1);
+        BinaryPrimitives.WriteUInt64LittleEndian(output, w0);
+        BinaryPrimitives.WriteUInt64LittleEndian(output.Slice(8), w1);
+    }
+
+    /// <summary>
+    /// Decrypts a block given as a ulong pair (little-endian), updating the values in-place.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The full inverse round is: XorKey → InvMixColumns → InvShiftRows → InvSubBytes.
+    /// InvSubBytes cannot be folded into the InvMixColumns T-tables because IS0(0) ≠ 0,
+    /// so contributions do not superpose linearly after InvMixColumns. The partial TI tables
+    /// handle only InvMixColumns; InvShiftRows and InvSubBytes are applied separately.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    internal void DecryptBlock(ref ulong w0, ref ulong w1)
+    {
+        fixed (KalynaCore* pCore = &this)
+        {
+            ulong* rk = pCore->_roundKeys;
+            int nr = _rounds;
+
+            ref ulong ri0 = ref MemoryMarshal.GetArrayDataReference(TI0);
+            ref ulong ri1 = ref MemoryMarshal.GetArrayDataReference(TI1);
+            ref ulong ri2 = ref MemoryMarshal.GetArrayDataReference(TI2);
+            ref ulong ri3 = ref MemoryMarshal.GetArrayDataReference(TI3);
+            ref ulong ri4 = ref MemoryMarshal.GetArrayDataReference(TI4);
+            ref ulong ri5 = ref MemoryMarshal.GetArrayDataReference(TI5);
+            ref ulong ri6 = ref MemoryMarshal.GetArrayDataReference(TI6);
+            ref ulong ri7 = ref MemoryMarshal.GetArrayDataReference(TI7);
+
+            ref byte pIs0 = ref MemoryMarshal.GetArrayDataReference(IS0);
+            ref byte pIs1 = ref MemoryMarshal.GetArrayDataReference(IS1);
+            ref byte pIs2 = ref MemoryMarshal.GetArrayDataReference(IS2);
+            ref byte pIs3 = ref MemoryMarshal.GetArrayDataReference(IS3);
+
+            // Pre-whitening: modular subtraction with round key nr
+            ulong s0 = w0 - rk[nr * 2];
+            ulong s1 = w1 - rk[nr * 2 + 1];
+
+            // First round: InvMixColumns + InvShiftRows + InvSubBytes (no XOR key)
+            {
+                ulong imc0 = Unsafe.Add(ref ri0, (byte)s0) ^ Unsafe.Add(ref ri1, (byte)(s0 >> 8))
+                           ^ Unsafe.Add(ref ri2, (byte)(s0 >> 16)) ^ Unsafe.Add(ref ri3, (byte)(s0 >> 24))
+                           ^ Unsafe.Add(ref ri4, (byte)(s0 >> 32)) ^ Unsafe.Add(ref ri5, (byte)(s0 >> 40))
+                           ^ Unsafe.Add(ref ri6, (byte)(s0 >> 48)) ^ Unsafe.Add(ref ri7, (byte)(s0 >> 56));
+                ulong imc1 = Unsafe.Add(ref ri0, (byte)s1) ^ Unsafe.Add(ref ri1, (byte)(s1 >> 8))
+                           ^ Unsafe.Add(ref ri2, (byte)(s1 >> 16)) ^ Unsafe.Add(ref ri3, (byte)(s1 >> 24))
+                           ^ Unsafe.Add(ref ri4, (byte)(s1 >> 32)) ^ Unsafe.Add(ref ri5, (byte)(s1 >> 40))
+                           ^ Unsafe.Add(ref ri6, (byte)(s1 >> 48)) ^ Unsafe.Add(ref ri7, (byte)(s1 >> 56));
+                // InvShiftRows: swap bits 32-63 (rows 4-7) between columns
+                ulong isr0 = (imc0 & 0x00000000_FFFFFFFFul) | (imc1 & 0xFFFFFFFF_00000000ul);
+                ulong isr1 = (imc1 & 0x00000000_FFFFFFFFul) | (imc0 & 0xFFFFFFFF_00000000ul);
+                // InvSubBytes: IS0/IS1/IS2/IS3 cycle per byte (rows 0,4 → IS0; 1,5 → IS1; 2,6 → IS2; 3,7 → IS3)
+                s0 = (ulong)Unsafe.Add(ref pIs0, (byte)isr0)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr0 >> 8)) << 8)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr0 >> 16)) << 16)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr0 >> 24)) << 24)
+                   | ((ulong)Unsafe.Add(ref pIs0, (byte)(isr0 >> 32)) << 32)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr0 >> 40)) << 40)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr0 >> 48)) << 48)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr0 >> 56)) << 56);
+                s1 = (ulong)Unsafe.Add(ref pIs0, (byte)isr1)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr1 >> 8)) << 8)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr1 >> 16)) << 16)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr1 >> 24)) << 24)
+                   | ((ulong)Unsafe.Add(ref pIs0, (byte)(isr1 >> 32)) << 32)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr1 >> 40)) << 40)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr1 >> 48)) << 48)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr1 >> 56)) << 56);
+            }
+
+            // Remaining rounds: XOR key, then InvMixColumns + InvShiftRows + InvSubBytes
+            for (int r = nr - 1; r > 0; r--)
+            {
+                s0 ^= rk[r * 2];
+                s1 ^= rk[r * 2 + 1];
+                ulong imc0 = Unsafe.Add(ref ri0, (byte)s0) ^ Unsafe.Add(ref ri1, (byte)(s0 >> 8))
+                           ^ Unsafe.Add(ref ri2, (byte)(s0 >> 16)) ^ Unsafe.Add(ref ri3, (byte)(s0 >> 24))
+                           ^ Unsafe.Add(ref ri4, (byte)(s0 >> 32)) ^ Unsafe.Add(ref ri5, (byte)(s0 >> 40))
+                           ^ Unsafe.Add(ref ri6, (byte)(s0 >> 48)) ^ Unsafe.Add(ref ri7, (byte)(s0 >> 56));
+                ulong imc1 = Unsafe.Add(ref ri0, (byte)s1) ^ Unsafe.Add(ref ri1, (byte)(s1 >> 8))
+                           ^ Unsafe.Add(ref ri2, (byte)(s1 >> 16)) ^ Unsafe.Add(ref ri3, (byte)(s1 >> 24))
+                           ^ Unsafe.Add(ref ri4, (byte)(s1 >> 32)) ^ Unsafe.Add(ref ri5, (byte)(s1 >> 40))
+                           ^ Unsafe.Add(ref ri6, (byte)(s1 >> 48)) ^ Unsafe.Add(ref ri7, (byte)(s1 >> 56));
+                ulong isr0 = (imc0 & 0x00000000_FFFFFFFFul) | (imc1 & 0xFFFFFFFF_00000000ul);
+                ulong isr1 = (imc1 & 0x00000000_FFFFFFFFul) | (imc0 & 0xFFFFFFFF_00000000ul);
+                s0 = (ulong)Unsafe.Add(ref pIs0, (byte)isr0)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr0 >> 8)) << 8)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr0 >> 16)) << 16)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr0 >> 24)) << 24)
+                   | ((ulong)Unsafe.Add(ref pIs0, (byte)(isr0 >> 32)) << 32)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr0 >> 40)) << 40)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr0 >> 48)) << 48)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr0 >> 56)) << 56);
+                s1 = (ulong)Unsafe.Add(ref pIs0, (byte)isr1)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr1 >> 8)) << 8)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr1 >> 16)) << 16)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr1 >> 24)) << 24)
+                   | ((ulong)Unsafe.Add(ref pIs0, (byte)(isr1 >> 32)) << 32)
+                   | ((ulong)Unsafe.Add(ref pIs1, (byte)(isr1 >> 40)) << 40)
+                   | ((ulong)Unsafe.Add(ref pIs2, (byte)(isr1 >> 48)) << 48)
+                   | ((ulong)Unsafe.Add(ref pIs3, (byte)(isr1 >> 56)) << 56);
+            }
+
+            // Post-whitening: modular subtraction with round key 0
+            w0 = s0 - rk[0];
+            w1 = s1 - rk[1];
+        }
+    }
+
+    private static int ExpandKey(ReadOnlySpan<byte> key, Span<byte> roundKeys)
     {
         int nr = key.Length switch {
             16 => 10,
@@ -179,67 +431,6 @@ internal static class KalynaCore
             KeyExpandEvenOdd256(key, kt, roundKeys, nr);
 
         return nr;
-    }
-
-    /// <summary>
-    /// Encrypts a single 16-byte block using Kalyna.
-    /// </summary>
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    public static void EncryptBlock(ReadOnlySpan<byte> input, Span<byte> output, ReadOnlySpan<byte> roundKeys, int nr)
-    {
-        Span<byte> state = stackalloc byte[16];
-        input.Slice(0, 16).CopyTo(state);
-
-        // Pre-whitening: AddRoundKey (modular addition)
-        AddRoundKeyMod(state, roundKeys.Slice(0, 16));
-
-        for (int r = 1; r < nr; r++)
-        {
-            SubBytes(state);
-            ShiftRows(state);
-            MixColumns(state);
-            XorRoundKey(state, roundKeys.Slice(r * 16, 16));
-        }
-
-        // Last round
-        SubBytes(state);
-        ShiftRows(state);
-        MixColumns(state);
-
-        // Post-whitening: AddRoundKey (modular addition)
-        AddRoundKeyMod(state, roundKeys.Slice(nr * 16, 16));
-
-        state.CopyTo(output);
-    }
-
-    /// <summary>
-    /// Decrypts a single 16-byte block using Kalyna.
-    /// </summary>
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    public static void DecryptBlock(ReadOnlySpan<byte> input, Span<byte> output, ReadOnlySpan<byte> roundKeys, int nr)
-    {
-        Span<byte> state = stackalloc byte[16];
-        input.Slice(0, 16).CopyTo(state);
-
-        // Pre-whitening: SubRoundKey (modular subtraction)
-        SubRoundKeyMod(state, roundKeys.Slice(nr * 16, 16));
-
-        InvMixColumns(state);
-        InvShiftRows(state);
-        InvSubBytes(state);
-
-        for (int r = nr - 1; r > 0; r--)
-        {
-            XorRoundKey(state, roundKeys.Slice(r * 16, 16));
-            InvMixColumns(state);
-            InvShiftRows(state);
-            InvSubBytes(state);
-        }
-
-        // Post-whitening: SubRoundKey (modular subtraction)
-        SubRoundKeyMod(state, roundKeys.Slice(0, 16));
-
-        state.CopyTo(output);
     }
 
     private static void SubBytes(Span<byte> state)
@@ -261,38 +452,11 @@ internal static class KalynaCore
         }
     }
 
-    private static void InvSubBytes(Span<byte> state)
-    {
-        for (int col = 0; col < NumWords; col++)
-        {
-            int off = col * 8;
-            state[off + 0] = IS0[state[off + 0]];
-            state[off + 1] = IS1[state[off + 1]];
-            state[off + 2] = IS2[state[off + 2]];
-            state[off + 3] = IS3[state[off + 3]];
-            state[off + 4] = IS0[state[off + 4]];
-            state[off + 5] = IS1[state[off + 5]];
-            state[off + 6] = IS2[state[off + 6]];
-            state[off + 7] = IS3[state[off + 7]];
-        }
-    }
-
     private static void ShiftRows(Span<byte> state)
     {
         // For 128-bit block (2 columns): swap rows 4-7 between columns
         for (int row = 4; row < 8; row++)
-        {
             (state[row], state[8 + row]) = (state[8 + row], state[row]);
-        }
-    }
-
-    private static void InvShiftRows(Span<byte> state)
-    {
-        // For 128-bit block: inverse is the same swap
-        for (int row = 4; row < 8; row++)
-        {
-            (state[row], state[8 + row]) = (state[8 + row], state[row]);
-        }
     }
 
     private static void MixColumns(Span<byte> state)
@@ -316,28 +480,6 @@ internal static class KalynaCore
         }
     }
 
-    private static void InvMixColumns(Span<byte> state)
-    {
-        // Unrolled inverse MDS matrix multiply using precomputed GF(2^8) lookup tables.
-        // Inverse MDS row pattern (circulant): AD, 95, 76, A8, 2F, 49, D7, CA
-        for (int col = 0; col < NumWords; col++)
-        {
-            int off = col * 8;
-            byte b0 = state[off], b1 = state[off + 1], b2 = state[off + 2], b3 = state[off + 3];
-            byte b4 = state[off + 4], b5 = state[off + 5], b6 = state[off + 6], b7 = state[off + 7];
-
-            state[off + 0] = (byte)(GfAD[b0] ^ Gf95[b1] ^ Gf76[b2] ^ GfA8[b3] ^ Gf2F[b4] ^ Gf49[b5] ^ GfD7[b6] ^ GfCA[b7]);
-            state[off + 1] = (byte)(GfCA[b0] ^ GfAD[b1] ^ Gf95[b2] ^ Gf76[b3] ^ GfA8[b4] ^ Gf2F[b5] ^ Gf49[b6] ^ GfD7[b7]);
-            state[off + 2] = (byte)(GfD7[b0] ^ GfCA[b1] ^ GfAD[b2] ^ Gf95[b3] ^ Gf76[b4] ^ GfA8[b5] ^ Gf2F[b6] ^ Gf49[b7]);
-            state[off + 3] = (byte)(Gf49[b0] ^ GfD7[b1] ^ GfCA[b2] ^ GfAD[b3] ^ Gf95[b4] ^ Gf76[b5] ^ GfA8[b6] ^ Gf2F[b7]);
-            state[off + 4] = (byte)(Gf2F[b0] ^ Gf49[b1] ^ GfD7[b2] ^ GfCA[b3] ^ GfAD[b4] ^ Gf95[b5] ^ Gf76[b6] ^ GfA8[b7]);
-            state[off + 5] = (byte)(GfA8[b0] ^ Gf2F[b1] ^ Gf49[b2] ^ GfD7[b3] ^ GfCA[b4] ^ GfAD[b5] ^ Gf95[b6] ^ Gf76[b7]);
-            state[off + 6] = (byte)(Gf76[b0] ^ GfA8[b1] ^ Gf2F[b2] ^ Gf49[b3] ^ GfD7[b4] ^ GfCA[b5] ^ GfAD[b6] ^ Gf95[b7]);
-            state[off + 7] = (byte)(Gf95[b0] ^ Gf76[b1] ^ GfA8[b2] ^ Gf2F[b3] ^ Gf49[b4] ^ GfD7[b5] ^ GfCA[b6] ^ GfAD[b7]);
-        }
-    }
-
-    // GF(2^8) multiplication with polynomial x^8 + x^4 + x^3 + x^2 + 1 (0x11D)
     private static byte GfMul(byte a, byte b)
     {
         byte result = 0;
@@ -362,16 +504,6 @@ internal static class KalynaCore
             ulong s = BinaryPrimitives.ReadUInt64LittleEndian(state.Slice(i * 8));
             ulong k = BinaryPrimitives.ReadUInt64LittleEndian(roundKey.Slice(i * 8));
             BinaryPrimitives.WriteUInt64LittleEndian(state.Slice(i * 8), s + k);
-        }
-    }
-
-    private static void SubRoundKeyMod(Span<byte> state, ReadOnlySpan<byte> roundKey)
-    {
-        for (int i = 0; i < NumWords; i++)
-        {
-            ulong s = BinaryPrimitives.ReadUInt64LittleEndian(state.Slice(i * 8));
-            ulong k = BinaryPrimitives.ReadUInt64LittleEndian(roundKey.Slice(i * 8));
-            BinaryPrimitives.WriteUInt64LittleEndian(state.Slice(i * 8), s - k);
         }
     }
 

--- a/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
@@ -163,7 +163,10 @@ internal unsafe struct KalynaCore
                 byte sx = (c & 3) switch { 0 => S0[x], 1 => S1[x], 2 => S2[x], _ => S3[x] };
                 ulong entry = 0;
                 for (int r = 0; r < 8; r++)
+                {
                     entry |= (ulong)GfMul(fwdBase[(c - r + 8) & 7], sx) << (r * 8);
+                }
+
                 table[x] = entry;
             }
         }
@@ -179,7 +182,10 @@ internal unsafe struct KalynaCore
             {
                 ulong entry = 0;
                 for (int r = 0; r < 8; r++)
+                {
                     entry |= (ulong)GfMul(invBase[(c - r + 8) & 7], (byte)x) << (r * 8);
+                }
+
                 table[x] = entry;
             }
         }
@@ -234,6 +240,7 @@ internal unsafe struct KalynaCore
             ulong* rk = pCore->_roundKeys;
             int nr = _rounds;
 
+#if NET5_0_OR_GREATER
             ref ulong rf0 = ref MemoryMarshal.GetArrayDataReference(TF0);
             ref ulong rf1 = ref MemoryMarshal.GetArrayDataReference(TF1);
             ref ulong rf2 = ref MemoryMarshal.GetArrayDataReference(TF2);
@@ -242,6 +249,16 @@ internal unsafe struct KalynaCore
             ref ulong rf5 = ref MemoryMarshal.GetArrayDataReference(TF5);
             ref ulong rf6 = ref MemoryMarshal.GetArrayDataReference(TF6);
             ref ulong rf7 = ref MemoryMarshal.GetArrayDataReference(TF7);
+#else
+            ref ulong rf0 = ref MemoryMarshal.GetReference(TF0);
+            ref ulong rf1 = ref MemoryMarshal.GetReference(TF1);
+            ref ulong rf2 = ref MemoryMarshal.GetReference(TF2);
+            ref ulong rf3 = ref MemoryMarshal.GetReference(TF3);
+            ref ulong rf4 = ref MemoryMarshal.GetReference(TF4);
+            ref ulong rf5 = ref MemoryMarshal.GetReference(TF5);
+            ref ulong rf6 = ref MemoryMarshal.GetReference(TF6);
+            ref ulong rf7 = ref MemoryMarshal.GetReference(TF7);
+#endif
 
             // Pre-whitening: modular addition with round key 0
             ulong s0 = w0 + rk[0];
@@ -323,6 +340,7 @@ internal unsafe struct KalynaCore
             ulong* rk = pCore->_roundKeys;
             int nr = _rounds;
 
+#if NET5_0_OR_GREATER
             ref ulong ri0 = ref MemoryMarshal.GetArrayDataReference(TI0);
             ref ulong ri1 = ref MemoryMarshal.GetArrayDataReference(TI1);
             ref ulong ri2 = ref MemoryMarshal.GetArrayDataReference(TI2);
@@ -336,7 +354,21 @@ internal unsafe struct KalynaCore
             ref byte pIs1 = ref MemoryMarshal.GetArrayDataReference(IS1);
             ref byte pIs2 = ref MemoryMarshal.GetArrayDataReference(IS2);
             ref byte pIs3 = ref MemoryMarshal.GetArrayDataReference(IS3);
+#else
+            ref ulong ri0 = ref MemoryMarshal.GetReference(TI0);
+            ref ulong ri1 = ref MemoryMarshal.GetReference(TI1);
+            ref ulong ri2 = ref MemoryMarshal.GetReference(TI2);
+            ref ulong ri3 = ref MemoryMarshal.GetReference(TI3);
+            ref ulong ri4 = ref MemoryMarshal.GetReference(TI4);
+            ref ulong ri5 = ref MemoryMarshal.GetReference(TI5);
+            ref ulong ri6 = ref MemoryMarshal.GetReference(TI6);
+            ref ulong ri7 = ref MemoryMarshal.GetReference(TI7);
 
+            ref byte pIs0 = ref MemoryMarshal.GetReference(IS0);
+            ref byte pIs1 = ref MemoryMarshal.GetReference(IS1);
+            ref byte pIs2 = ref MemoryMarshal.GetReference(IS2);
+            ref byte pIs3 = ref MemoryMarshal.GetReference(IS3);
+#endif
             // Pre-whitening: modular subtraction with round key nr
             ulong s0 = w0 - rk[nr * 2];
             ulong s1 = w1 - rk[nr * 2 + 1];
@@ -426,9 +458,13 @@ internal unsafe struct KalynaCore
 
         // Generate round keys
         if (key.Length == 16)
+        {
             KeyExpandEvenOdd128(key, kt, roundKeys, nr);
+        }
         else
+        {
             KeyExpandEvenOdd256(key, kt, roundKeys, nr);
+        }
 
         return nr;
     }
@@ -456,7 +492,9 @@ internal unsafe struct KalynaCore
     {
         // For 128-bit block (2 columns): swap rows 4-7 between columns
         for (int row = 4; row < 8; row++)
+        {
             (state[row], state[8 + row]) = (state[8 + row], state[row]);
+        }
     }
 
     private static void MixColumns(Span<byte> state)
@@ -487,11 +525,16 @@ internal unsafe struct KalynaCore
         for (int i = 0; i < 8; i++)
         {
             if ((a & (1 << i)) != 0)
+            {
                 result ^= temp;
+            }
+
             bool carry = (temp & 0x80) != 0;
             temp <<= 1;
             if (carry)
+            {
                 temp ^= 0x1D; // Low 8 bits of 0x11D
+            }
         }
         return result;
     }
@@ -510,14 +553,19 @@ internal unsafe struct KalynaCore
     private static void XorRoundKey(Span<byte> state, ReadOnlySpan<byte> roundKey)
     {
         for (int i = 0; i < 16; i++)
+        {
             state[i] ^= roundKey[i];
+        }
     }
 
     private static byte[] ComputeInverse(ReadOnlySpan<byte> sbox)
     {
         byte[] inv = new byte[256];
         for (int i = 0; i < 256; i++)
+        {
             inv[sbox[i]] = (byte)i;
+        }
+
         return inv;
     }
 
@@ -525,7 +573,10 @@ internal unsafe struct KalynaCore
     {
         byte[] table = new byte[256];
         for (int b = 0; b < 256; b++)
+        {
             table[b] = GfMul(a, (byte)b);
+        }
+
         return table;
     }
 
@@ -546,9 +597,13 @@ internal unsafe struct KalynaCore
 
         // Round 2: XOR with key part
         if (keyLen == 32)
+        {
             XorRoundKey(state, key.Slice(16, 16));
+        }
         else
+        {
             XorRoundKey(state, key.Slice(0, 16));
+        }
 
         SubBytes(state);
         ShiftRows(state);
@@ -604,7 +659,10 @@ internal unsafe struct KalynaCore
 
             state.CopyTo(roundKeys.Slice(round * 16, 16));
 
-            if (round == nr) break;
+            if (round == nr)
+            {
+                break;
+            }
 
             round += 2;
             tmv <<= 1;
@@ -663,7 +721,10 @@ internal unsafe struct KalynaCore
 
             state.CopyTo(roundKeys.Slice(round * 16, 16));
 
-            if (round == nr) break;
+            if (round == nr)
+            {
+                break;
+            }
 
             // Second even key: uses initialData[16:32]
             round += 2;
@@ -693,7 +754,10 @@ internal unsafe struct KalynaCore
 
             state.CopyTo(roundKeys.Slice(round * 16, 16));
 
-            if (round == nr) break;
+            if (round == nr)
+            {
+                break;
+            }
 
             round += 2;
             tmv <<= 1;

--- a/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
@@ -203,7 +203,7 @@ internal unsafe struct KalynaCore
         ulong* rk = pCore->_roundKeys;
         for (int i = 0; i <= nr; i++)
         {
-            rk[i * 2]     = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16));
+            rk[i * 2] = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16));
             rk[i * 2 + 1] = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16 + 8));
         }
 

--- a/src/Security/Cryptography/Cipher/Sm4/Sm4Core.cs
+++ b/src/Security/Cryptography/Cipher/Sm4/Sm4Core.cs
@@ -323,42 +323,6 @@ internal unsafe partial struct Sm4Core
     }
 
     /// <summary>
-    /// Encrypts four consecutive 16-byte blocks from <paramref name="input"/> into
-    /// <paramref name="output"/> using the most accelerated path available.
-    /// </summary>
-    /// <param name="input">64-byte plaintext buffer (4 × 16 bytes).</param>
-    /// <param name="output">64-byte ciphertext buffer.</param>
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    public void EncryptBlocks4(ReadOnlySpan<byte> input, Span<byte> output)
-    {
-        fixed (uint* rk = _roundKeys)
-        {
-            EncryptBlockScalar(input, output, rk);
-            EncryptBlockScalar(input[16..], output[16..], rk);
-            EncryptBlockScalar(input[32..], output[32..], rk);
-            EncryptBlockScalar(input[48..], output[48..], rk);
-        }
-    }
-
-    /// <summary>
-    /// Decrypts four consecutive 16-byte blocks from <paramref name="input"/> into
-    /// <paramref name="output"/> using the most accelerated path available.
-    /// </summary>
-    /// <param name="input">64-byte ciphertext buffer (4 × 16 bytes).</param>
-    /// <param name="output">64-byte plaintext buffer.</param>
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    public void DecryptBlocks4(ReadOnlySpan<byte> input, Span<byte> output)
-    {
-        fixed (uint* rk = _roundKeys)
-        {
-            DecryptBlockScalar(input, output, rk);
-            DecryptBlockScalar(input[16..], output[16..], rk);
-            DecryptBlockScalar(input[32..], output[32..], rk);
-            DecryptBlockScalar(input[48..], output[48..], rk);
-        }
-    }
-
-    /// <summary>
     /// Clears the expanded round keys.
     /// </summary>
     public void Clear()

--- a/src/Security/Cryptography/Hash/Blake/Blake2bState.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2bState.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 /// <summary>
 /// Computes the BLAKE2b hash for the input data.
 /// </summary>
-internal unsafe partial struct Blake2bState : IIncrementalHash
+internal unsafe partial struct Blake2bState : IIncrementalHash<byte[]>
 {
     /// <summary>
     /// The maximum hash size in bits.
@@ -125,9 +125,8 @@ internal unsafe partial struct Blake2bState : IIncrementalHash
     }
 
     /// <inheritdoc/>
-    public void Reset(object? resetState)
+    public void Reset(byte[]? key)
     {
-        byte[]? key = resetState as byte[];
         int keyLength = key?.Length ?? 0;
 
         ulong paramBlock = 0x01010000UL | ((ulong)keyLength << 8) | (uint)_outputBytes;

--- a/src/Security/Cryptography/Hash/Blake/Blake2sState.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2sState.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 /// BLAKE2s is optimized for 32-bit platforms and uses 32-bit words with a 64-byte block size.
 /// </para>
 /// </remarks>
-internal unsafe partial struct Blake2sState : IIncrementalHash
+internal unsafe partial struct Blake2sState : IIncrementalHash<byte[]>
 {
     /// <summary>
     /// The maximum hash size in bits.
@@ -148,9 +148,8 @@ internal unsafe partial struct Blake2sState : IIncrementalHash
     }
 
     /// <inheritdoc/>
-    public void Reset(object? resetState)
+    public void Reset(byte[]? key)
     {
-        byte[]? key = resetState as byte[];
         int keyLength = key?.Length ?? 0;
 
         uint paramBlock = 0x01010000U | ((uint)keyLength << 8) | (uint)_outputBytes;

--- a/src/Security/Cryptography/Hash/Blake/Blake3State.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake3State.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 /// compression blocks. This struct manages the full Merkle tree state.
 /// </para>
 /// </remarks>
-internal unsafe partial struct Blake3State : IIncrementalHash
+internal unsafe partial struct Blake3State : IIncrementalHash<bool>
 {
     /// <summary>
     /// The default hash size in bits.
@@ -74,11 +74,12 @@ internal unsafe partial struct Blake3State : IIncrementalHash
     internal const uint FlagDeriveKeyMaterial = 1 << 6;
 
     // BLAKE3 IV (same as BLAKE2s)
-    internal static ReadOnlySpan<uint> IV =>
-    [
+    private static readonly uint[] s_IV = new uint[] {
         0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
         0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U
-    ];
+    };
+
+    internal static ReadOnlySpan<uint> IV => s_IV;
 
     // Fixed buffers for all state
     private fixed byte _chunkBuffer[ChunkSizeBytes];
@@ -151,9 +152,8 @@ internal unsafe partial struct Blake3State : IIncrementalHash
     public bool Squeezed => _squeezed;
 
     /// <inheritdoc/>
-    public void Reset(object? resetState)
+    public void Reset(bool keyedMode)
     {
-        bool keyedMode = resetState as bool? ?? false;
         if (!keyedMode)
         {
             InitializeHash();

--- a/src/Security/Cryptography/Hash/IIncrementalHash.cs
+++ b/src/Security/Cryptography/Hash/IIncrementalHash.cs
@@ -9,6 +9,9 @@ using System.Buffers;
 /// <summary>
 /// Defines the contract for an incremental hash computation over arbitrary value types.
 /// </summary>
+/// <typeparam name="TR">
+/// The element reset type. The information required to reset the hash, e.g. a byte[] key or a bool.
+/// </typeparam>
 /// <remarks>
 /// <para>
 /// Implementations are expected to be lightweight structs that hold the full hash state
@@ -33,7 +36,7 @@ using System.Buffers;
 /// API surface.
 /// </para>
 /// </remarks>
-public interface IIncrementalHash : IDisposable
+internal interface IIncrementalHash<TR> : IDisposable
 {
     /// <summary>
     /// Gets the length of the hash digest produced by this instance, in bytes.
@@ -117,5 +120,5 @@ public interface IIncrementalHash : IDisposable
     /// Any previously appended data and any partially computed digest are discarded.
     /// </remarks>
     /// <param name="state">An additional state that is kept external.</param>
-    void Reset(object? state);
+    void Reset(TR state);
 }

--- a/src/Security/Cryptography/Hash/Keccak/CShake128.cs
+++ b/src/Security/Cryptography/Hash/Keccak/CShake128.cs
@@ -182,12 +182,14 @@ public sealed class CShake128 : KeccakCore, IExtendableOutput
             byte domainSep = _isCustomized ? (byte)0x04 : (byte)0x1F;
             _buffer[_bufferLength++] = domainSep;
 
-            while (_bufferLength < RateBytes - 1)
+            int clearLen = RateBytes - 1 - _bufferLength;
+            if (clearLen > 0)
             {
-                _buffer[_bufferLength++] = 0x00;
+                _buffer.AsSpan(_bufferLength, clearLen).Clear();
             }
+            _bufferLength = RateBytes - 1;
 
-            _buffer[RateBytes - 1] |= 0x80;
+            _buffer[_bufferLength] |= 0x80;
 
             _keccakCore.Absorb(_buffer, RateBytes);
             _finalized = true;

--- a/src/Security/Cryptography/Hash/Keccak/CShake256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/CShake256.cs
@@ -178,12 +178,14 @@ public sealed class CShake256 : KeccakCore, IExtendableOutput
             byte domainSep = _isCustomized ? (byte)0x04 : (byte)0x1F;
             _buffer[_bufferLength++] = domainSep;
 
-            while (_bufferLength < RateBytes - 1)
+            int clearLen = RateBytes - 1 - _bufferLength;
+            if (clearLen > 0)
             {
-                _buffer[_bufferLength++] = 0x00;
+                _buffer.AsSpan(_bufferLength, clearLen).Clear();
             }
+            _bufferLength = RateBytes - 1;
 
-            _buffer[RateBytes - 1] |= 0x80;
+            _buffer[_bufferLength] |= 0x80;
 
             _keccakCore.Absorb(_buffer, RateBytes);
             _finalized = true;

--- a/src/Security/Cryptography/Hash/Keccak/KT128.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KT128.cs
@@ -152,6 +152,8 @@ public sealed class KT128 : HashAlgorithm, IExtendableOutput
 
     internal static KT128 Create(SimdSupport simdSupport, int outputBytes) => new(simdSupport, outputBytes, ReadOnlySpan<byte>.Empty);
 
+    internal static new SimdSupport SimdSupport => KeccakCoreState.SimdSupport;
+
     /// <inheritdoc/>
     public override void Initialize()
     {

--- a/src/Security/Cryptography/Hash/Keccak/KT256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KT256.cs
@@ -152,6 +152,8 @@ public sealed class KT256 : HashAlgorithm, IExtendableOutput
 
     internal static KT256 Create(SimdSupport simdSupport, int outputBytes) => new(simdSupport, outputBytes, ReadOnlySpan<byte>.Empty);
 
+    internal static new SimdSupport SimdSupport => KeccakCoreState.SimdSupport;
+
     /// <inheritdoc/>
     public override void Initialize()
     {

--- a/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.Arm64.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.Arm64.cs
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Security.Cryptography.Hash;
+
+#if NET8_0_OR_GREATER
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// ARM64-optimized scalar Keccak-f[1600] permutation.
+/// </summary>
+internal unsafe partial struct KeccakCoreState
+{
+    /// <summary>
+    /// ARM64-optimized scalar Keccak-f[1600] permutation (1 round per loop iteration,
+    /// register-based state).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All 25 state lanes are loaded into local variables before the loop and stored back
+    /// after. Inside the loop every step — theta D-values, Pi+Rho, chi, iota — operates
+    /// entirely on locals, eliminating the ~50 store/reload memory round-trips per round
+    /// that the in-place theta pattern incurs.
+    /// </para>
+    /// <para>
+    /// One round per loop iteration (vs. the 2-round unrolling in <see cref="PermuteScalar"/>)
+    /// reduces peak live locals from ~57 to ~35, cutting register spills on ARM64's
+    /// 31 GP registers.
+    /// </para>
+    /// <para>
+    /// Register pressure is kept low by the <em>pre-save pattern</em>: each chi output
+    /// row overwrites 5 state lanes; any lane that is also a source for a <em>later</em>
+    /// chi row is rotated and saved before that earlier row executes. This ensures every
+    /// B value is read from the post-theta state before it can be overwritten.
+    /// </para>
+    /// <para>
+    /// Pi+Rho mapping (output index ← source index × rotation):<br/>
+    /// row 0: [0]←[0]×0  [1]←[6]×44  [2]←[12]×43 [3]←[18]×21 [4]←[24]×14<br/>
+    /// row 1: [5]←[3]×28 [6]←[9]×20  [7]←[10]×3  [8]←[16]×45 [9]←[22]×61<br/>
+    /// row 2: [10]←[1]×1 [11]←[7]×6  [12]←[13]×25 [13]←[19]×8 [14]←[20]×18<br/>
+    /// row 3: [15]←[4]×27 [16]←[5]×36 [17]←[11]×10 [18]←[17]×15 [19]←[23]×56<br/>
+    /// row 4: [20]←[2]×62 [21]←[8]×55 [22]←[14]×39 [23]←[15]×41 [24]←[21]×2
+    /// </para>
+    /// </remarks>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private void PermuteArm64()
+    {
+        ulong aba, abe, abi, abo, abu;
+        ulong aga, age, agi, ago, agu;
+        ulong aka, ake, aki, ako, aku;
+        ulong ama, ame, ami, amo, amu;
+        ulong asa, ase, asi, aso, asu;
+        ulong ca, ce, ci, co, cu;
+        ulong da, de, di, @do, du;
+        ulong r1b0, r2b0, r3b0, r4b0;
+        ulong r2b1, r3b1, r4b1;
+        ulong r3b2, r4b2;
+        ulong r4b3;
+
+        fixed (ulong* s = _state)
+        {
+            aba = s[ 0]; abe = s[ 1]; abi = s[ 2]; abo = s[ 3]; abu = s[ 4];
+            aga = s[ 5]; age = s[ 6]; agi = s[ 7]; ago = s[ 8]; agu = s[ 9];
+            aka = s[10]; ake = s[11]; aki = s[12]; ako = s[13]; aku = s[14];
+            ama = s[15]; ame = s[16]; ami = s[17]; amo = s[18]; amu = s[19];
+            asa = s[20]; ase = s[21]; asi = s[22]; aso = s[23]; asu = s[24];
+
+            for (int round = _startRound; round < Rounds; round++)
+            {
+                // ── Theta: column parities → D values ────────────────────────────────
+                ce = abe ^ age ^ ake ^ ame ^ ase;            cu = abu ^ agu ^ aku ^ amu ^ asu;
+                da = cu ^ BitOperations.RotateLeft(ce, 1);
+                co = abo ^ ago ^ ako ^ amo ^ aso;
+                di = ce ^ BitOperations.RotateLeft(co, 1);
+                ci = abi ^ agi ^ aki ^ ami ^ asi;
+                @do = ci ^ BitOperations.RotateLeft(cu, 1);
+                ca = aba ^ aga ^ aka ^ ama ^ asa;
+                du = co ^ BitOperations.RotateLeft(ca, 1);
+                de = ca ^ BitOperations.RotateLeft(ci, 1);
+
+                // ── Pre-save B[0] for rows 1-4 (abo,abe,abu,abi are overwritten by chi row 0)
+                r1b0 = BitOperations.RotateLeft(abo ^ @do, 28);
+                r2b0 = BitOperations.RotateLeft(abe ^ de,   1);
+                r3b0 = BitOperations.RotateLeft(abu ^ du,  27);
+                r4b0 = BitOperations.RotateLeft(abi ^ di,  62);
+
+                // ── Chi row 0 ─────────────────────────────────────────────────────────
+                ca = aba ^ da;
+                ce = BitOperations.RotateLeft(age ^ de, 44);
+                ci = BitOperations.RotateLeft(aki ^ di, 43);
+                aba = ca ^ (~ce & ci) ^ GetRoundConstants(round);
+                co = BitOperations.RotateLeft(amo ^ @do, 21);
+                abe = ce ^ (~ci & co);
+                cu = BitOperations.RotateLeft(asu ^ du, 14);
+                abu = cu ^ (~ca & ce);
+
+                // ── Pre-save B[1] for rows 2-4 (agi,aga,ago are overwritten by chi row 1)
+                r2b1 = BitOperations.RotateLeft(agi ^ di,   6);
+                r3b1 = BitOperations.RotateLeft(aga ^ da,  36);
+                r4b1 = BitOperations.RotateLeft(ago ^ @do, 55);
+
+                abo = co ^ (~cu & ca);
+                ce = BitOperations.RotateLeft(agu ^ du, 20);
+                abi = ci ^ (~co & cu);
+
+                // ── Chi row 1 ─────────────────────────────────────────────────────────
+                ca = r1b0;
+                ci = BitOperations.RotateLeft(aka ^ da,  3);
+                aga = ca ^ (~ce & ci);
+                co = BitOperations.RotateLeft(ame ^ de, 45);
+                age = ce ^ (~ci & co);
+                cu = BitOperations.RotateLeft(asi ^ di, 61);
+                agu = cu ^ (~ca & ce);
+
+                // ── Pre-save B[2] for rows 3-4 (ake,aku are overwritten by chi row 2) ──
+                r3b2 = BitOperations.RotateLeft(ake ^ de, 10);
+                r4b2 = BitOperations.RotateLeft(aku ^ du, 39);
+
+                ago = co ^ (~cu & ca);
+                ce = r2b1;
+                agi = ci ^ (~co & cu);
+                ca = r2b0;
+
+                // ── Chi row 2 ─────────────────────────────────────────────────────────
+                ci = BitOperations.RotateLeft(ako ^ @do, 25);
+                aka = ca ^ (~ce & ci);
+                co = BitOperations.RotateLeft(amu ^ du,   8);
+                ake = ce ^ (~ci & co);
+                cu = BitOperations.RotateLeft(asa ^ da,  18);
+                aku = cu ^ (~ca & ce);
+
+                // ── Pre-save B[3] for row 4 (ama is overwritten by chi row 3) ──────────
+                r4b3 = BitOperations.RotateLeft(ama ^ da, 41);
+
+                ako = co ^ (~cu & ca);
+                ce = r3b1;
+                aki = ci ^ (~co & cu);
+                ca = r3b0;
+
+                // ── Chi row 3 ─────────────────────────────────────────────────────────
+                ci = r3b2;
+                co = BitOperations.RotateLeft(ami ^ di, 15);
+                ama = ca ^ (~ce & ci);
+                cu = BitOperations.RotateLeft(aso ^ @do, 56);
+                ame = ce ^ (~ci & co);
+                amu = cu ^ (~ca & ce);
+                amo = co ^ (~cu & ca);
+                ce = r4b1;
+                ami = ci ^ (~co & cu);
+                ca = r4b0;
+
+                // ── Chi row 4 ─────────────────────────────────────────────────────────
+                ci = r4b2;
+                co = r4b3;
+                asa = ca ^ (~ce & ci);
+                cu = BitOperations.RotateLeft(ase ^ de, 2);
+                ase = ce ^ (~ci & co);
+                asu = cu ^ (~ca & ce);
+                aso = co ^ (~cu & ca);
+                asi = ci ^ (~co & cu);
+            }
+
+            s[ 0] = aba; s[ 1] = abe; s[ 2] = abi; s[ 3] = abo; s[ 4] = abu;
+            s[ 5] = aga; s[ 6] = age; s[ 7] = agi; s[ 8] = ago; s[ 9] = agu;
+            s[10] = aka; s[11] = ake; s[12] = aki; s[13] = ako; s[14] = aku;
+            s[15] = ama; s[16] = ame; s[17] = ami; s[18] = amo; s[19] = amu;
+            s[20] = asa; s[21] = ase; s[22] = asi; s[23] = aso; s[24] = asu;
+        }
+    }
+}
+
+#endif

--- a/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.Arm64.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.Arm64.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
@@ -62,8 +62,8 @@ internal unsafe partial struct KeccakCoreState
 
         fixed (ulong* s = _state)
         {
-            aba = s[ 0]; abe = s[ 1]; abi = s[ 2]; abo = s[ 3]; abu = s[ 4];
-            aga = s[ 5]; age = s[ 6]; agi = s[ 7]; ago = s[ 8]; agu = s[ 9];
+            aba = s[0]; abe = s[1]; abi = s[2]; abo = s[3]; abu = s[4];
+            aga = s[5]; age = s[6]; agi = s[7]; ago = s[8]; agu = s[9];
             aka = s[10]; ake = s[11]; aki = s[12]; ako = s[13]; aku = s[14];
             ama = s[15]; ame = s[16]; ami = s[17]; amo = s[18]; amu = s[19];
             asa = s[20]; ase = s[21]; asi = s[22]; aso = s[23]; asu = s[24];
@@ -71,7 +71,7 @@ internal unsafe partial struct KeccakCoreState
             for (int round = _startRound; round < Rounds; round++)
             {
                 // ── Theta: column parities → D values ────────────────────────────────
-                ce = abe ^ age ^ ake ^ ame ^ ase;            
+                ce = abe ^ age ^ ake ^ ame ^ ase;
                 cu = abu ^ agu ^ aku ^ amu ^ asu;
                 da = cu ^ BitOperations.RotateLeft(ce, 1);
                 co = abo ^ ago ^ ako ^ amo ^ aso;
@@ -84,9 +84,9 @@ internal unsafe partial struct KeccakCoreState
 
                 // ── Pre-save B[0] for rows 1-4 (abo,abe,abu,abi are overwritten by chi row 0)
                 r1b0 = BitOperations.RotateLeft(abo ^ @do, 28);
-                r2b0 = BitOperations.RotateLeft(abe ^ de,   1);
-                r3b0 = BitOperations.RotateLeft(abu ^ du,  27);
-                r4b0 = BitOperations.RotateLeft(abi ^ di,  62);
+                r2b0 = BitOperations.RotateLeft(abe ^ de, 1);
+                r3b0 = BitOperations.RotateLeft(abu ^ du, 27);
+                r4b0 = BitOperations.RotateLeft(abi ^ di, 62);
 
                 // ── Chi row 0 ─────────────────────────────────────────────────────────
                 ca = aba ^ da;
@@ -99,8 +99,8 @@ internal unsafe partial struct KeccakCoreState
                 abu = cu ^ (~ca & ce);
 
                 // ── Pre-save B[1] for rows 2-4 (agi,aga,ago are overwritten by chi row 1)
-                r2b1 = BitOperations.RotateLeft(agi ^ di,   6);
-                r3b1 = BitOperations.RotateLeft(aga ^ da,  36);
+                r2b1 = BitOperations.RotateLeft(agi ^ di, 6);
+                r3b1 = BitOperations.RotateLeft(aga ^ da, 36);
                 r4b1 = BitOperations.RotateLeft(ago ^ @do, 55);
 
                 abo = co ^ (~cu & ca);
@@ -109,7 +109,7 @@ internal unsafe partial struct KeccakCoreState
 
                 // ── Chi row 1 ─────────────────────────────────────────────────────────
                 ca = r1b0;
-                ci = BitOperations.RotateLeft(aka ^ da,  3);
+                ci = BitOperations.RotateLeft(aka ^ da, 3);
                 aga = ca ^ (~ce & ci);
                 co = BitOperations.RotateLeft(ame ^ de, 45);
                 age = ce ^ (~ci & co);
@@ -128,9 +128,9 @@ internal unsafe partial struct KeccakCoreState
                 // ── Chi row 2 ─────────────────────────────────────────────────────────
                 ci = BitOperations.RotateLeft(ako ^ @do, 25);
                 aka = ca ^ (~ce & ci);
-                co = BitOperations.RotateLeft(amu ^ du,   8);
+                co = BitOperations.RotateLeft(amu ^ du, 8);
                 ake = ce ^ (~ci & co);
-                cu = BitOperations.RotateLeft(asa ^ da,  18);
+                cu = BitOperations.RotateLeft(asa ^ da, 18);
                 aku = cu ^ (~ca & ce);
 
                 // ── Pre-save B[3] for row 4 (ama is overwritten by chi row 3) ──────────
@@ -164,8 +164,8 @@ internal unsafe partial struct KeccakCoreState
                 asi = ci ^ (~co & cu);
             }
 
-            s[ 0] = aba; s[ 1] = abe; s[ 2] = abi; s[ 3] = abo; s[ 4] = abu;
-            s[ 5] = aga; s[ 6] = age; s[ 7] = agi; s[ 8] = ago; s[ 9] = agu;
+            s[0] = aba; s[1] = abe; s[2] = abi; s[3] = abo; s[4] = abu;
+            s[5] = aga; s[6] = age; s[7] = agi; s[8] = ago; s[9] = agu;
             s[10] = aka; s[11] = ake; s[12] = aki; s[13] = ako; s[14] = aku;
             s[15] = ama; s[16] = ame; s[17] = ami; s[18] = amo; s[19] = amu;
             s[20] = asa; s[21] = ase; s[22] = asi; s[23] = aso; s[24] = asu;

--- a/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.Arm64.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.Arm64.cs
@@ -46,7 +46,7 @@ internal unsafe partial struct KeccakCoreState
     /// </remarks>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private void PermuteArm64()
+    private void PermuteScalarArm64()
     {
         ulong aba, abe, abi, abo, abu;
         ulong aga, age, agi, ago, agu;
@@ -71,7 +71,8 @@ internal unsafe partial struct KeccakCoreState
             for (int round = _startRound; round < Rounds; round++)
             {
                 // ── Theta: column parities → D values ────────────────────────────────
-                ce = abe ^ age ^ ake ^ ame ^ ase;            cu = abu ^ agu ^ aku ^ amu ^ asu;
+                ce = abe ^ age ^ ake ^ ame ^ ase;            
+                cu = abu ^ agu ^ aku ^ amu ^ asu;
                 da = cu ^ BitOperations.RotateLeft(ce, 1);
                 co = abo ^ ago ^ ako ^ amo ^ aso;
                 di = ce ^ BitOperations.RotateLeft(co, 1);

--- a/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.cs
@@ -81,7 +81,7 @@ internal unsafe partial struct KeccakCoreState
 #if NET8_0_OR_GREATER
             if (Avx2.IsSupported) support |= SimdSupport.Avx2;
             if (Avx512F.IsSupported) support |= SimdSupport.Avx512F;
-            if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
+            if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Arm64;
 #endif
             return support;
         }
@@ -93,7 +93,7 @@ internal unsafe partial struct KeccakCoreState
     private fixed ulong _state[StateSize];
 
     /// <summary>
-    /// The SimD instruction sets to use for this instance.
+    /// The SIMD instruction sets to use for this instance.
     /// </summary>
     private readonly SimdSupport _simdSupport;
 
@@ -139,14 +139,12 @@ internal unsafe partial struct KeccakCoreState
     public void Permute()
     {
 #if NET8_0_OR_GREATER
-        if ((_simdSupport & SimdSupport.Neon) != 0 && AdvSimd.Arm64.IsSupported)
+        if ((_simdSupport & SimdSupport.Arm64) != 0)
         {
-            PermuteArm64();
+            PermuteScalarArm64();
             return;
         }
-#endif
 #if EXPERIMENTAL
-#if NET8_0_OR_GREATER
         if ((_simdSupport & SimdSupport.Avx512F) != 0)
         {
             PermuteAvx512F();
@@ -1201,24 +1199,42 @@ internal unsafe partial struct KeccakCoreState
                     squeezeOffset = 0;
                 }
 
-                int stateIndex = squeezeOffset / 8;
-                int byteIndex = squeezeOffset % 8;
+                int available = rateBytes - squeezeOffset;
+                int needed = output.Length - outputOffset;
+                int toCopy = needed < available ? needed : available;
 
-                unchecked
+                if (BitConverter.IsLittleEndian)
                 {
-                    while (outputOffset < output.Length && squeezeOffset < rateBytes)
-                    {
-                        output[outputOffset++] = (byte)(statePtr[stateIndex] >> (byteIndex * 8));
-                        byteIndex++;
-                        squeezeOffset++;
+                    // Fast path: state bytes map directly to output on little-endian systems.
+                    Unsafe.CopyBlockUnaligned(
+                        ref Unsafe.Add(ref MemoryMarshal.GetReference(output), outputOffset),
+                        ref *((byte*)statePtr + squeezeOffset),
+                        (uint)toCopy);
+                }
+                else
+                {
+                    // Big-endian: convert each byte individually.
+                    int stateIndex = squeezeOffset / 8;
+                    int byteIndex = squeezeOffset % 8;
 
-                        if (byteIndex >= 8)
+                    unchecked
+                    {
+                        for (int i = 0; i < toCopy; i++)
                         {
-                            byteIndex = 0;
-                            stateIndex++;
+                            output[outputOffset + i] = (byte)(statePtr[stateIndex] >> (byteIndex * 8));
+                            byteIndex++;
+
+                            if (byteIndex >= 8)
+                            {
+                                byteIndex = 0;
+                                stateIndex++;
+                            }
                         }
                     }
                 }
+
+                outputOffset += toCopy;
+                squeezeOffset += toCopy;
             }
         }
     }

--- a/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakCoreState.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if NET8_0_OR_GREATER
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -36,7 +37,7 @@ using System.Runtime.Intrinsics.X86;
 /// which is used for benchmarking, so SIMD is disabled by default in release packages.
 /// </para>
 /// </remarks>
-internal unsafe struct KeccakCoreState
+internal unsafe partial struct KeccakCoreState
 {
     /// <summary>
     /// The state size in 64-bit words (25 lanes × 64 bits = 1600 bits).
@@ -80,6 +81,7 @@ internal unsafe struct KeccakCoreState
 #if NET8_0_OR_GREATER
             if (Avx2.IsSupported) support |= SimdSupport.Avx2;
             if (Avx512F.IsSupported) support |= SimdSupport.Avx512F;
+            if (AdvSimd.Arm64.IsSupported) support |= SimdSupport.Neon;
 #endif
             return support;
         }
@@ -136,6 +138,13 @@ internal unsafe struct KeccakCoreState
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     public void Permute()
     {
+#if NET8_0_OR_GREATER
+        if ((_simdSupport & SimdSupport.Neon) != 0 && AdvSimd.Arm64.IsSupported)
+        {
+            PermuteArm64();
+            return;
+        }
+#endif
 #if EXPERIMENTAL
 #if NET8_0_OR_GREATER
         if ((_simdSupport & SimdSupport.Avx512F) != 0)

--- a/src/Security/Cryptography/Hash/Keccak/KeccakHashCore.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakHashCore.cs
@@ -49,13 +49,15 @@ public abstract class KeccakHashCore : KeccakCore
         _buffer[_bufferLength++] = _domainSeparator;
 
         // Zero-pad
-        while (_bufferLength < _rateBytes - 1)
+        int clearLen = _rateBytes - 1 - _bufferLength;
+        if (clearLen > 0)
         {
-            _buffer[_bufferLength++] = 0x00;
+            _buffer.AsSpan(_bufferLength, clearLen).Clear();
         }
+        _bufferLength = _rateBytes - 1;
 
         // Set last bit (OR preserves domain separator if it landed at this position)
-        _buffer[_rateBytes - 1] |= 0x80;
+        _buffer[_bufferLength] |= 0x80;
 
         // Absorb final block
         _keccakCore.Absorb(_buffer, _rateBytes);

--- a/src/Security/Cryptography/Hash/Keccak/KeccakXofCore.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakXofCore.cs
@@ -99,13 +99,15 @@ public abstract class KeccakXofCore : KeccakCore, IExtendableOutput
             _buffer[_bufferLength++] = _domainSeparator;
 
             // Zero-pad
-            while (_bufferLength < _rateBytes - 1)
+            int clearLen = _rateBytes - 1 - _bufferLength;
+            if (clearLen > 0)
             {
-                _buffer[_bufferLength++] = 0x00;
+                _buffer.AsSpan(_bufferLength, clearLen).Clear();
             }
+            _bufferLength = _rateBytes - 1;
 
             // Set last bit (OR preserves domain separator if it landed at this position)
-            _buffer[_rateBytes - 1] |= 0x80;
+            _buffer[_bufferLength] |= 0x80;
 
             // Absorb final block
             _keccakCore.Absorb(_buffer, _rateBytes);

--- a/src/Security/Cryptography/Mac/Kmac/KeccakKMacCore.cs
+++ b/src/Security/Cryptography/Mac/Kmac/KeccakKMacCore.cs
@@ -161,12 +161,14 @@ public abstract class KeccakKMacCore : KeccakCore, IExtendableOutput
             // cSHAKE domain separator (0x04 for customized)
             _buffer[_bufferLength++] = 0x04;
 
-            while (_bufferLength < _rateBytes - 1)
+            int clearLen = _rateBytes - 1 - _bufferLength;
+            if (clearLen > 0)
             {
-                _buffer[_bufferLength++] = 0x00;
+                _buffer.AsSpan(_bufferLength, clearLen).Clear();
             }
+            _bufferLength = _rateBytes - 1;
 
-            _buffer[_rateBytes - 1] |= 0x80;
+            _buffer[_bufferLength] |= 0x80;
 
             _keccakCore.Absorb(_buffer, _rateBytes);
             _finalized = true;

--- a/src/Security/Cryptography/shared/SimdSupport.cs
+++ b/src/Security/Cryptography/shared/SimdSupport.cs
@@ -77,14 +77,19 @@ internal enum SimdSupport
     ArmSha256 = 1 << 10,
 
     /// <summary>
+    /// ARM64 specific implementation.
+    /// </summary>
+    Arm64 = 1 << 11,
+
+    /// <summary>
     /// All available SIMD optimizations (default behavior).
     /// </summary>
-    All = Sse2 | Ssse3 | Avx2 | Avx512F | Neon | AesNi | PClMul | PClMulV256 | ArmAes | ArmPmull | ArmSha256,
+    All = Sse2 | Ssse3 | Avx2 | Avx512F | Neon | AesNi | PClMul | PClMulV256 | ArmAes | ArmPmull | ArmSha256 | Arm64,
 
     /// <summary>
     /// The default optimization to use for Keccak based algorithms.
-    /// Enables the ARM64 scalar path (<see cref="Neon"/>) which is automatically
+    /// Enables the ARM64 scalar path (<see cref="Arm64"/>) which is automatically
     /// masked to <see cref="None"/> on non-ARM64 platforms.
     /// </summary>
-    KeccakDefault = Neon
+    KeccakDefault = Arm64
 }

--- a/src/Security/Cryptography/shared/SimdSupport.cs
+++ b/src/Security/Cryptography/shared/SimdSupport.cs
@@ -83,7 +83,8 @@ internal enum SimdSupport
 
     /// <summary>
     /// The default optimization to use for Keccak based algorithms.
-    /// Set to None since Keccak is faster with scalar instructions.
+    /// Enables the ARM64 scalar path (<see cref="Neon"/>) which is automatically
+    /// masked to <see cref="None"/> on non-ARM64 platforms.
     /// </summary>
-    KeccakDefault = None
+    KeccakDefault = Neon
 }

--- a/tests/Security/Cryptography/Benchmarks/Hash/HashConfig.cs
+++ b/tests/Security/Cryptography/Benchmarks/Hash/HashConfig.cs
@@ -91,6 +91,8 @@ public class HashConfig : ManualConfig
                 return "OS Native";
             if (name.EndsWith("(Blake3Native)", StringComparison.InvariantCultureIgnoreCase))
                 return "Blake3Native";
+            if (name.EndsWith("(CryptoHives-Arm64)", StringComparison.InvariantCultureIgnoreCase))
+                return "CryptoHives-Arm64";
             if (name.EndsWith("(CryptoHives-Neon)", StringComparison.InvariantCultureIgnoreCase))
                 return "CryptoHives-Neon";
             if (name.EndsWith("(CryptoHives-AVX2)", StringComparison.InvariantCultureIgnoreCase))

--- a/tests/Security/Cryptography/Benchmarks/Hash/XofAlgorithmType.cs
+++ b/tests/Security/Cryptography/Benchmarks/Hash/XofAlgorithmType.cs
@@ -82,7 +82,7 @@ public sealed class XofAlgorithmType : IFormattable
         if ((simdSupport & SimdSupport.Arm64) != 0)
         {
             yield return new("SHAKE256", "SHAKE256 (CryptoHives-Arm64)", () => CH.Hash.Shake256.Create(SimdSupport.Arm64, 64));
-        }   
+        }
         yield return new("SHAKE256", "SHAKE256 (CryptoHives-Scalar)", () => CH.Hash.Shake256.Create(SimdSupport.None, 64));
         yield return new("SHAKE256", "SHAKE256 (BouncyCastle)", () => new BouncyCastleIXofAdapter(new Org.BouncyCastle.Crypto.Digests.ShakeDigest(256)));
 #if NET8_0_OR_GREATER

--- a/tests/Security/Cryptography/Benchmarks/Hash/XofAlgorithmType.cs
+++ b/tests/Security/Cryptography/Benchmarks/Hash/XofAlgorithmType.cs
@@ -62,7 +62,12 @@ public sealed class XofAlgorithmType : IFormattable
     /// <summary>SHAKE128 XOF implementations.</summary>
     public static IEnumerable<XofAlgorithmType> Shake128()
     {
-        yield return new("SHAKE128", "SHAKE128 (CryptoHives-Scalar)", () => CH.Hash.Shake128.Create(32));
+        var simdSupport = CH.Hash.Shake128.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("SHAKE128", "SHAKE128 (CryptoHives-Arm64)", () => CH.Hash.Shake128.Create(SimdSupport.Arm64, 32));
+        }
+        yield return new("SHAKE128", "SHAKE128 (CryptoHives-Scalar)", () => CH.Hash.Shake128.Create(SimdSupport.None, 32));
         yield return new("SHAKE128", "SHAKE128 (BouncyCastle)", () => new BouncyCastleIXofAdapter(new Org.BouncyCastle.Crypto.Digests.ShakeDigest(128)));
 #if NET8_0_OR_GREATER
         if (OS.Shake128.IsSupported)
@@ -73,7 +78,12 @@ public sealed class XofAlgorithmType : IFormattable
     /// <summary>SHAKE256 XOF implementations.</summary>
     public static IEnumerable<XofAlgorithmType> Shake256()
     {
-        yield return new("SHAKE256", "SHAKE256 (CryptoHives-Scalar)", () => CH.Hash.Shake256.Create(64));
+        var simdSupport = CH.Hash.Shake256.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("SHAKE256", "SHAKE256 (CryptoHives-Arm64)", () => CH.Hash.Shake256.Create(SimdSupport.Arm64, 64));
+        }   
+        yield return new("SHAKE256", "SHAKE256 (CryptoHives-Scalar)", () => CH.Hash.Shake256.Create(SimdSupport.None, 64));
         yield return new("SHAKE256", "SHAKE256 (BouncyCastle)", () => new BouncyCastleIXofAdapter(new Org.BouncyCastle.Crypto.Digests.ShakeDigest(256)));
 #if NET8_0_OR_GREATER
         if (OS.Shake256.IsSupported)
@@ -88,14 +98,24 @@ public sealed class XofAlgorithmType : IFormattable
     /// <summary>cSHAKE128 XOF implementations.</summary>
     public static IEnumerable<XofAlgorithmType> CShake128()
     {
-        yield return new("cSHAKE128", "cSHAKE128 (CryptoHives-Scalar)", () => CH.Hash.CShake128.Create(32));
+        var simdSupport = CH.Hash.CShake128.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("cSHAKE128", "cSHAKE128 (CryptoHives-Arm64)", () => CH.Hash.CShake128.Create(SimdSupport.Arm64, 32));
+        }
+        yield return new("cSHAKE128", "cSHAKE128 (CryptoHives-Scalar)", () => CH.Hash.CShake128.Create(SimdSupport.None, 32));
         yield return new("cSHAKE128", "cSHAKE128 (BouncyCastle)", () => new BouncyCastleIXofAdapter(new Org.BouncyCastle.Crypto.Digests.CShakeDigest(128, null, null)));
     }
 
     /// <summary>cSHAKE256 XOF implementations.</summary>
     public static IEnumerable<XofAlgorithmType> CShake256()
     {
-        yield return new("cSHAKE256", "cSHAKE256 (CryptoHives-Scalar)", () => CH.Hash.CShake256.Create(64));
+        var simdSupport = CH.Hash.CShake256.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("cSHAKE256", "cSHAKE256 (CryptoHives-Arm64)", () => CH.Hash.CShake256.Create(SimdSupport.Arm64, 64));
+        }
+        yield return new("cSHAKE256", "cSHAKE256 (CryptoHives-Scalar)", () => CH.Hash.CShake256.Create(SimdSupport.None, 64));
         yield return new("cSHAKE256", "cSHAKE256 (BouncyCastle)", () => new BouncyCastleIXofAdapter(new Org.BouncyCastle.Crypto.Digests.CShakeDigest(256, null, null)));
     }
 
@@ -106,13 +126,23 @@ public sealed class XofAlgorithmType : IFormattable
     /// <summary>TurboSHAKE128 XOF implementation.</summary>
     public static IEnumerable<XofAlgorithmType> TurboShake128()
     {
-        yield return new("TurboSHAKE128", "TurboSHAKE128 (CryptoHives-Scalar)", () => CH.Hash.TurboShake128.Create(32));
+        var simdSupport = CH.Hash.TurboShake128.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("TurboSHAKE128", "TurboSHAKE128 (CryptoHives-Arm64)", () => CH.Hash.TurboShake128.Create(SimdSupport.Arm64, 32));
+        }
+        yield return new("TurboSHAKE128", "TurboSHAKE128 (CryptoHives-Scalar)", () => CH.Hash.TurboShake128.Create(SimdSupport.None, 32));
     }
 
     /// <summary>TurboSHAKE256 XOF implementation.</summary>
     public static IEnumerable<XofAlgorithmType> TurboShake256()
     {
-        yield return new("TurboSHAKE256", "TurboSHAKE256 (CryptoHives-Scalar)", () => CH.Hash.TurboShake256.Create(64));
+        var simdSupport = CH.Hash.TurboShake256.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("TurboSHAKE256", "TurboSHAKE256 (CryptoHives-Arm64)", () => CH.Hash.TurboShake256.Create(SimdSupport.Arm64, 64));
+        }
+        yield return new("TurboSHAKE256", "TurboSHAKE256 (CryptoHives-Scalar)", () => CH.Hash.TurboShake256.Create(SimdSupport.None, 64));
     }
 
     #endregion
@@ -122,13 +152,23 @@ public sealed class XofAlgorithmType : IFormattable
     /// <summary>KT128 XOF implementation.</summary>
     public static IEnumerable<XofAlgorithmType> KT128()
     {
-        yield return new("KT128", "KT128 (CryptoHives-Scalar)", () => CH.Hash.KT128.Create(32));
+        var simdSupport = CH.Hash.KT128.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("KT128", "KT128 (CryptoHives-Arm64)", () => CH.Hash.KT128.Create(SimdSupport.Arm64, 32));
+        }
+        yield return new("KT128", "KT128 (CryptoHives-Scalar)", () => CH.Hash.KT128.Create(SimdSupport.None, 32));
     }
 
     /// <summary>KT256 XOF implementation.</summary>
     public static IEnumerable<XofAlgorithmType> KT256()
     {
-        yield return new("KT256", "KT256 (CryptoHives-Scalar)", () => CH.Hash.KT256.Create(64));
+        var simdSupport = CH.Hash.KT256.SimdSupport;
+        if ((simdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("KT256", "KT256 (CryptoHives-Arm64)", () => CH.Hash.KT256.Create(SimdSupport.Arm64, 64));
+        }
+        yield return new("KT256", "KT256 (CryptoHives-Scalar)", () => CH.Hash.KT256.Create(SimdSupport.None, 64));
     }
 
     #endregion
@@ -148,6 +188,10 @@ public sealed class XofAlgorithmType : IFormattable
     /// <summary>KMAC128 XOF implementations.</summary>
     public static IEnumerable<XofAlgorithmType> KMac128()
     {
+        if ((CH.Mac.KMac128.SimdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("KMAC-128", "KMAC-128 (CryptoHives-Arm64)", () => CH.Mac.KMac128.Create(SimdSupport.Arm64, SharedKMacKey, 32, "Benchmark"));
+        }
         yield return new("KMAC-128", "KMAC-128 (CryptoHives-Scalar)", () => CH.Mac.KMac128.Create(SimdSupport.None, SharedKMacKey, 32, "Benchmark"));
         yield return new("KMAC-128", "KMAC-128 (BouncyCastle)", () => new BouncyCastleKMacXofAdapter(128, SharedKMacKey, SharedKMacCustomization));
 #if NET9_0_OR_GREATER
@@ -159,6 +203,10 @@ public sealed class XofAlgorithmType : IFormattable
     /// <summary>KMAC256 XOF implementations.</summary>
     public static IEnumerable<XofAlgorithmType> KMac256()
     {
+        if ((CH.Mac.KMac256.SimdSupport & SimdSupport.Arm64) != 0)
+        {
+            yield return new("KMAC-256", "KMAC-256 (CryptoHives-Arm64)", () => CH.Mac.KMac256.Create(SimdSupport.Arm64, SharedKMacKey, 64, "Benchmark"));
+        }
         yield return new("KMAC-256", "KMAC-256 (CryptoHives-Scalar)", () => CH.Mac.KMac256.Create(SimdSupport.None, SharedKMacKey, 64, "Benchmark"));
         yield return new("KMAC-256", "KMAC-256 (BouncyCastle)", () => new BouncyCastleKMacXofAdapter(256, SharedKMacKey, SharedKMacCustomization));
 #if NET9_0_OR_GREATER

--- a/tests/Security/Cryptography/Cipher/Kalyna/KalynaTests.cs
+++ b/tests/Security/Cryptography/Cipher/Kalyna/KalynaTests.cs
@@ -184,6 +184,32 @@ public class KalynaTests
     }
 
     /// <summary>
+    /// Cross-validates Kalyna-128/128 ECB decryption with BouncyCastle Dstu7624Engine.
+    /// </summary>
+    [Test]
+    public void CrossValidateDecryptWithBouncyCastle128()
+    {
+        byte[] key = FromHex("000102030405060708090a0b0c0d0e0f");
+        byte[] plaintext = FromHex("101112131415161718191a1b1c1d1e1f");
+
+        // Use BC to encrypt
+        var bcEnc = new Org.BouncyCastle.Crypto.Engines.Dstu7624Engine(128);
+        bcEnc.Init(true, new Org.BouncyCastle.Crypto.Parameters.KeyParameter(key));
+        byte[] ciphertext = new byte[16];
+        bcEnc.ProcessBlock(plaintext, 0, ciphertext, 0);
+
+        // Our implementation decrypts
+        using var dec = Kalyna128.Create();
+        dec.Mode = CipherMode.ECB;
+        dec.Padding = PaddingMode.None;
+        dec.Key = key;
+        dec.IV = new byte[16];
+        byte[] decrypted = dec.Decrypt(ciphertext);
+
+        Assert.That(decrypted, Is.EqualTo(plaintext), "Kalyna-128 decrypt mismatch with BouncyCastle");
+    }
+
+    /// <summary>
     /// Cross-validates Kalyna-128/256 ECB with BouncyCastle Dstu7624Engine.
     /// </summary>
     [Test]
@@ -205,6 +231,118 @@ public class KalynaTests
         bcEngine.ProcessBlock(plaintext, 0, bcOutput, 0);
 
         Assert.That(managed, Is.EqualTo(bcOutput), "Kalyna-256 output mismatch with BouncyCastle");
+    }
+
+    /// <summary>
+    /// Cross-validates Kalyna-128/256 ECB decryption with BouncyCastle Dstu7624Engine.
+    /// </summary>
+    [Test]
+    public void CrossValidateDecryptWithBouncyCastle256()
+    {
+        byte[] key = FromHex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+        byte[] plaintext = FromHex("202122232425262728292a2b2c2d2e2f");
+
+        var bcEnc = new Org.BouncyCastle.Crypto.Engines.Dstu7624Engine(128);
+        bcEnc.Init(true, new Org.BouncyCastle.Crypto.Parameters.KeyParameter(key));
+        byte[] ciphertext = new byte[16];
+        bcEnc.ProcessBlock(plaintext, 0, ciphertext, 0);
+
+        using var dec = Kalyna256.Create();
+        dec.Mode = CipherMode.ECB;
+        dec.Padding = PaddingMode.None;
+        dec.Key = key;
+        dec.IV = new byte[16];
+        byte[] decrypted = dec.Decrypt(ciphertext);
+
+        Assert.That(decrypted, Is.EqualTo(plaintext), "Kalyna-256 decrypt mismatch with BouncyCastle");
+    }
+
+    /// <summary>
+    /// Cross-validates Kalyna-128/128 CBC encryption with BouncyCastle.
+    /// </summary>
+    [Test]
+    public void CrossValidateCbcEncryptWithBouncyCastle128()
+    {
+        byte[] key = FromHex("000102030405060708090a0b0c0d0e0f");
+        byte[] iv = FromHex("00112233445566778899aabbccddeeff");
+        byte[] plaintext = FromHex("0123456789abcdeffedcba98765432100011223344556677fedcba9876543210");
+
+        using var enc = Kalyna128.Create();
+        enc.Mode = CipherMode.CBC;
+        enc.Padding = PaddingMode.None;
+        enc.Key = key;
+        enc.IV = iv;
+        byte[] managed = enc.Encrypt(plaintext);
+
+        var bcCbc = new Org.BouncyCastle.Crypto.Modes.CbcBlockCipher(new Org.BouncyCastle.Crypto.Engines.Dstu7624Engine(128));
+        bcCbc.Init(true, new Org.BouncyCastle.Crypto.Parameters.ParametersWithIV(
+            new Org.BouncyCastle.Crypto.Parameters.KeyParameter(key), iv));
+        byte[] bcOutput = new byte[plaintext.Length];
+        for (int i = 0; i < plaintext.Length / 16; i++)
+            bcCbc.ProcessBlock(plaintext, i * 16, bcOutput, i * 16);
+
+        Assert.That(managed, Is.EqualTo(bcOutput), "Kalyna-128 CBC encrypt mismatch with BouncyCastle");
+    }
+
+    /// <summary>
+    /// Cross-validates Kalyna-128/128 CBC decryption with BouncyCastle.
+    /// </summary>
+    [Test]
+    public void CrossValidateCbcDecryptWithBouncyCastle128()
+    {
+        byte[] key = FromHex("000102030405060708090a0b0c0d0e0f");
+        byte[] iv = FromHex("00112233445566778899aabbccddeeff");
+        byte[] plaintext = FromHex("0123456789abcdeffedcba98765432100011223344556677fedcba9876543210");
+
+        // Encrypt with BC to generate ciphertext
+        var bcEnc = new Org.BouncyCastle.Crypto.Modes.CbcBlockCipher(new Org.BouncyCastle.Crypto.Engines.Dstu7624Engine(128));
+        bcEnc.Init(true, new Org.BouncyCastle.Crypto.Parameters.ParametersWithIV(
+            new Org.BouncyCastle.Crypto.Parameters.KeyParameter(key), iv));
+        byte[] ciphertext = new byte[plaintext.Length];
+        for (int i = 0; i < plaintext.Length / 16; i++)
+            bcEnc.ProcessBlock(plaintext, i * 16, ciphertext, i * 16);
+
+        // Our implementation decrypts
+        using var dec = Kalyna128.Create();
+        dec.Mode = CipherMode.CBC;
+        dec.Padding = PaddingMode.None;
+        dec.Key = key;
+        dec.IV = iv;
+        byte[] decrypted = dec.Decrypt(ciphertext);
+
+        Assert.That(decrypted, Is.EqualTo(plaintext), "Kalyna-128 CBC decrypt mismatch with BouncyCastle");
+    }
+
+    /// <summary>
+    /// Randomized round-trip: verifies encrypt(decrypt(x)) == x for many random keys and plaintexts.
+    /// </summary>
+    [Test]
+    public void RandomizedRoundTrip128()
+    {
+        var rng = new System.Random(42);
+        byte[] key = new byte[16];
+        byte[] plaintext = new byte[64];
+        for (int i = 0; i < 200; i++)
+        {
+            rng.NextBytes(key);
+            rng.NextBytes(plaintext);
+
+            using var enc = Kalyna128.Create();
+            enc.Mode = CipherMode.ECB;
+            enc.Padding = PaddingMode.None;
+            enc.Key = key;
+            enc.IV = new byte[16];
+            byte[] ciphertext = enc.Encrypt(plaintext);
+
+            using var dec = Kalyna128.Create();
+            dec.Mode = CipherMode.ECB;
+            dec.Padding = PaddingMode.None;
+            dec.Key = key;
+            dec.IV = new byte[16];
+            byte[] decrypted = dec.Decrypt(ciphertext);
+
+            Assert.That(decrypted, Is.EqualTo(plaintext), $"Round-trip failed at iteration {i}");
+        }
     }
 
     // ========================================================================

--- a/tests/Security/Cryptography/Hash/HashAlgorithmRegistry.cs
+++ b/tests/Security/Cryptography/Hash/HashAlgorithmRegistry.cs
@@ -33,7 +33,7 @@ public static class HashAlgorithmRegistry
     {
         /// <summary>Operating system provided implementation.</summary>
         OS,
-        /// <summary>CryptoHives managed implementation.</summary>
+        /// <summary>CryptoHives managed scalar implementation.</summary>
         Managed,
         /// <summary>CryptoHives SIMD-optimized implementation.</summary>
         Simd,
@@ -376,7 +376,7 @@ public static class HashAlgorithmRegistry
             if ((simdSupport & flag) != 0)
             {
                 list.Add(new(family, variantName, hashSizeBits,
-                    () => factory(flag), Source.Simd,
+                    () => factory(flag), flag == CHRoot.SimdSupport.Arm64 ? Source.Managed : Source.Simd,
                     () => (simdSupport & flag) != 0));
             }
         }

--- a/tests/Security/Cryptography/shared/AlgorithmRegistry.cs
+++ b/tests/Security/Cryptography/shared/AlgorithmRegistry.cs
@@ -49,6 +49,7 @@ internal static class AlgorithmRegistry
             CH.SimdSupport.ArmPmull => "ArmPmull",
             CH.SimdSupport.ArmSha256 => "ArmSha256",
             CH.SimdSupport.Neon => "Neon",
+            CH.SimdSupport.Arm64 => "ARM64",
             _ => flag.ToString()
         };
 

--- a/tests/Security/Cryptography/shared/AlgorithmRegistry.cs
+++ b/tests/Security/Cryptography/shared/AlgorithmRegistry.cs
@@ -23,6 +23,8 @@ internal static class AlgorithmRegistry
         return Enum.GetValues<CH.SimdSupport>()
 #endif
             .Where<CH.SimdSupport>(IsSingleBitSimdFlag)
+            .GroupBy(flag => (int)flag)
+            .Select(g => g.First())
             .Where(flag => (simdSupport & flag) != 0)
             .OrderByDescending(flag => (int)flag);
     }
@@ -46,6 +48,7 @@ internal static class AlgorithmRegistry
             CH.SimdSupport.ArmAes => "ARM-AES",
             CH.SimdSupport.ArmPmull => "ArmPmull",
             CH.SimdSupport.ArmSha256 => "ArmSha256",
+            CH.SimdSupport.Neon => "Neon",
             _ => flag.ToString()
         };
 


### PR DESCRIPTION
- Various improvements to regional ciphers and hashes to be faster on ARM and x64
- Improved: Aria, Camellia, Kalyna, SM4
- ARM64 version of Keccak which better suits the registers available on Mac M4, auto selected on ARM64 over the default.
