### PR TITLE
Add ReadOnlySequence as signature to single shot pooled hashers

### DIFF
--- a/src/Security/Cryptography/Hash/Ascon/AsconHash256.cs
+++ b/src/Security/Cryptography/Hash/Ascon/AsconHash256.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
@@ -91,6 +92,24 @@ public sealed class AsconHash256 : AsconHashAlgorithm
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the Ascon-Hash256 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<AsconHash256>.HashData(source);
+
+    /// <summary>
+    /// Computes the Ascon-Hash256 of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<AsconHash256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the Ascon-Hash256 of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the Ascon-Hash256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<AsconHash256>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -7,6 +7,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the BLAKE2b hash for the input data.
@@ -141,6 +142,26 @@ public sealed class Blake2b : HashAlgorithm
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the BLAKE2b hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Blake2b>.HashData(source);
+
+    /// <summary>
+    /// Computes the BLAKE2b hash of <paramref name="source"/> using the default output size (64 bytes)
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="MaxHashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Blake2b>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the BLAKE2b hash of <paramref name="source"/> using the default output size (64 bytes)
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the BLAKE2b hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Blake2b>.HashData(source);
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.cs
@@ -7,6 +7,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the BLAKE2s hash for the input data.
@@ -141,6 +142,26 @@ public sealed class Blake2s : HashAlgorithm
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the BLAKE2s hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Blake2s>.HashData(source);
+
+    /// <summary>
+    /// Computes the BLAKE2s hash of <paramref name="source"/> using the default output size (32 bytes)
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="MaxHashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Blake2s>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the BLAKE2s hash of <paramref name="source"/> using the default output size (32 bytes)
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the BLAKE2s hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Blake2s>.HashData(source);
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/Blake/Blake3.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake3.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Specifies the mode of operation for BLAKE3.
@@ -171,6 +172,26 @@ public sealed class Blake3 : HashAlgorithm, IExtendableOutput
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the BLAKE3 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Blake3>.HashData(source);
+
+    /// <summary>
+    /// Computes the BLAKE3 hash of <paramref name="source"/> using the default output size (32 bytes)
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="DefaultHashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Blake3>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the BLAKE3 hash of <paramref name="source"/> using the default output size (32 bytes)
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the BLAKE3 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Blake3>.HashData(source);
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/HashAlgorithm.cs
+++ b/src/Security/Cryptography/Hash/HashAlgorithm.cs
@@ -9,6 +9,7 @@ namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using Microsoft.Extensions.ObjectPool;
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Base class for the CryptoHives hash algorithm implementations.
@@ -192,7 +193,7 @@ public abstract class HashAlgorithm : System.Security.Cryptography.HashAlgorithm
     /// <remarks>
     /// <para>
     /// The algorithm is automatically reset after a successful computation, allowing the
-    /// instance to be reused for subsequent <see cref="AppendData"/> calls or another
+    /// instance to be reused for subsequent <see cref="AppendData(System.ReadOnlySpan{byte})"/> calls or another
     /// <see cref="TryComputeHash"/> without calling
     /// <see cref="System.Security.Cryptography.HashAlgorithm.Initialize"/> first.
     /// </para>
@@ -254,6 +255,35 @@ public abstract class HashAlgorithm : System.Security.Cryptography.HashAlgorithm
     public void AppendData(ReadOnlySpan<byte> source)
     {
         HashCore(source);
+    }
+
+    /// <summary>
+    /// Appends all segments of <paramref name="source"/> to the data already processed in the hash algorithm.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to append to the hash computation.</param>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when data arrives from <c>System.IO.Pipelines</c> or any other source that
+    /// provides a <see cref="ReadOnlySequence{T}"/>. Each segment is fed directly into the algorithm
+    /// without copying the data into a contiguous buffer.
+    /// </para>
+    /// <para>
+    /// Call <see cref="TryGetHashAndReset"/> after all data has been appended to retrieve
+    /// the final hash value and reset the algorithm for reuse.
+    /// </para>
+    /// </remarks>
+    public void AppendData(in ReadOnlySequence<byte> source)
+    {
+        if (source.IsSingleSegment)
+        {
+            HashCore(source.First.Span);
+            return;
+        }
+
+        foreach (ReadOnlyMemory<byte> segment in source)
+        {
+            HashCore(segment.Span);
+        }
     }
 
     /// <summary>

--- a/src/Security/Cryptography/Hash/IIncrementalHash.cs
+++ b/src/Security/Cryptography/Hash/IIncrementalHash.cs
@@ -32,7 +32,7 @@ using System.Buffers;
 /// <para>
 /// Higher-level consumers such as <see cref="HashAlgorithm"/> wrap implementations of this
 /// interface and expose the same computation through the more familiar
-/// <see cref="HashAlgorithm.AppendData"/> / <see cref="HashAlgorithm.TryGetHashAndReset"/>
+/// <see cref="HashAlgorithm.AppendData(System.ReadOnlySpan{byte})"/> / <see cref="HashAlgorithm.TryGetHashAndReset"/>
 /// API surface.
 /// </para>
 /// </remarks>

--- a/src/Security/Cryptography/Hash/Keccak/KT128.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KT128.cs
@@ -174,6 +174,26 @@ public sealed class KT128 : HashAlgorithm, IExtendableOutput
     public static byte[] HashData(ReadOnlySpan<byte> source)
         => HashAlgorithmPool<KT128>.HashData(source);
 
+    /// <summary>
+    /// Computes the KT128 hash of <paramref name="source"/> using the default output size (32 bytes)
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <c>32</c> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<KT128>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the KT128 hash of <paramref name="source"/> using the default output size (32 bytes)
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the KT128 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
+        => HashAlgorithmPool<KT128>.HashData(source);
+
     /// <inheritdoc/>
     public override void Initialize()
     {

--- a/src/Security/Cryptography/Hash/Keccak/KT256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KT256.cs
@@ -174,6 +174,26 @@ public sealed class KT256 : HashAlgorithm, IExtendableOutput
     public static byte[] HashData(ReadOnlySpan<byte> source)
         => HashAlgorithmPool<KT256>.HashData(source);
 
+    /// <summary>
+    /// Computes the KT256 hash of <paramref name="source"/> using the default output size (64 bytes)
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <c>64</c> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<KT256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the KT256 hash of <paramref name="source"/> using the default output size (64 bytes)
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the KT256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
+        => HashAlgorithmPool<KT256>.HashData(source);
+
     /// <inheritdoc/>
     public override void Initialize()
     {

--- a/src/Security/Cryptography/Hash/Keccak/Keccak256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/Keccak256.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the Keccak-256 hash for the input data.
@@ -91,5 +92,23 @@ public sealed class Keccak256 : KeccakHashCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the Keccak-256 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Keccak256>.HashData(source);
+
+    /// <summary>
+    /// Computes the Keccak-256 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Keccak256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the Keccak-256 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the Keccak-256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Keccak256>.HashData(source);
 }

--- a/src/Security/Cryptography/Hash/Keccak/Keccak384.cs
+++ b/src/Security/Cryptography/Hash/Keccak/Keccak384.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the Keccak-384 hash for the input data.
@@ -91,5 +92,23 @@ public sealed class Keccak384 : KeccakHashCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the Keccak-384 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Keccak384>.HashData(source);
+
+    /// <summary>
+    /// Computes the Keccak-384 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Keccak384>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the Keccak-384 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the Keccak-384 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Keccak384>.HashData(source);
 }

--- a/src/Security/Cryptography/Hash/Keccak/Keccak512.cs
+++ b/src/Security/Cryptography/Hash/Keccak/Keccak512.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the Keccak-512 hash for the input data.
@@ -91,5 +92,23 @@ public sealed class Keccak512 : KeccakHashCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the Keccak-512 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Keccak512>.HashData(source);
+
+    /// <summary>
+    /// Computes the Keccak-512 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Keccak512>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the Keccak-512 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the Keccak-512 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Keccak512>.HashData(source);
 }

--- a/src/Security/Cryptography/Hash/Keccak/SHA3_224.cs
+++ b/src/Security/Cryptography/Hash/Keccak/SHA3_224.cs
@@ -6,6 +6,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the SHA3-224 hash for the input data.
@@ -99,5 +100,23 @@ public sealed class SHA3_224 : KeccakHashCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA3-224 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA3_224>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA3-224 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA3_224>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA3-224 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA3-224 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA3_224>.HashData(source);
 }

--- a/src/Security/Cryptography/Hash/Keccak/SHA3_256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/SHA3_256.cs
@@ -6,6 +6,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the SHA3-256 hash for the input data.
@@ -99,5 +100,23 @@ public sealed class SHA3_256 : KeccakHashCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA3-256 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA3_256>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA3-256 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA3_256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA3-256 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA3-256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA3_256>.HashData(source);
 }

--- a/src/Security/Cryptography/Hash/Keccak/SHA3_384.cs
+++ b/src/Security/Cryptography/Hash/Keccak/SHA3_384.cs
@@ -6,6 +6,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the SHA3-384 hash for the input data.
@@ -99,5 +100,23 @@ public sealed class SHA3_384 : KeccakHashCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA3-384 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA3_384>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA3-384 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA3_384>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA3-384 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA3-384 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA3_384>.HashData(source);
 }

--- a/src/Security/Cryptography/Hash/Keccak/SHA3_512.cs
+++ b/src/Security/Cryptography/Hash/Keccak/SHA3_512.cs
@@ -6,6 +6,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes the SHA3-512 hash for the input data.
@@ -99,5 +100,23 @@ public sealed class SHA3_512 : KeccakHashCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA3-512 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA3_512>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA3-512 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA3_512>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA3-512 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA3-512 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA3_512>.HashData(source);
 }

--- a/src/Security/Cryptography/Hash/Keccak/Shake128.cs
+++ b/src/Security/Cryptography/Hash/Keccak/Shake128.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes a variable-length output using SHAKE128 (XOF).
@@ -110,6 +111,26 @@ public sealed class Shake128 : KeccakXofCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHAKE128 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Shake128>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHAKE128 hash of <paramref name="source"/> using the default output size
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <c>32</c> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Shake128>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHAKE128 hash of <paramref name="source"/> using the default output size
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHAKE128 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Shake128>.HashData(source);
 }
 

--- a/src/Security/Cryptography/Hash/Keccak/Shake256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/Shake256.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Computes a variable-length output using SHAKE256 (XOF).
@@ -110,6 +111,26 @@ public sealed class Shake256 : KeccakXofCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHAKE256 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Shake256>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHAKE256 hash of <paramref name="source"/> using the default output size
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <c>64</c> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Shake256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHAKE256 hash of <paramref name="source"/> using the default output size
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHAKE256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Shake256>.HashData(source);
 }
 

--- a/src/Security/Cryptography/Hash/Keccak/TurboShake128.cs
+++ b/src/Security/Cryptography/Hash/Keccak/TurboShake128.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
@@ -149,6 +150,26 @@ public sealed class TurboShake128 : KeccakXofCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the TurboSHAKE128 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<TurboShake128>.HashData(source);
+
+    /// <summary>
+    /// Computes the TurboSHAKE128 hash of <paramref name="source"/> using the default output size
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <c>32</c> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<TurboShake128>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the TurboSHAKE128 hash of <paramref name="source"/> using the default output size
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the TurboSHAKE128 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<TurboShake128>.HashData(source);
 }
 

--- a/src/Security/Cryptography/Hash/Keccak/TurboShake256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/TurboShake256.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
@@ -149,6 +150,26 @@ public sealed class TurboShake256 : KeccakXofCore
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the TurboSHAKE256 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<TurboShake256>.HashData(source);
+
+    /// <summary>
+    /// Computes the TurboSHAKE256 hash of <paramref name="source"/> using the default output size
+    /// and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <c>64</c> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<TurboShake256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the TurboSHAKE256 hash of <paramref name="source"/> using the default output size
+    /// and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the TurboSHAKE256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<TurboShake256>.HashData(source);
 }
 

--- a/src/Security/Cryptography/Hash/Legacy/MD5.cs
+++ b/src/Security/Cryptography/Hash/Legacy/MD5.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -127,6 +128,28 @@ public sealed class MD5 : HashAlgorithm
     /// <returns>A new byte array containing the MD5 hash.</returns>
 #pragma warning disable CS0618 // Type or member is obsolete
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<MD5>.HashData(source);
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Computes the MD5 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<MD5>.TryHashData(source, destination, out bytesWritten);
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Computes the MD5 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the MD5 hash.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<MD5>.HashData(source);
 #pragma warning restore CS0618
 

--- a/src/Security/Cryptography/Hash/Regional/Kupyna.cs
+++ b/src/Security/Cryptography/Hash/Regional/Kupyna.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -298,6 +299,44 @@ public sealed class Kupyna : HashAlgorithm
     /// <returns>A new byte array containing the Kupyna hash.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 32, 48, or 64.</exception>
     public static byte[] HashData(ReadOnlySpan<byte> source, int hashSizeBytes)
+    {
+        var pool = hashSizeBytes switch {
+            32 => _pool256,
+            48 => _pool384,
+            64 => _pool512,
+            _ => throw new ArgumentException("Hash size must be 32, 48, or 64 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.HashData(pool, source);
+    }
+
+    /// <summary>
+    /// Computes the Kupyna hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <paramref name="hashSizeBytes"/> bytes.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (32, 48, or 64).</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 32, 48, or 64.</exception>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, int hashSizeBytes, out int bytesWritten)
+    {
+        var pool = hashSizeBytes switch {
+            32 => _pool256,
+            48 => _pool384,
+            64 => _pool512,
+            _ => throw new ArgumentException("Hash size must be 32, 48, or 64 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.TryHashData(pool, source, destination, out bytesWritten);
+    }
+
+    /// <summary>
+    /// Computes the Kupyna hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (32, 48, or 64).</param>
+    /// <returns>A new byte array containing the Kupyna hash.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 32, 48, or 64.</exception>
+    public static byte[] HashData(in ReadOnlySequence<byte> source, int hashSizeBytes)
     {
         var pool = hashSizeBytes switch {
             32 => _pool256,

--- a/src/Security/Cryptography/Hash/Regional/Lsh256.cs
+++ b/src/Security/Cryptography/Hash/Regional/Lsh256.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -223,6 +224,42 @@ public sealed class Lsh256 : HashAlgorithm
     /// <returns>A new byte array containing the LSH-256 hash.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 28 or 32.</exception>
     public static byte[] HashData(ReadOnlySpan<byte> source, int hashSizeBytes)
+    {
+        var pool = hashSizeBytes switch {
+            28 => _pool224,
+            32 => _pool256,
+            _ => throw new ArgumentException("Hash size must be 28 or 32 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.HashData(pool, source);
+    }
+
+    /// <summary>
+    /// Computes the LSH-256 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <paramref name="hashSizeBytes"/> bytes.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (28 or 32).</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 28 or 32.</exception>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, int hashSizeBytes, out int bytesWritten)
+    {
+        var pool = hashSizeBytes switch {
+            28 => _pool224,
+            32 => _pool256,
+            _ => throw new ArgumentException("Hash size must be 28 or 32 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.TryHashData(pool, source, destination, out bytesWritten);
+    }
+
+    /// <summary>
+    /// Computes the LSH-256 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (28 or 32).</param>
+    /// <returns>A new byte array containing the LSH-256 hash.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 28 or 32.</exception>
+    public static byte[] HashData(in ReadOnlySequence<byte> source, int hashSizeBytes)
     {
         var pool = hashSizeBytes switch {
             28 => _pool224,

--- a/src/Security/Cryptography/Hash/Regional/Lsh512.cs
+++ b/src/Security/Cryptography/Hash/Regional/Lsh512.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -256,6 +257,46 @@ public sealed class Lsh512 : HashAlgorithm
     /// <returns>A new byte array containing the LSH-512 hash.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 28, 32, 48, or 64.</exception>
     public static byte[] HashData(ReadOnlySpan<byte> source, int hashSizeBytes)
+    {
+        var pool = hashSizeBytes switch {
+            28 => _pool224,
+            32 => _pool256,
+            48 => _pool384,
+            64 => _pool512,
+            _ => throw new ArgumentException("Hash size must be 28, 32, 48, or 64 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.HashData(pool, source);
+    }
+
+    /// <summary>
+    /// Computes the LSH-512 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <paramref name="hashSizeBytes"/> bytes.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (28, 32, 48, or 64).</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 28, 32, 48, or 64.</exception>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, int hashSizeBytes, out int bytesWritten)
+    {
+        var pool = hashSizeBytes switch {
+            28 => _pool224,
+            32 => _pool256,
+            48 => _pool384,
+            64 => _pool512,
+            _ => throw new ArgumentException("Hash size must be 28, 32, 48, or 64 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.TryHashData(pool, source, destination, out bytesWritten);
+    }
+
+    /// <summary>
+    /// Computes the LSH-512 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (28, 32, 48, or 64).</param>
+    /// <returns>A new byte array containing the LSH-512 hash.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 28, 32, 48, or 64.</exception>
+    public static byte[] HashData(in ReadOnlySequence<byte> source, int hashSizeBytes)
     {
         var pool = hashSizeBytes switch {
             28 => _pool224,

--- a/src/Security/Cryptography/Hash/Regional/SM3.cs
+++ b/src/Security/Cryptography/Hash/Regional/SM3.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -96,6 +97,24 @@ public sealed class SM3 : HashAlgorithm
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SM3 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SM3>.HashData(source);
+
+    /// <summary>
+    /// Computes the SM3 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SM3>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SM3 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SM3 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SM3>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Regional/Streebog.cs
+++ b/src/Security/Cryptography/Hash/Regional/Streebog.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -310,6 +311,42 @@ public sealed class Streebog : HashAlgorithm
     /// <returns>A new byte array containing the Streebog hash.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 32 or 64.</exception>
     public static byte[] HashData(ReadOnlySpan<byte> source, int hashSizeBytes)
+    {
+        var pool = hashSizeBytes switch {
+            32 => _pool256,
+            64 => _pool512,
+            _ => throw new ArgumentException("Hash size must be 32 or 64 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.HashData(pool, source);
+    }
+
+    /// <summary>
+    /// Computes the Streebog hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <paramref name="hashSizeBytes"/> bytes.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (32 or 64).</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 32 or 64.</exception>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, int hashSizeBytes, out int bytesWritten)
+    {
+        var pool = hashSizeBytes switch {
+            32 => _pool256,
+            64 => _pool512,
+            _ => throw new ArgumentException("Hash size must be 32 or 64 bytes.", nameof(hashSizeBytes))
+        };
+        return HashAlgorithmPool.TryHashData(pool, source, destination, out bytesWritten);
+    }
+
+    /// <summary>
+    /// Computes the Streebog hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="hashSizeBytes">The desired output size in bytes (32 or 64).</param>
+    /// <returns>A new byte array containing the Streebog hash.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashSizeBytes"/> is not 32 or 64.</exception>
+    public static byte[] HashData(in ReadOnlySequence<byte> source, int hashSizeBytes)
     {
         var pool = hashSizeBytes switch {
             32 => _pool256,

--- a/src/Security/Cryptography/Hash/Regional/Whirlpool.cs
+++ b/src/Security/Cryptography/Hash/Regional/Whirlpool.cs
@@ -6,6 +6,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -185,6 +186,24 @@ public sealed class Whirlpool : HashAlgorithm
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the Whirlpool hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Whirlpool>.HashData(source);
+
+    /// <summary>
+    /// Computes the Whirlpool hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Whirlpool>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the Whirlpool hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the Whirlpool hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Whirlpool>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Ripemd/Ripemd160.cs
+++ b/src/Security/Cryptography/Hash/Ripemd/Ripemd160.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -133,6 +134,24 @@ public sealed class Ripemd160 : HashAlgorithm
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the RIPEMD-160 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<Ripemd160>.HashData(source);
+
+    /// <summary>
+    /// Computes the RIPEMD-160 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<Ripemd160>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the RIPEMD-160 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the RIPEMD-160 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<Ripemd160>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Sha2/SHA224.cs
+++ b/src/Security/Cryptography/Hash/Sha2/SHA224.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 
 /// <summary>
@@ -100,6 +101,24 @@ public sealed class SHA224 : Sha2HashAlgorithm<uint>
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA-224 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA224>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA-224 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA224>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA-224 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA-224 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA224>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Sha2/SHA256.cs
+++ b/src/Security/Cryptography/Hash/Sha2/SHA256.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 
 /// <summary>
@@ -115,6 +116,24 @@ public sealed class SHA256 : Sha2HashAlgorithm<uint>
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA-256 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA256>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA-256 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA-256 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA-256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA256>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Sha2/SHA384.cs
+++ b/src/Security/Cryptography/Hash/Sha2/SHA384.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 
 /// <summary>
@@ -74,6 +75,24 @@ public sealed class SHA384 : Sha2HashAlgorithm<ulong>
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA-384 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA384>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA-384 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA384>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA-384 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA-384 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA384>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Sha2/SHA512.cs
+++ b/src/Security/Cryptography/Hash/Sha2/SHA512.cs
@@ -4,6 +4,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 
 /// <summary>
@@ -73,6 +74,24 @@ public sealed class SHA512 : Sha2HashAlgorithm<ulong>
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA-512 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA512>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA-512 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA512>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA-512 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA-512 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA512>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Sha2/SHA512_224.cs
+++ b/src/Security/Cryptography/Hash/Sha2/SHA512_224.cs
@@ -6,6 +6,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 
 /// <summary>
@@ -76,6 +77,24 @@ public sealed class SHA512_224 : Sha2HashAlgorithm<ulong>
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA-512/224 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA512_224>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA-512/224 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA512_224>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA-512/224 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA-512/224 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA512_224>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Hash/Sha2/SHA512_256.cs
+++ b/src/Security/Cryptography/Hash/Sha2/SHA512_256.cs
@@ -6,6 +6,7 @@
 namespace CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 
 /// <summary>
@@ -76,6 +77,24 @@ public sealed class SHA512_256 : Sha2HashAlgorithm<ulong>
     /// <param name="source">The input data to hash.</param>
     /// <returns>A new byte array containing the SHA-512/256 hash.</returns>
     public static byte[] HashData(ReadOnlySpan<byte> source)
+        => HashAlgorithmPool<SHA512_256>.HashData(source);
+
+    /// <summary>
+    /// Computes the SHA-512/256 hash of <paramref name="source"/> and writes it into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value. Must be at least <see cref="HashSizeBytes"/> bytes.</param>
+    /// <param name="bytesWritten">When this method returns, the number of bytes written into <paramref name="destination"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="destination"/> was large enough; otherwise, <see langword="false"/>.</returns>
+    public static bool TryHashData(in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        => HashAlgorithmPool<SHA512_256>.TryHashData(source, destination, out bytesWritten);
+
+    /// <summary>
+    /// Computes the SHA-512/256 hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the SHA-512/256 hash.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
         => HashAlgorithmPool<SHA512_256>.HashData(source);
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/shared/HashAlgorithmPool.cs
+++ b/src/Security/Cryptography/shared/HashAlgorithmPool.cs
@@ -6,6 +6,7 @@ namespace CryptoHives.Foundation.Security.Cryptography;
 using CryptoHives.Foundation.Security.Cryptography.Hash;
 using Microsoft.Extensions.ObjectPool;
 using System;
+using System.Buffers;
 
 /// <summary>
 /// Provides a per-type object pool of hash algorithm instances for use by static
@@ -92,6 +93,56 @@ internal static class HashAlgorithmPool<T>
             _pool.Return(hasher);
         }
     }
+
+    /// <summary>
+    /// Attempts to compute the hash of <paramref name="source"/> and write it into
+    /// <paramref name="destination"/> without allocating a hash instance or output array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value.</param>
+    /// <param name="bytesWritten">
+    /// When this method returns, the number of bytes written into <paramref name="destination"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="destination"/> was large enough;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool TryHashData(
+        in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+    {
+        T hasher = _pool.Get();
+        try
+        {
+            hasher.AppendData(source);
+            return hasher.TryGetHashAndReset(destination, out bytesWritten);
+        }
+        finally
+        {
+            _pool.Return(hasher);
+        }
+    }
+
+    /// <summary>
+    /// Computes the hash of <paramref name="source"/> and returns it as a new byte array.
+    /// </summary>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the hash value.</returns>
+    public static byte[] HashData(in ReadOnlySequence<byte> source)
+    {
+        T hasher = _pool.Get();
+        try
+        {
+            int hashBytes = hasher.HashSize / 8;
+            byte[] result = new byte[hashBytes];
+            hasher.AppendData(source);
+            hasher.TryGetHashAndReset(result, out _);
+            return result;
+        }
+        finally
+        {
+            _pool.Return(hasher);
+        }
+    }
 }
 
 /// <summary>
@@ -158,6 +209,63 @@ internal static class HashAlgorithmPool
             int hashBytes = hasher.HashSize / 8;
             byte[] result = new byte[hashBytes];
             hasher.TryComputeHash(source, result, out _);
+            return result;
+        }
+        finally
+        {
+            pool.Return(hasher);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute the hash of <paramref name="source"/> using a delegate-backed pool,
+    /// writing the result into <paramref name="destination"/>.
+    /// </summary>
+    /// <typeparam name="T">A concrete <see cref="HashAlgorithm"/> type.</typeparam>
+    /// <param name="pool">The pool to rent from and return to.</param>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <param name="destination">The buffer to receive the hash value.</param>
+    /// <param name="bytesWritten">
+    /// When this method returns, the number of bytes written into <paramref name="destination"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="destination"/> was large enough;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool TryHashData<T>(
+        ObjectPool<T> pool, in ReadOnlySequence<byte> source, Span<byte> destination, out int bytesWritten)
+        where T : HashAlgorithm
+    {
+        T hasher = pool.Get();
+        try
+        {
+            hasher.AppendData(source);
+            return hasher.TryGetHashAndReset(destination, out bytesWritten);
+        }
+        finally
+        {
+            pool.Return(hasher);
+        }
+    }
+
+    /// <summary>
+    /// Computes the hash of <paramref name="source"/> using a delegate-backed pool and returns
+    /// it as a new byte array.
+    /// </summary>
+    /// <typeparam name="T">A concrete <see cref="HashAlgorithm"/> type.</typeparam>
+    /// <param name="pool">The pool to rent from and return to.</param>
+    /// <param name="source">The (possibly multi-segment) input sequence to hash.</param>
+    /// <returns>A new byte array containing the hash value.</returns>
+    public static byte[] HashData<T>(ObjectPool<T> pool, in ReadOnlySequence<byte> source)
+        where T : HashAlgorithm
+    {
+        T hasher = pool.Get();
+        try
+        {
+            int hashBytes = hasher.HashSize / 8;
+            byte[] result = new byte[hashBytes];
+            hasher.AppendData(source);
+            hasher.TryGetHashAndReset(result, out _);
             return result;
         }
         finally

--- a/tests/Security/Cryptography/Hash/PooledHashApiTests.cs
+++ b/tests/Security/Cryptography/Hash/PooledHashApiTests.cs
@@ -6,6 +6,7 @@ namespace Cryptography.Tests.Hash;
 using CryptoHives.Foundation.Security.Cryptography.Hash;
 using NUnit.Framework;
 using System;
+using System.Buffers;
 using System.Text;
 
 /// <summary>
@@ -792,5 +793,96 @@ public class PooledHashApiTests
         Span<byte> kupyna256Span = stackalloc byte[32];
         Kupyna.TryHashData(Abc, kupyna256Span, 32, out _);
         Assert.That(kupyna256Span.ToArray(), Is.EqualTo(kupyna256Array));
+    }
+
+    // ── ReadOnlySequence overloads ────────────────────────────────────────────
+
+    private static ReadOnlySequence<byte> BuildMultiSegmentSequence(byte[] data, int segmentSize)
+    {
+        // Split data into fixed-size segments linked via BufferSegment chain.
+        BufferSegment? first = null;
+        BufferSegment? last = null;
+        for (int offset = 0; offset < data.Length; offset += segmentSize)
+        {
+            int length = Math.Min(segmentSize, data.Length - offset);
+            var seg = new BufferSegment(data.AsMemory(offset, length));
+            if (first is null)
+            {
+                first = last = seg;
+            }
+            else
+            {
+                last = last!.Append(seg);
+            }
+        }
+        if (first is null)
+            return ReadOnlySequence<byte>.Empty;
+        return new ReadOnlySequence<byte>(first, 0, last!, last!.Memory.Length);
+    }
+
+    private sealed class BufferSegment : ReadOnlySequenceSegment<byte>
+    {
+        public BufferSegment(ReadOnlyMemory<byte> memory)
+        {
+            Memory = memory;
+        }
+
+        public BufferSegment Append(BufferSegment next)
+        {
+            next.RunningIndex = RunningIndex + Memory.Length;
+            Next = next;
+            return next;
+        }
+    }
+
+    [Test]
+    public void ReadOnlySequenceSingleSegmentMatchesSpanOverload()
+    {
+        ReadOnlySequence<byte> seq = new(Abc);
+
+        Assert.That(SHA256.HashData(seq), Is.EqualTo(SHA256.HashData(Abc.AsSpan())));
+        Assert.That(SHA512.HashData(seq), Is.EqualTo(SHA512.HashData(Abc.AsSpan())));
+        Assert.That(Blake3.HashData(seq), Is.EqualTo(Blake3.HashData(Abc.AsSpan())));
+        Assert.That(SM3.HashData(seq), Is.EqualTo(SM3.HashData(Abc.AsSpan())));
+        Assert.That(Streebog.HashData(seq, 32), Is.EqualTo(Streebog.HashData(Abc.AsSpan(), 32)));
+        Assert.That(Kupyna.HashData(seq, 32), Is.EqualTo(Kupyna.HashData(Abc.AsSpan(), 32)));
+        Assert.That(Lsh256.HashData(seq, 32), Is.EqualTo(Lsh256.HashData(Abc.AsSpan(), 32)));
+        Assert.That(Lsh512.HashData(seq, 64), Is.EqualTo(Lsh512.HashData(Abc.AsSpan(), 64)));
+    }
+
+    [Test]
+    public void ReadOnlySequenceMultiSegmentMatchesSpanOverload()
+    {
+        byte[] data = Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog");
+        ReadOnlySequence<byte> seq = BuildMultiSegmentSequence(data, 8);
+
+        Assert.That(SHA256.HashData(seq), Is.EqualTo(SHA256.HashData(data.AsSpan())));
+        Assert.That(Blake3.HashData(seq), Is.EqualTo(Blake3.HashData(data.AsSpan())));
+        Assert.That(Whirlpool.HashData(seq), Is.EqualTo(Whirlpool.HashData(data.AsSpan())));
+        Assert.That(Ripemd160.HashData(seq), Is.EqualTo(Ripemd160.HashData(data.AsSpan())));
+        Assert.That(AsconHash256.HashData(seq), Is.EqualTo(AsconHash256.HashData(data.AsSpan())));
+    }
+
+    [Test]
+    public void ReadOnlySequenceTryHashDataWritesCorrectBytes()
+    {
+        byte[] data = Encoding.ASCII.GetBytes("abc");
+        ReadOnlySequence<byte> seq = BuildMultiSegmentSequence(data, 1);
+
+        Span<byte> dest = stackalloc byte[32];
+        bool ok = SHA256.TryHashData(seq, dest, out int written);
+        Assert.That(ok, Is.True);
+        Assert.That(written, Is.EqualTo(32));
+        Assert.That(dest.ToArray(), Is.EqualTo(SHA256.HashData(data.AsSpan())));
+    }
+
+    [Test]
+    public void ReadOnlySequenceEmptyInputMatchesSpanOverload()
+    {
+        ReadOnlySequence<byte> emptySeq = ReadOnlySequence<byte>.Empty;
+
+        Assert.That(SHA256.HashData(emptySeq), Is.EqualTo(SHA256.HashData(ReadOnlySpan<byte>.Empty)));
+        Assert.That(Blake3.HashData(emptySeq), Is.EqualTo(Blake3.HashData(ReadOnlySpan<byte>.Empty)));
+        Assert.That(Streebog.HashData(emptySeq, 64), Is.EqualTo(Streebog.HashData(ReadOnlySpan<byte>.Empty, 64)));
     }
 }


### PR DESCRIPTION
Adds support for hashing data from multi-segment buffers using `ReadOnlySequence<byte>` across all major hash algorithm implementations. It introduces new overloads for hashing methods to accept `ReadOnlySequence<byte>`, making the library compatible with data sources like pipelines and other non-contiguous memory buffers. Additionally, the base `HashAlgorithm` class now supports appending data from `ReadOnlySequence<byte>`, improving flexibility and performance when working with segmented data.

These changes make the cryptography library much more flexible and efficient when working with modern .NET data pipelines and non-contiguous memory sources.