### PR TITLE
Add ParallelHash algorithm with docs and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -433,3 +433,5 @@ docfx/api/
 .AppleDouble
 .LSOverride
 
+# Ignore github Copilot local MCP data
+/.playwright-mcp

--- a/README.md
+++ b/README.md
@@ -7,7 +7,73 @@ The goal of the CryptoHives Open Source Initiative is to provide a collection of
 
 ---
 
-## 🏛️ CryptoHives .NET Foundation Libraries
+## 🏗️ Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                      CryptoHives .NET Foundation                            │
+│                  CryptoHives Open Source Initiative                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+         ┌──────────────────────────┼──────────────────────────┐
+         │                          │                          │
+         ▼                          ▼                          ▼
+┌──────────────────┐   ┌──────────────────────┐   ┌──────────────────────────┐
+│     Memory       │   │      Threading       │   │  Security.Cryptography   │
+├──────────────────┤   ├──────────────────────┤   ├──────────────────────────┤
+│ ArrayPool-       │   │ AsyncLock            │   │ Hash                     │
+│  MemoryStream    │   │ AsyncSemaphore       │   │  SHA-2 · SHA-3           │
+│ ArrayPool-       │   │ AsyncAutoResetEvent  │   │  SHAKE · cSHAKE          │
+│  BufferWriter<T> │   │ AsyncManualReset-    │   │  TurboSHAKE · KT128/256  │
+│ ReadOnlySequence-│   │   Event             │   │  ParallelHash (SP 800-185)│
+│  MemoryStream    │   │ AsyncReaderWriter-   │   │  KMAC128 · KMAC256       │
+│ Ownership        │   │   Lock              │   │  Keccak · BLAKE2 · BLAKE3 │
+│  Primitives      │   │ AsyncBarrier        │   │  Ascon · Regional · Legacy│
+│                  │   │ AsyncCountdown-      │   │                          │
+│                  │   │   Event             │   │ MAC                      │
+│                  │   │                      │   │  HMAC · KMAC             │
+│                  │   │ IValueTaskSource<T>  │   │  AES-CMAC · AES-GMAC    │
+│                  │   │  backed by           │   │  Poly1305 · BLAKE2/3     │
+│                  │   │  ObjectPool<T>       │   │                          │
+│                  │   │                      │   │ Cipher                   │
+│                  │   ├──────────────────────┤   │  AES-GCM/CCM (AEAD)     │
+│                  │   │ Threading.Analyzers  │   │  ChaCha20-Poly1305       │
+│                  │   │  ValueTask Roslyn    │   │  XChaCha20-Poly1305      │
+│                  │   │  analyzers           │   │  Ascon-AEAD128           │
+└──────────────────┘   └──────────────────────┘   │  AES-128/192/256         │
+                                                    │  ChaCha20 (stream)       │
+                                                    │  SM4 · ARIA · Camellia   │
+                                                    │  Kuznyechik · Kalyna     │
+                                                    │  SEED                    │
+                                                    │                          │
+                                                    │ Key Derivation           │
+                                                    │  HKDF · KBKDF           │
+                                                    │  ConcatKDF · PBKDF2     │
+                                                    └──────────────────────────┘
+
+Keccak class hierarchy (Security.Cryptography):
+
+  HashAlgorithm
+  └── KeccakCore  (Keccak-p[1600] sponge, AVX2/SSSE3/scalar dispatch)
+      ├── KeccakHashCore  (fixed-length)
+      │   ├── SHA3_{224,256,384,512}
+      │   └── Keccak{256,384,512}  (Ethereum-compatible, domain sep 0x01)
+      ├── KeccakXofCore : IExtendableOutput  (variable-length)
+      │   ├── Shake{128,256}        (domain sep 0x1F, rate 168/136 bytes)
+      │   ├── TurboShake{128,256}   (12-round Keccak, domain sep 0x7F/0x7E)
+      │   └── KT{128,256}           (KangarooTwelve tree-hashing XOF)
+      └── CShake{128,256} : IExtendableOutput  (bytepad prefix, domain sep 0x04)
+
+  ParallelHash  (static, NIST SP 800-185)
+    per-block inner hash ─── Shake{128,256}
+    finalization         ─── CShake{128,256}  (N="ParallelHash", S=user)
+
+  IncrementalParallelHash  (streaming wrapper, buffers input until Squeeze)
+```
+
+---
+
+
 
 The **CryptoHives Open Source Initiative** is a collection of modern, high-assurance libraries for .NET, developed and maintained by **The Keepers of the CryptoHives**. 
 Each package is designed for security, interoperability, and clarity — making it easy to build secure systems for high performance transformation pipelines and for cryptography workloads without sacrificing developer experience.
@@ -91,6 +157,7 @@ No OS crypto dependency — deterministic results on every platform. Hardware ac
 | SHA-3 | SHA3-224, SHA3-256, SHA3-384, SHA3-512 |
 | Keccak | Keccak-256, Keccak-384, Keccak-512 (Ethereum compatible) |
 | SHAKE / cSHAKE | SHAKE128, SHAKE256, cSHAKE128, cSHAKE256 |
+| ParallelHash (SP 800-185) | ParallelHash128, ParallelHash256 |
 | TurboSHAKE / KT | TurboSHAKE128, TurboSHAKE256, KT128, KT256 |
 | BLAKE | BLAKE2b, BLAKE2s (SIMD-accelerated), BLAKE3 |
 | Ascon | Ascon-Hash256, Ascon-XOF128 (NIST SP 800-232 lightweight) |

--- a/docfx/packages/security/cryptography/hash-algorithms.md
+++ b/docfx/packages/security/cryptography/hash-algorithms.md
@@ -343,7 +343,82 @@ cshake.TryComputeHash(data, hash, out _);
 
 ---
 
-## TurboSHAKE
+## ParallelHash
+
+Tree-hashing construction for parallel processing of large inputs from NIST SP 800-185.
+
+### ParallelHash static class
+
+```csharp
+public static class ParallelHash
+```
+
+**Properties:**
+- Output Size: Variable (specified via output span length)
+- Security: 128 or 256 bits (choose variant)
+- Inner hash: SHAKE128 (128-bit) or SHAKE256 (256-bit)
+- Finalization: cSHAKE128 or cSHAKE256 with function name `"ParallelHash"`
+
+**Algorithm overview:**
+
+Input is split into `B`-byte blocks. Each block is hashed independently with SHAKE128/256 (32 or 64-byte chaining value). The chaining values, block count, and output length are concatenated and finalized with cSHAKE128/256 — enabling parallel computation of the inner block hashes.
+
+**Usage:**
+
+```csharp
+using CryptoHives.Foundation.Security.Cryptography.Hash;
+
+byte[] data = new byte[1024];
+
+// ParallelHash128 — 32-byte output, 64-byte blocks
+Span<byte> hash128 = stackalloc byte[32];
+ParallelHash.ComputeHash128(hash128, data, blockSizeBytes: 64);
+
+// ParallelHash128 with customization string
+ParallelHash.ComputeHash128(hash128, data, blockSizeBytes: 64,
+    customization: System.Text.Encoding.UTF8.GetBytes("My Application"));
+
+// ParallelHash256 — 64-byte output
+Span<byte> hash256 = stackalloc byte[64];
+ParallelHash.ComputeHash256(hash256, data, blockSizeBytes: 64);
+
+// Variable-length output: pass any size output span
+Span<byte> xofOutput = stackalloc byte[128];
+ParallelHash.ComputeHash128(xofOutput, data, blockSizeBytes: 64);
+```
+
+### IncrementalParallelHash
+
+```csharp
+public sealed class IncrementalParallelHash : IDisposable
+```
+
+Streaming wrapper that accepts data in chunks and computes the ParallelHash on `Squeeze`.
+
+```csharp
+using var ph = new IncrementalParallelHash(
+    type: IncrementalParallelHash.ShakeType.Shake128,
+    blockSizeBytes: 64);
+
+ph.Absorb(chunk1);
+ph.Absorb(chunk2);
+ph.Absorb(chunk3);
+
+Span<byte> output = stackalloc byte[32];
+ph.Squeeze(output);
+
+// Reuse for another computation
+ph.Reset();
+ph.Absorb(newData);
+ph.Squeeze(output);
+```
+
+> **Note:** `IncrementalParallelHash` buffers the entire input until `Squeeze` is called
+> (parallel block hashing requires knowledge of total block count before finalizing).
+
+---
+
+
 
 High-performance XOFs from RFC 9861 (Reduced-round Keccak).
 

--- a/docfx/packages/security/cryptography/index.md
+++ b/docfx/packages/security/cryptography/index.md
@@ -61,6 +61,7 @@ using CryptoHives.Foundation.Security.Cryptography.Kdf;
 | SHA-3 | SHA3-224, SHA3-256, SHA3-384, SHA3-512 | [Details](hash-algorithms.md#sha-3-family) |
 | SHAKE | SHAKE128, SHAKE256 (XOF) | [Details](hash-algorithms.md#shake-xof) |
 | cSHAKE | cSHAKE128, cSHAKE256 (Customizable XOF) | [Details](hash-algorithms.md#cshake) |
+| ParallelHash | ParallelHash128, ParallelHash256 (SP 800-185) | [Details](hash-algorithms.md#parallelhash) |
 | TurboSHAKE | TurboSHAKE128, TurboSHAKE256 (High-performance XOF) | [Details](hash-algorithms.md#turboshake) |
 | KangarooTwelve | KT128, KT256 (Parallelizable XOF) | [Details](hash-algorithms.md#kangarootwelve-kt) |
 | Keccak | Keccak-256, Keccak-384, Keccak-512 (Ethereum compatible) | [Details](hash-algorithms.md#keccak) |

--- a/docfx/packages/security/cryptography/specs/NIST-SP-800-185.md
+++ b/docfx/packages/security/cryptography/specs/NIST-SP-800-185.md
@@ -26,8 +26,8 @@ NIST Special Publication 800-185 specifies SHA-3-derived functions:
 | KMAC256 | ✅ Implemented | `KMac256` |
 | TupleHash128 | ⬜ Not implemented | - |
 | TupleHash256 | ⬜ Not implemented | - |
-| ParallelHash128 | ⬜ Not implemented | - |
-| ParallelHash256 | ⬜ Not implemented | - |
+| ParallelHash128 | ✅ Implemented | `ParallelHash` (static), `IncrementalParallelHash` |
+| ParallelHash256 | ✅ Implemented | `ParallelHash` (static), `IncrementalParallelHash` |
 
 ---
 
@@ -216,7 +216,114 @@ The NUnit suite in `tests/Security/Cryptography/Hash/Keccak/CShakeTests.cs` cons
 
 ---
 
-## References
+## ParallelHash
+
+### Definition
+
+ParallelHash is a tree-hashing construction that splits input into fixed-size blocks,
+hashes each block independently with SHAKE128 or SHAKE256, then finalizes with cSHAKE.
+This allows parallel computation across blocks and is suitable for large-input scenarios.
+
+### Parameters
+
+| Variant | Inner hash | Finalization | Chaining value | Security |
+|---------|------------|--------------|----------------|----------|
+| ParallelHash128 | SHAKE128 (256-bit output) | cSHAKE128 | 32 bytes | 128 bits |
+| ParallelHash256 | SHAKE256 (512-bit output) | cSHAKE256 | 64 bytes | 256 bits |
+
+### Algorithm (Appendix A.4 KECCAK-direct form)
+
+```
+ParallelHash128(X, B, L, S):
+  n = max(1, ⌈len(X) / B⌉)
+  z = left_encode(B)
+  for i = 0 to n−1:
+    z = z || KECCAK[256](X[i*B … (i+1)*B−1] || 1111, 256)  -- SHAKE128 inner block
+  z = z || right_encode(n) || right_encode(L)
+  T = bytepad(encode_string("ParallelHash") || encode_string(S), 168)
+  return KECCAK[256](T || z || 00, L)                        -- cSHAKE128 finalization
+```
+
+`KECCAK[256](M || 1111, n)` is SHAKE128 (domain separator `0x1F`).  
+`KECCAK[256](T || M || 00, L)` is cSHAKE128 (domain separator `0x04` when T is non-empty).  
+ParallelHash256 uses KECCAK[512] (SHAKE256 / cSHAKE256, rate 136 bytes) with the same structure.
+
+### Test Vectors (NIST SP 800-185 Sample Data)
+
+**ParallelHash128 Sample #1**
+
+```
+Input:    000102030405060710111213141516172021222324252627 (24 bytes)
+B:        8 bytes
+S:        "" (empty)
+L:        256 bits (32 bytes)
+Output:   BA8DC1D1D979331D3F813603C67F72609AB5E44B94A0B8F9AF46514454A2B4F5
+```
+
+**ParallelHash128 Sample #2**
+
+```
+Input:    000102030405060710111213141516172021222324252627 (24 bytes)
+B:        8 bytes
+S:        "Parallel Data"
+L:        256 bits (32 bytes)
+Output:   FC484DCB3F84DCEEDC353438151BEE58157D6EFED0445A81F165E495795B7206
+```
+
+**ParallelHash128 Sample #3**
+
+```
+Input:    000102030405060708090A0B101112131415161718191A1B
+          202122232425262728292A2B303132333435363738393A3B
+          404142434445464748494A4B505152535455565758595A5B
+          606162636465666768696A6B707172737475767778797A7B (72 bytes)
+B:        12 bytes
+S:        "Parallel Data"
+L:        256 bits (32 bytes)
+Output:   F7FD5312896C6685C828AF7E2ADB97E393E7F8D54E3C2EA4B95E5ACA3796E8FC
+```
+
+**ParallelHash256 Sample #1**
+
+```
+Input:    000102030405060710111213141516172021222324252627 (24 bytes)
+B:        8 bytes
+S:        "" (empty)
+L:        512 bits (64 bytes)
+Output:   BC1EF124DA34495E948EAD207DD9842235DA432D2BBC54B4C110E64C45110553
+          1B7F2A3E0CE055C02805E7C2DE1FB746AF97A1DD01F43B824E31B87612410429
+```
+
+**ParallelHash256 Sample #2**
+
+```
+Input:    000102030405060710111213141516172021222324252627 (24 bytes)
+B:        8 bytes
+S:        "Parallel Data"
+L:        512 bits (64 bytes)
+Output:   CDF15289B54F6212B4BC270528B49526006DD9B54E2B6ADD1EF6900DDA3963BB
+          33A72491F236969CA8AFAEA29C682D47A393C065B38E29FAE651A2091C833110
+```
+
+**ParallelHash256 Sample #3**
+
+```
+Input:    000102030405060708090A0B101112131415161718191A1B
+          202122232425262728292A2B303132333435363738393A3B
+          404142434445464748494A4B505152535455565758595A5B
+          606162636465666768696A6B707172737475767778797A7B (72 bytes)
+B:        12 bytes
+S:        "Parallel Data"
+L:        512 bits (64 bytes)
+Output:   69D0FCB764EA055DD09334BC6021CB7E4B61348DFF375DA262671CDEC3EFFA8D
+          1B4568A6CCE16B1CAD946DDDE27F6CE2B8DEE4CD1B24851EBF00EB90D43813E9
+```
+
+All 6 NIST sample vectors are verified in `tests/Security/Cryptography/Hash/ParallelHashTests.cs`.
+
+---
+
+
 
 1. NIST SP 800-185: https://doi.org/10.6028/NIST.SP.800-185
 2. Keccak Team: https://keccak.team/

--- a/docfx/packages/security/cryptography/specs/ParallelHash-vectors.md
+++ b/docfx/packages/security/cryptography/specs/ParallelHash-vectors.md
@@ -1,0 +1,151 @@
+# ParallelHash Test Vectors (NIST SP 800-185)
+
+## Overview
+
+Test vectors for `ParallelHash128` and `ParallelHash256` from NIST SP 800-185 Appendix A.4.
+
+All vectors are verified by the NUnit suite in
+`tests/Security/Cryptography/Hash/ParallelHashTests.cs`.
+
+---
+
+## ParallelHash128
+
+Inner block hash: SHAKE128 (256-bit output = 32-byte chaining values)
+Finalization: cSHAKE128, N=`"ParallelHash"`, S=user customization string
+
+### Sample #1 — empty customization
+
+```
+Input (24 bytes):
+  00 01 02 03 04 05 06 07
+  10 11 12 13 14 15 16 17
+  20 21 22 23 24 25 26 27
+
+Block size B: 8 bytes  (3 blocks)
+Customization S: "" (empty)
+Output length L: 256 bits (32 bytes)
+
+Output:
+  BA 8D C1 D1 D9 79 33 1D 3F 81 36 03 C6 7F 72 60
+  9A B5 E4 4B 94 A0 B8 F9 AF 46 51 44 54 A2 B4 F5
+```
+
+### Sample #2 — with customization string
+
+```
+Input (24 bytes):
+  00 01 02 03 04 05 06 07
+  10 11 12 13 14 15 16 17
+  20 21 22 23 24 25 26 27
+
+Block size B: 8 bytes  (3 blocks)
+Customization S: "Parallel Data"
+Output length L: 256 bits (32 bytes)
+
+Output:
+  FC 48 4D CB 3F 84 DC EE DC 35 34 38 15 1B EE 58
+  15 7D 6E FE D0 44 5A 81 F1 65 E4 95 79 5B 72 06
+```
+
+### Sample #3 — larger input, different block size
+
+```
+Input (72 bytes):
+  00 01 02 03 04 05 06 07 08 09 0A 0B
+  10 11 12 13 14 15 16 17 18 19 1A 1B
+  20 21 22 23 24 25 26 27 28 29 2A 2B
+  30 31 32 33 34 35 36 37 38 39 3A 3B
+  40 41 42 43 44 45 46 47 48 49 4A 4B
+  50 51 52 53 54 55 56 57 58 59 5A 5B
+  60 61 62 63 64 65 66 67 68 69 6A 6B
+  70 71 72 73 74 75 76 77 78 79 7A 7B
+
+Block size B: 12 bytes  (6 blocks)
+Customization S: "Parallel Data"
+Output length L: 256 bits (32 bytes)
+
+Output:
+  F7 FD 53 12 89 6C 66 85 C8 28 AF 7E 2A DB 97 E3
+  93 E7 F8 D5 4E 3C 2E A4 B9 5E 5A CA 37 96 E8 FC
+```
+
+---
+
+## ParallelHash256
+
+Inner block hash: SHAKE256 (512-bit output = 64-byte chaining values)
+Finalization: cSHAKE256, N=`"ParallelHash"`, S=user customization string
+
+### Sample #1 — empty customization
+
+```
+Input (24 bytes):
+  00 01 02 03 04 05 06 07
+  10 11 12 13 14 15 16 17
+  20 21 22 23 24 25 26 27
+
+Block size B: 8 bytes  (3 blocks)
+Customization S: "" (empty)
+Output length L: 512 bits (64 bytes)
+
+Output:
+  BC 1E F1 24 DA 34 49 5E 94 8E AD 20 7D D9 84 22
+  35 DA 43 2D 2B BC 54 B4 C1 10 E6 4C 45 11 05 53
+  1B 7F 2A 3E 0C E0 55 C0 28 05 E7 C2 DE 1F B7 46
+  AF 97 A1 DD 01 F4 3B 82 4E 31 B8 76 12 41 04 29
+```
+
+### Sample #2 — with customization string
+
+```
+Input (24 bytes):
+  00 01 02 03 04 05 06 07
+  10 11 12 13 14 15 16 17
+  20 21 22 23 24 25 26 27
+
+Block size B: 8 bytes  (3 blocks)
+Customization S: "Parallel Data"
+Output length L: 512 bits (64 bytes)
+
+Output:
+  CD F1 52 89 B5 4F 62 12 B4 BC 27 05 28 B4 95 26
+  00 6D D9 B5 4E 2B 6A DD 1E F6 90 0D DA 39 63 BB
+  33 A7 24 91 F2 36 96 9C A8 AF AE A2 9C 68 2D 47
+  A3 93 C0 65 B3 8E 29 FA E6 51 A2 09 1C 83 31 10
+```
+
+### Sample #3 — larger input, different block size
+
+```
+Input (72 bytes):
+  00 01 02 03 04 05 06 07 08 09 0A 0B
+  10 11 12 13 14 15 16 17 18 19 1A 1B
+  20 21 22 23 24 25 26 27 28 29 2A 2B
+  30 31 32 33 34 35 36 37 38 39 3A 3B
+  40 41 42 43 44 45 46 47 48 49 4A 4B
+  50 51 52 53 54 55 56 57 58 59 5A 5B
+  60 61 62 63 64 65 66 67 68 69 6A 6B
+  70 71 72 73 74 75 76 77 78 79 7A 7B
+
+Block size B: 12 bytes  (6 blocks)
+Customization S: "Parallel Data"
+Output length L: 512 bits (64 bytes)
+
+Output:
+  69 D0 FC B7 64 EA 05 5D D0 93 34 BC 60 21 CB 7E
+  4B 61 34 8D FF 37 5D A2 62 67 1C DE C3 EF FA 8D
+  1B 45 68 A6 CC E1 6B 1C AD 94 6D DD E2 7F 6C E2
+  B8 DE E4 CD 1B 24 85 1E BF 00 EB 90 D4 38 13 E9
+```
+
+---
+
+## References
+
+- NIST SP 800-185: <https://doi.org/10.6028/NIST.SP.800-185>
+- Bouncy Castle C# reference: `ParallelHashTest.cs`
+
+---
+
+© 2026 The Keepers of the CryptoHives

--- a/docfx/packages/security/cryptography/toc.yml
+++ b/docfx/packages/security/cryptography/toc.yml
@@ -32,7 +32,7 @@
           href: specs/NIST-FIPS-197.md
         - name: FIPS 202 (SHA-3, SHAKE)
           href: specs/NIST-FIPS-202.md
-        - name: SP 800-185 (cSHAKE, KMAC)
+        - name: SP 800-185 (cSHAKE, KMAC, ParallelHash)
           href: specs/NIST-SP-800-185.md
         - name: RFC 2104 (HMAC)
           href: specs/RFC-2104.md
@@ -50,6 +50,8 @@
           href: specs/SHA3-vectors.md
         - name: SHAKE XOF
           href: specs/SHAKE-vectors.md
+        - name: ParallelHash (SP 800-185)
+          href: specs/ParallelHash-vectors.md
         - name: TurboSHAKE
           href: specs/TurboSHAKE-vectors.md
         - name: KT (KangarooTwelve)

--- a/src/Security/Cryptography/Hash/IncrementalParallelHash.cs
+++ b/src/Security/Cryptography/Hash/IncrementalParallelHash.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;

--- a/src/Security/Cryptography/Hash/IncrementalParallelHash.cs
+++ b/src/Security/Cryptography/Hash/IncrementalParallelHash.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Security.Cryptography.Hash;
+
+using System;
+using System.IO;
+
+/// <summary>
+/// Provides incremental ParallelHash computation.
+/// </summary>
+public sealed class IncrementalParallelHash : IDisposable
+{
+    /// <summary>
+    /// The default block size in bytes (4 MiB).
+    /// </summary>
+    public const int DefaultBlockSizeBytes = 0x100_000;
+
+    private readonly MemoryStream _buffer;
+    private readonly ShakeType _type;
+    private readonly int _blockSizeBytes;
+    private readonly byte[] _customization;
+    private bool _isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IncrementalParallelHash"/> class.
+    /// </summary>
+    /// <param name="type">The SHAKE variant used for the ParallelHash construction.</param>
+    /// <param name="blockSizeBytes">The block size in bytes.</param>
+    /// <param name="customization">Optional customization string S (default: empty).</param>
+    public IncrementalParallelHash(ShakeType type = ShakeType.Shake128, int blockSizeBytes = DefaultBlockSizeBytes, ReadOnlySpan<byte> customization = default)
+    {
+        if (blockSizeBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(blockSizeBytes), "Block size must be positive.");
+        }
+
+        _type = type;
+        _blockSizeBytes = blockSizeBytes;
+        _customization = customization.IsEmpty ? Array.Empty<byte>() : customization.ToArray();
+        _buffer = new MemoryStream();
+    }
+
+    /// <summary>
+    /// Absorbs data into the ParallelHash instance.
+    /// </summary>
+    /// <param name="data">The data to absorb.</param>
+    public void Absorb(ReadOnlySpan<byte> data)
+    {
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException(nameof(IncrementalParallelHash));
+        }
+
+        if (!data.IsEmpty)
+        {
+            byte[] copy = data.ToArray();
+            _buffer.Write(copy, 0, copy.Length);
+        }
+    }
+
+    /// <summary>
+    /// Squeezes the final hash output.
+    /// </summary>
+    /// <param name="output">The span to receive the hash value.</param>
+    /// <returns>The output span containing the hash value.</returns>
+    public Span<byte> Squeeze(Span<byte> output)
+    {
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException(nameof(IncrementalParallelHash));
+        }
+
+        ReadOnlySpan<byte> input = _buffer.ToArray();
+        ParallelHash.ComputeHashCore(output, input, _blockSizeBytes, _type == ShakeType.Shake256, _customization);
+        return output;
+    }
+
+    /// <summary>
+    /// Resets the instance for reuse.
+    /// </summary>
+    public void Reset()
+    {
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException(nameof(IncrementalParallelHash));
+        }
+
+        _buffer.SetLength(0);
+        _buffer.Position = 0;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _buffer.Dispose();
+        _isDisposed = true;
+    }
+
+    /// <summary>
+    /// The SHAKE type used for the hash computation.
+    /// </summary>
+    public enum ShakeType
+    {
+        /// <summary>
+        /// Use SHAKE128 (128-bit security strength).
+        /// </summary>
+        Shake128,
+
+        /// <summary>
+        /// Use SHAKE256 (256-bit security strength).
+        /// </summary>
+        Shake256
+    }
+}

--- a/src/Security/Cryptography/Hash/ParallelHash.cs
+++ b/src/Security/Cryptography/Hash/ParallelHash.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;

--- a/src/Security/Cryptography/Hash/ParallelHash.cs
+++ b/src/Security/Cryptography/Hash/ParallelHash.cs
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Security.Cryptography.Hash;
+
+using System;
+using System.Text;
+
+/// <summary>
+/// Computes a variable-length output using ParallelHash (NIST SP 800-185).
+/// </summary>
+/// <remarks>
+/// <para>
+/// ParallelHash divides input into fixed-size blocks, hashes each block with SHAKE128 or SHAKE256
+/// (i.e. <c>KECCAK[256](block ‖ 1111, 256)</c> or <c>KECCAK[512](block ‖ 1111, 512)</c>),
+/// concatenates those chaining values with encoding of the block count and output length, and
+/// finalizes with cSHAKE128 or cSHAKE256 using function-name string <c>"ParallelHash"</c>
+/// per NIST SP 800-185 Section 6.3 / Appendix A.4.
+/// </para>
+/// <para>
+/// Use <see cref="ComputeHash128(Span{byte}, ReadOnlySpan{byte}, int, ReadOnlySpan{byte})"/> for 128-bit security (SHAKE128 inner blocks, cSHAKE128
+/// finalization) and <see cref="ComputeHash256(Span{byte}, ReadOnlySpan{byte}, int, ReadOnlySpan{byte})"/> for 256-bit security (SHAKE256, cSHAKE256).
+/// For incremental or streaming computation, use <see cref="IncrementalParallelHash"/>.
+/// </para>
+/// </remarks>
+public static class ParallelHash
+{
+    /// <summary>
+    /// Default block size in bytes (4 MiB).
+    /// </summary>
+    public const int DefaultBlockSizeBytes = 0x100_000;
+
+    private const int ChainingValue128Bytes = 32;
+    private const int ChainingValue256Bytes = 64;
+    private static readonly byte[] ParallelHashFunctionName = Encoding.ASCII.GetBytes("ParallelHash");
+
+    /// <summary>
+    /// Computes a hash using ParallelHash128.
+    /// </summary>
+    /// <param name="output">The output span to receive the hash.</param>
+    /// <param name="inputData">The data to hash.</param>
+    /// <param name="blockSizeBytes">Block size in bytes (default: 4 MiB).</param>
+    /// <param name="customization">Optional customization string S (default: empty).</param>
+    /// <returns>The computed hash value as a span.</returns>
+    public static Span<byte> ComputeHash128(
+        Span<byte> output,
+        ReadOnlySpan<byte> inputData,
+        int blockSizeBytes = DefaultBlockSizeBytes,
+        ReadOnlySpan<byte> customization = default)
+        => ComputeHashCore(output, inputData, blockSizeBytes, useShake256: false, customization);
+
+    /// <summary>
+    /// Computes a hash using ParallelHash256.
+    /// </summary>
+    /// <param name="output">The output span to receive the hash.</param>
+    /// <param name="inputData">The data to hash.</param>
+    /// <param name="blockSizeBytes">Block size in bytes (default: 4 MiB).</param>
+    /// <param name="customization">Optional customization string S (default: empty).</param>
+    /// <returns>The computed hash value as a span.</returns>
+    public static Span<byte> ComputeHash256(
+        Span<byte> output,
+        ReadOnlySpan<byte> inputData,
+        int blockSizeBytes = DefaultBlockSizeBytes,
+        ReadOnlySpan<byte> customization = default)
+        => ComputeHashCore(output, inputData, blockSizeBytes, useShake256: true, customization);
+
+    /// <summary>
+    /// Computes a hash using ParallelHash128, returning the result as an immutable byte array.
+    /// </summary>
+    /// <param name="inputData">The data to hash.</param>
+    /// <param name="blockSizeBytes">Block size in bytes (default: 4 MiB).</param>
+    /// <returns>The 32-byte hash value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="inputData"/> is null.</exception>
+    public static byte[] ComputeHash128(byte[] inputData, int blockSizeBytes = DefaultBlockSizeBytes)
+    {
+        if (inputData is null) throw new ArgumentNullException(nameof(inputData));
+        byte[] output = new byte[ChainingValue128Bytes];
+        ComputeHash128(output, inputData, blockSizeBytes);
+        return output;
+    }
+
+    /// <summary>
+    /// Computes a hash using ParallelHash256, returning the result as an immutable byte array.
+    /// </summary>
+    /// <param name="inputData">The data to hash.</param>
+    /// <param name="blockSizeBytes">Block size in bytes (default: 4 MiB).</param>
+    /// <returns>The 64-byte hash value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="inputData"/> is null.</exception>
+    public static byte[] ComputeHash256(byte[] inputData, int blockSizeBytes = DefaultBlockSizeBytes)
+    {
+        if (inputData is null) throw new ArgumentNullException(nameof(inputData));
+        byte[] output = new byte[ChainingValue256Bytes];
+        ComputeHash256(output, inputData, blockSizeBytes);
+        return output;
+    }
+
+    internal static Span<byte> ComputeHashCore(
+        Span<byte> output,
+        ReadOnlySpan<byte> inputData,
+        int blockSizeBytes,
+        bool useShake256,
+        ReadOnlySpan<byte> customization)
+    {
+        if (output.Length == 0)
+        {
+            return output;
+        }
+
+        if (blockSizeBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(blockSizeBytes), "Block size must be positive.");
+        }
+
+        byte[] customBytes = customization.IsEmpty ? Array.Empty<byte>() : customization.ToArray();
+
+        if (useShake256)
+        {
+            using var finalXof = CShake256.Create(
+                outputBytes: CShake256.DefaultOutputBits / 8,
+                functionName: ParallelHashFunctionName,
+                customization: customBytes);
+            return RunHashWithXof(finalXof, output, inputData, blockSizeBytes, useShake256: true);
+        }
+        else
+        {
+            using var finalXof = CShake128.Create(
+                outputBytes: CShake128.DefaultOutputBits / 8,
+                functionName: ParallelHashFunctionName,
+                customization: customBytes);
+            return RunHashWithXof(finalXof, output, inputData, blockSizeBytes, useShake256: false);
+        }
+    }
+
+    private static Span<byte> RunHashWithXof(
+        IExtendableOutput finalXof,
+        Span<byte> output,
+        ReadOnlySpan<byte> inputData,
+        int blockSizeBytes,
+        bool useShake256)
+    {
+        long blockCount = (inputData.Length + blockSizeBytes - 1L) / blockSizeBytes;
+        long outputBits = checked((long)output.Length * 8L);
+
+        Span<byte> encodeBuffer = stackalloc byte[CShake128.EncodeBufferLength];
+        AbsorbEncodedLeft(finalXof, blockSizeBytes, encodeBuffer);
+
+        int chainingValueBytes = useShake256 ? ChainingValue256Bytes : ChainingValue128Bytes;
+        byte[] chainingValue = new byte[chainingValueBytes];
+
+        for (long i = 0; i < blockCount; i++)
+        {
+            int offset = checked((int)(i * blockSizeBytes));
+            int blockLength = Math.Min(blockSizeBytes, inputData.Length - offset);
+            ReadOnlySpan<byte> block = inputData.Slice(offset, blockLength);
+
+            ComputeInnerBlockHash(useShake256, block, chainingValue);
+            finalXof.Absorb(chainingValue);
+        }
+
+        AbsorbEncodedRight(finalXof, blockCount, encodeBuffer);
+        AbsorbEncodedRight(finalXof, outputBits, encodeBuffer);
+        finalXof.Squeeze(output);
+        return output;
+    }
+
+    private static void ComputeInnerBlockHash(bool useShake256, ReadOnlySpan<byte> block, Span<byte> chainingValue)
+    {
+        // Spec: KECCAK[256](block || 1111, 256) = SHAKE128(block, 256 bits) for 128-bit variant
+        //       KECCAK[512](block || 1111, 512) = SHAKE256(block, 512 bits) for 256-bit variant
+        if (useShake256)
+        {
+            using var shake256 = Shake256.Create(ChainingValue256Bytes);
+            if (!shake256.TryComputeHash(block, chainingValue, out _))
+            {
+                throw new InvalidOperationException("Failed to compute SHAKE256 chaining value.");
+            }
+            return;
+        }
+
+        using var shake128 = Shake128.Create(ChainingValue128Bytes);
+        if (!shake128.TryComputeHash(block, chainingValue, out _))
+        {
+            throw new InvalidOperationException("Failed to compute SHAKE128 chaining value.");
+        }
+    }
+
+    private static void AbsorbEncodedLeft(IExtendableOutput xof, long value, Span<byte> encodeBuffer)
+    {
+        if (!CShake128.TryLeftEncode(encodeBuffer, value, out int written))
+        {
+            throw new InvalidOperationException("Failed to left-encode value.");
+        }
+
+        xof.Absorb(encodeBuffer[..written]);
+    }
+
+    private static void AbsorbEncodedRight(IExtendableOutput xof, long value, Span<byte> encodeBuffer)
+    {
+        if (!CShake128.TryRightEncode(encodeBuffer, value, out int written))
+        {
+            throw new InvalidOperationException("Failed to right-encode value.");
+        }
+
+        xof.Absorb(encodeBuffer[..written]);
+    }
+}

--- a/tests/Security/Cryptography/Hash/ParallelHashTests.cs
+++ b/tests/Security/Cryptography/Hash/ParallelHashTests.cs
@@ -3,9 +3,9 @@
 
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
+using NUnit.Framework;
 using System;
 using System.Text;
-using NUnit.Framework;
 
 /// <summary>
 /// Tests for <see cref="ParallelHash"/> using NIST SP 800-185 sample vectors.

--- a/tests/Security/Cryptography/Hash/ParallelHashTests.cs
+++ b/tests/Security/Cryptography/Hash/ParallelHashTests.cs
@@ -1,0 +1,323 @@
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Security.Cryptography.Hash;
+
+using System;
+using System.Text;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for <see cref="ParallelHash"/> using NIST SP 800-185 sample vectors.
+/// </summary>
+/// <remarks>
+/// Sample values from the NIST SP 800-185 companion document:
+/// https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/ParallelHash_samples.pdf
+/// </remarks>
+[TestFixture, Parallelizable(ParallelScope.All), CancelAfter(30000)]
+public class ParallelHashTests
+{
+    // NIST SP 800-185 sample input data used across multiple test cases.
+    private static readonly byte[] SampleData24 = TestHelpers.FromHexString(
+        "000102030405060710111213141516172021222324252627");
+
+    private static readonly byte[] SampleData72 = TestHelpers.FromHexString(
+        "000102030405060708090A0B" +
+        "101112131415161718191A1B" +
+        "202122232425262728292A2B" +
+        "303132333435363738393A3B" +
+        "404142434445464748494A4B" +
+        "505152535455565758595A5B");
+
+    // -------------------------------------------------------------------------
+    // ParallelHash128 — NIST SP 800-185 Appendix sample vectors
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// ParallelHash128 Sample 1: empty customization, blockSize=8, 24-byte input.
+    /// </summary>
+    [Test]
+    public void ParallelHash128NistSample1()
+    {
+        byte[] expected = TestHelpers.FromHexString(
+            "BA8DC1D1D979331D3F813603C67F72609AB5E44B94A0B8F9AF46514454A2B4F5");
+        byte[] output = new byte[32];
+
+        ParallelHash.ComputeHash128(output, SampleData24, blockSizeBytes: 8);
+
+        Assert.That(output, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// ParallelHash128 Sample 2: customization="Parallel Data", blockSize=8, 24-byte input.
+    /// </summary>
+    [Test]
+    public void ParallelHash128NistSample2()
+    {
+        byte[] expected = TestHelpers.FromHexString(
+            "FC484DCB3F84DCEEDC353438151BEE58157D6EFED0445A81F165E495795B7206");
+        byte[] output = new byte[32];
+        byte[] customization = Encoding.ASCII.GetBytes("Parallel Data");
+
+        ParallelHash.ComputeHash128(output, SampleData24, blockSizeBytes: 8, customization);
+
+        Assert.That(output, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// ParallelHash128 Sample 3: customization="Parallel Data", blockSize=12, 72-byte input.
+    /// </summary>
+    [Test]
+    public void ParallelHash128NistSample3()
+    {
+        byte[] expected = TestHelpers.FromHexString(
+            "F7FD5312896C6685C828AF7E2ADB97E393E7F8D54E3C2EA4B95E5ACA3796E8FC");
+        byte[] output = new byte[32];
+        byte[] customization = Encoding.ASCII.GetBytes("Parallel Data");
+
+        ParallelHash.ComputeHash128(output, SampleData72, blockSizeBytes: 12, customization);
+
+        Assert.That(output, Is.EqualTo(expected));
+    }
+
+    // -------------------------------------------------------------------------
+    // ParallelHash256 — NIST SP 800-185 Appendix sample vectors
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// ParallelHash256 Sample 1: empty customization, blockSize=8, 24-byte input.
+    /// </summary>
+    [Test]
+    public void ParallelHash256NistSample1()
+    {
+        byte[] expected = TestHelpers.FromHexString(
+            "BC1EF124DA34495E948EAD207DD9842235DA432D2BBC54B4C110E64C451105531B7F2A3E" +
+            "0CE055C02805E7C2DE1FB746AF97A1DD01F43B824E31B87612410429");
+        byte[] output = new byte[64];
+
+        ParallelHash.ComputeHash256(output, SampleData24, blockSizeBytes: 8);
+
+        Assert.That(output, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// ParallelHash256 Sample 2: customization="Parallel Data", blockSize=8, 24-byte input.
+    /// </summary>
+    [Test]
+    public void ParallelHash256NistSample2()
+    {
+        byte[] expected = TestHelpers.FromHexString(
+            "CDF15289B54F6212B4BC270528B49526006DD9B54E2B6ADD1EF6900DDA3963BB" +
+            "33A72491F236969CA8AFAEA29C682D47A393C065B38E29FAE651A2091C833110");
+        byte[] output = new byte[64];
+        byte[] customization = Encoding.ASCII.GetBytes("Parallel Data");
+
+        ParallelHash.ComputeHash256(output, SampleData24, blockSizeBytes: 8, customization);
+
+        Assert.That(output, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// ParallelHash256 Sample 3: customization="Parallel Data", blockSize=12, 72-byte input.
+    /// </summary>
+    [Test]
+    public void ParallelHash256NistSample3()
+    {
+        byte[] expected = TestHelpers.FromHexString(
+            "69D0FCB764EA055DD09334BC6021CB7E4B61348DFF375DA262671CDEC3EFFA8D" +
+            "1B4568A6CCE16B1CAD946DDDE27F6CE2B8DEE4CD1B24851EBF00EB90D43813E9");
+        byte[] output = new byte[64];
+        byte[] customization = Encoding.ASCII.GetBytes("Parallel Data");
+
+        ParallelHash.ComputeHash256(output, SampleData72, blockSizeBytes: 12, customization);
+
+        Assert.That(output, Is.EqualTo(expected));
+    }
+
+    // -------------------------------------------------------------------------
+    // Incremental API consistency tests
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// IncrementalParallelHash128 produces same result as static ParallelHash128.
+    /// </summary>
+    [Test]
+    public void IncrementalParallelHash128MatchesStaticApi()
+    {
+        byte[] expected = new byte[32];
+        ParallelHash.ComputeHash128(expected, SampleData24, blockSizeBytes: 8);
+
+        byte[] actual = new byte[32];
+        using var incremental = new IncrementalParallelHash(IncrementalParallelHash.ShakeType.Shake128, blockSizeBytes: 8);
+        incremental.Absorb(SampleData24);
+        incremental.Squeeze(actual);
+
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// IncrementalParallelHash256 produces same result as static ParallelHash256.
+    /// </summary>
+    [Test]
+    public void IncrementalParallelHash256MatchesStaticApi()
+    {
+        byte[] expected = new byte[64];
+        byte[] customization = Encoding.ASCII.GetBytes("Parallel Data");
+        ParallelHash.ComputeHash256(expected, SampleData24, blockSizeBytes: 8, customization);
+
+        byte[] actual = new byte[64];
+        using var incremental = new IncrementalParallelHash(IncrementalParallelHash.ShakeType.Shake256, blockSizeBytes: 8, customization);
+        incremental.Absorb(SampleData24);
+        incremental.Squeeze(actual);
+
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Absorbing data in multiple chunks matches a single-chunk absorb.
+    /// </summary>
+    [Test]
+    public void IncrementalAbsorbInChunksMatchesSingleAbsorb()
+    {
+        byte[] expected = new byte[32];
+        using (var single = new IncrementalParallelHash(blockSizeBytes: 8))
+        {
+            single.Absorb(SampleData24);
+            single.Squeeze(expected);
+        }
+
+        byte[] actual = new byte[32];
+        using (var chunked = new IncrementalParallelHash(blockSizeBytes: 8))
+        {
+            chunked.Absorb(SampleData24.AsSpan(0, 12));
+            chunked.Absorb(SampleData24.AsSpan(12));
+            chunked.Squeeze(actual);
+        }
+
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge case / boundary tests
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Empty output span returns without error.
+    /// </summary>
+    [Test]
+    public void EmptyOutputSpanReturnsEmpty()
+    {
+        var result = ParallelHash.ComputeHash128(Span<byte>.Empty, SampleData24);
+        Assert.That(result.Length, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// Zero-length input produces a deterministic result.
+    /// </summary>
+    [Test]
+    public void EmptyInputProducesDeterministicOutput()
+    {
+        byte[] result1 = new byte[32];
+        byte[] result2 = new byte[32];
+        ParallelHash.ComputeHash128(result1, ReadOnlySpan<byte>.Empty, blockSizeBytes: 8);
+        ParallelHash.ComputeHash128(result2, ReadOnlySpan<byte>.Empty, blockSizeBytes: 8);
+        Assert.That(result1, Is.EqualTo(result2));
+    }
+
+    /// <summary>
+    /// Non-positive block size throws ArgumentOutOfRangeException.
+    /// </summary>
+    [Test]
+    public void ZeroBlockSizeThrows()
+    {
+        byte[] output = new byte[32];
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ParallelHash.ComputeHash128(output, SampleData24, blockSizeBytes: 0));
+    }
+
+    /// <summary>
+    /// Null input byte array throws ArgumentNullException.
+    /// </summary>
+    [Test]
+    public void NullInputThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ParallelHash.ComputeHash128(null!, blockSizeBytes: 8));
+    }
+
+    /// <summary>
+    /// Input exactly equal to block size (single full block) is handled correctly.
+    /// </summary>
+    [Test]
+    public void SingleFullBlockProducesDeterministicOutput()
+    {
+        byte[] data = new byte[8];
+        for (int i = 0; i < data.Length; i++) data[i] = (byte)i;
+
+        byte[] result1 = new byte[32];
+        byte[] result2 = new byte[32];
+        ParallelHash.ComputeHash128(result1, data, blockSizeBytes: 8);
+        ParallelHash.ComputeHash128(result2, data, blockSizeBytes: 8);
+        Assert.That(result1, Is.EqualTo(result2));
+    }
+
+    /// <summary>
+    /// Input spanning multiple complete blocks is handled correctly.
+    /// </summary>
+    [Test]
+    public void MultipleCompleteBlocksProducesDeterministicOutput()
+    {
+        byte[] data = new byte[48];
+        for (int i = 0; i < data.Length; i++) data[i] = (byte)(i % 256);
+
+        byte[] result1 = new byte[32];
+        byte[] result2 = new byte[32];
+        ParallelHash.ComputeHash128(result1, data, blockSizeBytes: 8);
+        ParallelHash.ComputeHash128(result2, data, blockSizeBytes: 8);
+        Assert.That(result1, Is.EqualTo(result2));
+    }
+
+    /// <summary>
+    /// Reset allows reuse of IncrementalParallelHash instance.
+    /// </summary>
+    [Test]
+    public void IncrementalResetAllowsReuse()
+    {
+        byte[] expected = new byte[32];
+        byte[] actual = new byte[32];
+
+        using var incremental = new IncrementalParallelHash(blockSizeBytes: 8);
+
+        incremental.Absorb(SampleData24);
+        incremental.Squeeze(expected);
+
+        incremental.Reset();
+
+        incremental.Absorb(SampleData24);
+        incremental.Squeeze(actual);
+
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Disposed instance throws ObjectDisposedException on Absorb.
+    /// </summary>
+    [Test]
+    public void DisposedInstanceThrowsOnAbsorb()
+    {
+        var incremental = new IncrementalParallelHash();
+        incremental.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => incremental.Absorb(SampleData24));
+    }
+
+    /// <summary>
+    /// Disposed instance throws ObjectDisposedException on Squeeze.
+    /// </summary>
+    [Test]
+    public void DisposedInstanceThrowsOnSqueeze()
+    {
+        var incremental = new IncrementalParallelHash();
+        incremental.Dispose();
+        byte[] output = new byte[32];
+        Assert.Throws<ObjectDisposedException>(() => incremental.Squeeze(output));
+    }
+}


### PR DESCRIPTION
Add support and documentation for the NIST SP 800-185 ParallelHash construction (ParallelHash128 and ParallelHash256) to the CryptoHives .NET Foundation libraries. Implementation, updated documentation and detailed test vectors.

**ParallelHash Implementation:**

- Added new `IncrementalParallelHash` class for streaming/incremental computation of ParallelHash, supporting both SHAKE128 and SHAKE256 variants with customization and block size options. (`src/Security/Cryptography/Hash/IncrementalParallelHash.cs`)

