### PR TITLE
Kalyna512 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ No OS crypto dependency — deterministic results on every platform. Hardware ac
 | MAC | HMAC-SHA-256/384/512, HMAC-SHA3-256, AES-CMAC, AES-GMAC, Poly1305, KMAC128, KMAC256, BLAKE2 keyed, BLAKE3 keyed |
 | Cipher (AEAD) | AES-GCM (128/192/256), AES-CCM (128/192/256), ChaCha20-Poly1305, XChaCha20-Poly1305, Ascon-AEAD128 |
 | Cipher (Block) | AES-128, AES-192, AES-256 (ECB/CBC/CTR), ChaCha20 |
-| Cipher (Regional) | SM4, ARIA (128/192/256), Camellia (128/192/256), Kuznyechik, Kalyna (128/256), SEED |
+| Cipher (Regional) | SM4, ARIA (128/192/256), Camellia (128/192/256), Kuznyechik, Kalyna (128/256/512), SEED |
 | Regional | SM3, Streebog, Kupyna, LSH, Whirlpool, RIPEMD-160 |
 | Legacy | SHA-1, MD5 (backward compatibility only) |
 
@@ -308,4 +308,3 @@ Please see the [Contributing Guide](https://github.com/CryptoHives/.github/blob/
 ---
 
 © 2026 The Keepers of the CryptoHives
-

--- a/docfx/packages/security/cryptography/benchmarks.md
+++ b/docfx/packages/security/cryptography/benchmarks.md
@@ -103,6 +103,7 @@ The following tables show the per-instance memory footprint (internal state + bu
 | Kuznyechik (ECB/CBC/CTR) | 320 B | 16 B | 8 KB | byte[10×16] round keys + IV + feedback; LS/IL tables |
 | Kalyna-128 (ECB/CBC/CTR) | 320 B | 16 B | 5 KB | ulong[22] round keys + IV + feedback; 4 S-boxes + MDS |
 | Kalyna-256 (ECB/CBC/CTR) | 400 B | 16 B | 5 KB | ulong[30] round keys (shared S-boxes/MDS) |
+| Kalyna-512 (ECB/CBC/CTR) | ~816 B | 32 B | 5 KB | ulong[76] round keys + IV + feedback; 4 S-boxes + MDS |
 | SEED (ECB/CBC/CTR) | 192 B | 16 B | 4 KB | uint[32] round keys + IV + feedback; 4 SS-boxes |
 
 ### Message Authentication Codes (MAC)

--- a/docfx/packages/security/cryptography/cipher-algorithms.md
+++ b/docfx/packages/security/cryptography/cipher-algorithms.md
@@ -646,13 +646,18 @@ byte[] ciphertext = kuz.Encrypt(plaintext);
 ```csharp
 public sealed class Kalyna128 : BlockCipherTransform
 public sealed class Kalyna256 : BlockCipherTransform
+public sealed class Kalyna512 : BlockCipherTransform
 ```
 
 **Properties:**
-- Key Sizes: 128 or 256 bits
-- Block Size: 128 bits
-- Rounds: 10 (128-bit key), 14 (256-bit key)
+- Key Sizes: 128, 256, or 512 bits
+- Block Size: 128 bits (Kalyna-128/Kalyna-256), 256 bits (Kalyna-512)
+- Rounds: 10 (128-bit key), 14 (256-bit key), 18 (512-bit key)
 - Standard: DSTU 7624:2014
+
+**Kalyna-512 note:**
+- Uses a 256-bit block with a 512-bit key
+- Matches the widest Kalyna configuration in the standard
 
 **Security:**
 - ✅ Ukrainian national standard

--- a/docfx/packages/security/cryptography/index.md
+++ b/docfx/packages/security/cryptography/index.md
@@ -120,7 +120,7 @@ using CryptoHives.Foundation.Security.Cryptography.Kdf;
 | ARIA | Korea | 128/192/256 bits | ECB, CBC, CTR | [Details](cipher-algorithms.md#aria-korea) |
 | Camellia | Japan | 128/192/256 bits | ECB, CBC, CTR | [Details](cipher-algorithms.md#camellia-japan) |
 | Kuznyechik | Russia | 256 bits | ECB, CBC, CTR | [Details](cipher-algorithms.md#kuznyechik-russia) |
-| Kalyna | Ukraine | 128/256 bits | ECB, CBC, CTR | [Details](cipher-algorithms.md#kalyna-ukraine) |
+| Kalyna | Ukraine | 128/256/512 bits | ECB, CBC, CTR | [Details](cipher-algorithms.md#kalyna-ukraine) |
 | SEED | Korea | 128 bits | ECB, CBC, CTR | [Details](cipher-algorithms.md#seed-korea) |
 
 ### Cipher Algorithms (AEAD)

--- a/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
@@ -232,7 +232,7 @@ internal abstract class BlockCipherTransform : ICipherTransform
             {
                 byte padValue = output[written - 1];
 
-                if (!IsPkcs7PaddingValid(output.Slice(written - _blockSize, _blockSize), padValue))
+                if (!IsPkcs7PaddingValid(output.Slice(written - _blockSize, _blockSize), padValue, _blockSize))
                     throw new CryptographicException("Invalid padding.");
 
                 written -= padValue;
@@ -253,19 +253,20 @@ internal abstract class BlockCipherTransform : ICipherTransform
     /// attacks) - even without a distinguishable error message, the timing difference alone is
     /// enough to decrypt ciphertext one byte at a time.
     /// </remarks>
-    /// <param name="block">The last decrypted block (exactly <see cref="BlockSizeConst"/> bytes).</param>
+    /// <param name="block">The last decrypted block (exactly <paramref name="blockSize"/> bytes).</param>
     /// <param name="padValue">The claimed pad length (<c>block[^1]</c>).</param>
+    /// <param name="blockSize">The cipher's block size in bytes.</param>
     /// <returns><see langword="true"/> if the padding is well-formed.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsPkcs7PaddingValid(ReadOnlySpan<byte> block, byte padValue)
+    private static bool IsPkcs7PaddingValid(ReadOnlySpan<byte> block, byte padValue, int blockSize)
     {
-        int badLength = ((uint)(padValue - 1) > (uint)(BlockSizeConst - 1)) ? 1 : 0;
+        int badLength = ((uint)(padValue - 1) > (uint)(blockSize - 1)) ? 1 : 0;
 
         int mismatch = 0;
-        for (int i = 0; i < BlockSizeConst; i++)
+        for (int i = 0; i < blockSize; i++)
         {
-            byte expected = i < padValue ? padValue : block[BlockSizeConst - 1 - i];
-            mismatch |= expected ^ block[BlockSizeConst - 1 - i];
+            byte expected = i < padValue ? padValue : block[blockSize - 1 - i];
+            mismatch |= expected ^ block[blockSize - 1 - i];
         }
 
         return badLength == 0 && mismatch == 0;

--- a/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
@@ -20,8 +20,7 @@ using System.Security.Cryptography;
 /// </remarks>
 internal abstract class BlockCipherTransform : ICipherTransform
 {
-    private const int BlockSizeConst = 16;
-
+    private readonly int _blockSize;
     private readonly CipherMode _mode;
     private readonly PaddingMode _padding;
     private readonly bool _encrypting;
@@ -37,32 +36,34 @@ internal abstract class BlockCipherTransform : ICipherTransform
     /// <param name="encrypting">True for encryption, false for decryption.</param>
     /// <param name="mode">The cipher mode.</param>
     /// <param name="padding">The padding mode.</param>
-    protected BlockCipherTransform(ReadOnlySpan<byte> iv, bool encrypting, CipherMode mode, PaddingMode padding)
+    /// <param name="blockSizeBytes">The cipher block size in bytes.</param>
+    protected BlockCipherTransform(ReadOnlySpan<byte> iv, bool encrypting, CipherMode mode, PaddingMode padding, int blockSizeBytes = 16)
     {
+        _blockSize = blockSizeBytes;
         _encrypting = encrypting;
         _mode = mode;
         _padding = padding;
 
-        _iv = new byte[BlockSizeConst];
-        _counter = new byte[BlockSizeConst];
-        _feedback = new byte[BlockSizeConst];
+        _iv = new byte[_blockSize];
+        _counter = new byte[_blockSize];
+        _feedback = new byte[_blockSize];
 
         if (!iv.IsEmpty)
         {
-            iv.Slice(0, BlockSizeConst).CopyTo(_iv);
-            iv.Slice(0, BlockSizeConst).CopyTo(_counter);
-            iv.Slice(0, BlockSizeConst).CopyTo(_feedback);
+            iv.Slice(0, _blockSize).CopyTo(_iv);
+            iv.Slice(0, _blockSize).CopyTo(_counter);
+            iv.Slice(0, _blockSize).CopyTo(_feedback);
         }
     }
 
     /// <inheritdoc/>
-    public int BlockSize => BlockSizeConst;
+    public int BlockSize => _blockSize;
 
     /// <inheritdoc/>
-    int ICryptoTransform.InputBlockSize => BlockSizeConst;
+    int ICryptoTransform.InputBlockSize => _blockSize;
 
     /// <inheritdoc/>
-    int ICryptoTransform.OutputBlockSize => BlockSizeConst;
+    int ICryptoTransform.OutputBlockSize => _blockSize;
 
     /// <inheritdoc/>
     public bool CanTransformMultipleBlocks => true;
@@ -80,6 +81,11 @@ internal abstract class BlockCipherTransform : ICipherTransform
     /// Gets the current cipher mode of operation.
     /// </summary>
     protected CipherMode CurrentMode => _mode;
+
+    /// <summary>
+    /// Gets the block size in bytes.
+    /// </summary>
+    protected int BlockSizeBytes => _blockSize;
 
     /// <summary>
     /// Gets a <see cref="Span{T}"/> over the current CBC feedback register.
@@ -108,18 +114,18 @@ internal abstract class BlockCipherTransform : ICipherTransform
     /// <inheritdoc/>
     public virtual int TransformBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
-        if (input.Length < BlockSizeConst)
+        if (input.Length < _blockSize)
             throw new ArgumentException("Input must be at least one block.", nameof(input));
-        if (output.Length < BlockSizeConst)
+        if (output.Length < _blockSize)
             throw new ArgumentException("Output buffer too small.", nameof(output));
 
-        int blocks = input.Length / BlockSizeConst;
+        int blocks = input.Length / _blockSize;
         int bytesProcessed = 0;
 
         for (int i = 0; i < blocks; i++)
         {
-            var inBlock = input.Slice(i * BlockSizeConst, BlockSizeConst);
-            var outBlock = output.Slice(i * BlockSizeConst, BlockSizeConst);
+            var inBlock = input.Slice(i * _blockSize, _blockSize);
+            var outBlock = output.Slice(i * _blockSize, _blockSize);
 
             switch (_mode)
             {
@@ -136,7 +142,7 @@ internal abstract class BlockCipherTransform : ICipherTransform
                     throw new NotSupportedException($"Cipher mode {_mode} is not supported.");
             }
 
-            bytesProcessed += BlockSizeConst;
+            bytesProcessed += _blockSize;
         }
 
         return bytesProcessed;
@@ -149,13 +155,13 @@ internal abstract class BlockCipherTransform : ICipherTransform
     /// <inheritdoc/>
     public int TransformFinalBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
-        int fullBlocks = input.Length / BlockSizeConst;
-        int remainder = input.Length % BlockSizeConst;
+        int fullBlocks = input.Length / _blockSize;
+        int remainder = input.Length % _blockSize;
         int written = 0;
 
         if (fullBlocks > 0)
         {
-            written = TransformBlock(input.Slice(0, fullBlocks * BlockSizeConst), output);
+            written = TransformBlock(input.Slice(0, fullBlocks * _blockSize), output);
         }
 
         if (_encrypting)
@@ -164,35 +170,35 @@ internal abstract class BlockCipherTransform : ICipherTransform
             {
                 if (remainder > 0)
                 {
-                    Span<byte> keystream = stackalloc byte[BlockSizeConst];
+                    Span<byte> keystream = stackalloc byte[_blockSize];
                     EncryptBlock(_counter, keystream);
                     IncrementCounter(_counter);
 
                     for (int i = 0; i < remainder; i++)
                     {
-                        output[written + i] = (byte)(input[fullBlocks * BlockSizeConst + i] ^ keystream[i]);
+                        output[written + i] = (byte)(input[fullBlocks * _blockSize + i] ^ keystream[i]);
                     }
                     written += remainder;
                 }
             }
             else if (_padding != PaddingMode.None)
             {
-                Span<byte> paddedBlock = stackalloc byte[BlockSizeConst];
-                int paddingLength = BlockSizeConst - remainder;
+                Span<byte> paddedBlock = stackalloc byte[_blockSize];
+                int paddingLength = _blockSize - remainder;
 
                 if (remainder > 0)
                 {
-                    input.Slice(fullBlocks * BlockSizeConst, remainder).CopyTo(paddedBlock);
+                    input.Slice(fullBlocks * _blockSize, remainder).CopyTo(paddedBlock);
                 }
 
                 byte padValue = (byte)paddingLength;
-                for (int i = remainder; i < BlockSizeConst; i++)
+                for (int i = remainder; i < _blockSize; i++)
                 {
                     paddedBlock[i] = padValue;
                 }
 
                 TransformBlock(paddedBlock, output.Slice(written));
-                written += BlockSizeConst;
+                written += _blockSize;
             }
             else if (remainder > 0)
             {
@@ -205,13 +211,13 @@ internal abstract class BlockCipherTransform : ICipherTransform
             {
                 if (remainder > 0)
                 {
-                    Span<byte> keystream = stackalloc byte[BlockSizeConst];
+                    Span<byte> keystream = stackalloc byte[_blockSize];
                     EncryptBlock(_counter, keystream);
                     IncrementCounter(_counter);
 
                     for (int i = 0; i < remainder; i++)
                     {
-                        output[written + i] = (byte)(input[fullBlocks * BlockSizeConst + i] ^ keystream[i]);
+                        output[written + i] = (byte)(input[fullBlocks * _blockSize + i] ^ keystream[i]);
                     }
                     written += remainder;
                 }
@@ -220,7 +226,7 @@ internal abstract class BlockCipherTransform : ICipherTransform
             {
                 byte padValue = output[written - 1];
 
-                if (padValue < 1 || padValue > BlockSizeConst)
+                if (padValue < 1 || padValue > _blockSize)
                     throw new CryptographicException("Invalid padding.");
 
                 for (int i = 0; i < padValue; i++)
@@ -239,7 +245,7 @@ internal abstract class BlockCipherTransform : ICipherTransform
     /// <inheritdoc/>
     public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
     {
-        int maxOutput = inputCount + BlockSizeConst;
+        int maxOutput = inputCount + _blockSize;
         byte[] output = new byte[maxOutput];
 
         int written = TransformFinalBlock(
@@ -293,22 +299,22 @@ internal abstract class BlockCipherTransform : ICipherTransform
     {
         if (_encrypting)
         {
-            Span<byte> xored = stackalloc byte[BlockSizeConst];
-            for (int i = 0; i < BlockSizeConst; i++)
+            Span<byte> xored = stackalloc byte[_blockSize];
+            for (int i = 0; i < _blockSize; i++)
                 xored[i] = (byte)(input[i] ^ _feedback[i]);
 
             EncryptBlock(xored, output);
 
-            output.Slice(0, BlockSizeConst).CopyTo(_feedback);
+            output.Slice(0, _blockSize).CopyTo(_feedback);
         }
         else
         {
-            Span<byte> savedInput = stackalloc byte[BlockSizeConst];
+            Span<byte> savedInput = stackalloc byte[_blockSize];
             input.CopyTo(savedInput);
 
             DecryptBlock(input, output);
 
-            for (int i = 0; i < BlockSizeConst; i++)
+            for (int i = 0; i < _blockSize; i++)
                 output[i] ^= _feedback[i];
 
             savedInput.CopyTo(_feedback);
@@ -317,10 +323,10 @@ internal abstract class BlockCipherTransform : ICipherTransform
 
     private void TransformBlockCtr(ReadOnlySpan<byte> input, Span<byte> output)
     {
-        Span<byte> keystream = stackalloc byte[BlockSizeConst];
+        Span<byte> keystream = stackalloc byte[_blockSize];
         EncryptBlock(_counter, keystream);
 
-        for (int i = 0; i < BlockSizeConst; i++)
+        for (int i = 0; i < _blockSize; i++)
             output[i] = (byte)(input[i] ^ keystream[i]);
 
         IncrementCounter(_counter);
@@ -329,7 +335,7 @@ internal abstract class BlockCipherTransform : ICipherTransform
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void IncrementCounter(Span<byte> counter)
     {
-        for (int i = BlockSizeConst - 1; i >= 0; i--)
+        for (int i = counter.Length - 1; i >= 0; i--)
         {
             if (++counter[i] != 0)
                 break;

--- a/src/Security/Cryptography/Cipher/Kalyna/Kalyna128.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/Kalyna128.cs
@@ -47,13 +47,13 @@ public sealed class Kalyna128 : SymmetricCipher
     protected override ICipherTransform CreateCipherEncryptor(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv)
     {
         ValidateKeySize(key.Length * 8);
-        return new KalynaCipherTransform(key, iv, encrypting: true, Mode, Padding);
+        return new KalynaCipherTransform(key, iv, encrypting: true, Mode, Padding, 16);
     }
 
     /// <inheritdoc/>
     protected override ICipherTransform CreateCipherDecryptor(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv)
     {
         ValidateKeySize(key.Length * 8);
-        return new KalynaCipherTransform(key, iv, encrypting: false, Mode, Padding);
+        return new KalynaCipherTransform(key, iv, encrypting: false, Mode, Padding, 16);
     }
 }

--- a/src/Security/Cryptography/Cipher/Kalyna/Kalyna256.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/Kalyna256.cs
@@ -47,13 +47,13 @@ public sealed class Kalyna256 : SymmetricCipher
     protected override ICipherTransform CreateCipherEncryptor(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv)
     {
         ValidateKeySize(key.Length * 8);
-        return new KalynaCipherTransform(key, iv, encrypting: true, Mode, Padding);
+        return new KalynaCipherTransform(key, iv, encrypting: true, Mode, Padding, 16);
     }
 
     /// <inheritdoc/>
     protected override ICipherTransform CreateCipherDecryptor(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv)
     {
         ValidateKeySize(key.Length * 8);
-        return new KalynaCipherTransform(key, iv, encrypting: false, Mode, Padding);
+        return new KalynaCipherTransform(key, iv, encrypting: false, Mode, Padding, 16);
     }
 }

--- a/src/Security/Cryptography/Cipher/Kalyna/Kalyna512.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/Kalyna512.cs
@@ -1,0 +1,80 @@
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Security.Cryptography.Cipher;
+
+using System;
+using System.Security.Cryptography;
+
+/// <summary>
+/// Kalyna-512 symmetric cipher implementation (DSTU 7624:2014).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Kalyna-512 uses a 256-bit block with a 512-bit key (18 rounds).
+/// This is the widest Kalyna configuration supported by the standard.
+/// </para>
+/// </remarks>
+public sealed class Kalyna512 : SymmetricCipher
+{
+    /// <summary>Block size in bits.</summary>
+    public const int BlockSizeBits = 256;
+
+    /// <summary>Block size in bytes.</summary>
+    public const int BlockSizeBytes = 32;
+
+    /// <summary>Key size in bits.</summary>
+    public const int KeySizeBits = 512;
+
+    /// <summary>Key size in bytes.</summary>
+    public const int KeySizeBytes = 64;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Kalyna512"/> class.
+    /// </summary>
+    public Kalyna512()
+    {
+        BlockSizeValue = BlockSizeBits;
+        KeySizeValue = KeySizeBits;
+        LegalKeySizesValue = [new KeySizes(256, 256, 0), new KeySizes(512, 512, 0)];
+        LegalBlockSizesValue = [new KeySizes(BlockSizeBits, BlockSizeBits, 0)];
+    }
+
+    /// <inheritdoc/>
+    public override string AlgorithmName => "Kalyna-512";
+
+    /// <inheritdoc/>
+    public override int IVSize => BlockSizeBytes;
+
+    /// <inheritdoc/>
+    public override byte[] Key
+    {
+        get => base.Key;
+        set
+        {
+            if (value is null) throw new ArgumentNullException(nameof(value));
+            if (value.Length != KeySizeBytes)
+                throw new CryptographicException($"Invalid key size: {value.Length * 8} bits. Expected: {KeySizeBits} bits.");
+
+            KeySizeValue = KeySizeBits;
+            KeyValue = (byte[])value.Clone();
+        }
+    }
+
+    /// <summary>Creates a new instance of the <see cref="Kalyna512"/> cipher.</summary>
+    public static new Kalyna512 Create() => new();
+
+    /// <inheritdoc/>
+    protected override ICipherTransform CreateCipherEncryptor(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv)
+    {
+        ValidateKeySize(key.Length * 8);
+        return new KalynaCipherTransform(key, iv, encrypting: true, Mode, Padding, BlockSizeBytes);
+    }
+
+    /// <inheritdoc/>
+    protected override ICipherTransform CreateCipherDecryptor(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv)
+    {
+        ValidateKeySize(key.Length * 8);
+        return new KalynaCipherTransform(key, iv, encrypting: false, Mode, Padding, BlockSizeBytes);
+    }
+}

--- a/src/Security/Cryptography/Cipher/Kalyna/KalynaCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/KalynaCipherTransform.cs
@@ -13,14 +13,16 @@ using System.Runtime.CompilerServices;
 internal sealed class KalynaCipherTransform : BlockCipherTransform
 {
     private KalynaCore _core;
+    private readonly int _blockSizeBytes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KalynaCipherTransform"/> class.
     /// </summary>
-    public KalynaCipherTransform(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv, bool encrypting, CipherMode mode, PaddingMode padding)
-        : base(iv, encrypting, mode, padding)
+    public KalynaCipherTransform(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv, bool encrypting, CipherMode mode, PaddingMode padding, int blockSizeBytes)
+        : base(iv, encrypting, mode, padding, blockSizeBytes)
     {
-        _core = KalynaCore.Create(key);
+        _blockSizeBytes = blockSizeBytes;
+        _core = KalynaCore.Create(key, blockSizeBytes);
     }
 
     /// <inheritdoc/>
@@ -29,9 +31,12 @@ internal sealed class KalynaCipherTransform : BlockCipherTransform
         // Only the hot CBC path is overridden here; all other modes fall through to the base
         // class. This avoids per-block virtual dispatch, per-block stackalloc, and byte-by-byte
         // XOR by operating directly on ulong pairs in little-endian byte order.
-        int blocks = input.Length / 16;
-        if (CurrentMode != CipherMode.CBC || input.Length < 16 || output.Length < blocks * 16)
+        int blocks = input.Length / _blockSizeBytes;
+        if (CurrentMode != CipherMode.CBC || _blockSizeBytes != 16 || input.Length < _blockSizeBytes || output.Length < blocks * _blockSizeBytes)
+        {
             return base.TransformBlock(input, output);
+        }
+
         Span<byte> fb = FeedbackSpan;
 
         if (IsEncrypting)
@@ -40,8 +45,8 @@ internal sealed class KalynaCipherTransform : BlockCipherTransform
             ulong fbk1 = BinaryPrimitives.ReadUInt64LittleEndian(fb.Slice(8));
             for (int i = 0; i < blocks; i++)
             {
-                ReadOnlySpan<byte> inBlk = input.Slice(i * 16, 16);
-                Span<byte> outBlk = output.Slice(i * 16, 16);
+                ReadOnlySpan<byte> inBlk = input.Slice(i * _blockSizeBytes, _blockSizeBytes);
+                Span<byte> outBlk = output.Slice(i * _blockSizeBytes, _blockSizeBytes);
                 ulong w0 = BinaryPrimitives.ReadUInt64LittleEndian(inBlk) ^ fbk0;
                 ulong w1 = BinaryPrimitives.ReadUInt64LittleEndian(inBlk.Slice(8)) ^ fbk1;
                 _core.EncryptBlock(ref w0, ref w1);
@@ -74,7 +79,7 @@ internal sealed class KalynaCipherTransform : BlockCipherTransform
             BinaryPrimitives.WriteUInt64LittleEndian(fb.Slice(8), fbk1);
         }
 
-        return blocks * 16;
+        return blocks * _blockSizeBytes;
     }
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
@@ -10,11 +10,12 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 /// <summary>
-/// Core Kalyna (DSTU 7624:2014) block cipher operations for 128-bit block size.
+/// Core Kalyna (DSTU 7624:2014) block cipher operations.
 /// </summary>
 /// <remarks>
 /// Kalyna is the Ukrainian national standard block cipher. This implementation
-/// supports 128-bit blocks with 128-bit or 256-bit keys (10 or 14 rounds).
+/// supports 128-bit blocks with 128-bit or 256-bit keys (10 or 14 rounds) and
+/// 256-bit blocks with 256-bit or 512-bit keys (14 or 18 rounds).
 /// State is stored as a pair of 64-bit words in little-endian byte order,
 /// matching the DSTU 7624:2014 specification.
 /// </remarks>
@@ -22,11 +23,14 @@ using System.Runtime.InteropServices;
 internal unsafe struct KalynaCore
 {
     public const int BlockSizeBytes = 16;
+    private const int MaxRoundKeyWords = 152;
 
     private const int NumWords = 2;
 
-    private fixed ulong _roundKeys[30]; // MaxRoundKeyCount: 15 round keys × 2 ulongs (up to 14 rounds)
+    private fixed ulong _roundKeys[MaxRoundKeyWords];
     private int _rounds;
+    private int _blockWords;
+    private int _keyWords;
 
     // S-boxes from DSTU 7624:2014
     private static ReadOnlySpan<byte> S0 =>
@@ -194,34 +198,65 @@ internal unsafe struct KalynaCore
     /// <summary>
     /// Creates and initializes a new <see cref="KalynaCore"/> with expanded round keys.
     /// </summary>
-    /// <param name="key">The cipher key (16 or 32 bytes for 128-bit block).</param>
+    /// <param name="key">The cipher key.</param>
+    /// <param name="blockSizeBytes">The block size in bytes.</param>
     /// <returns>An initialized <see cref="KalynaCore"/> ready for use.</returns>
     /// <exception cref="ArgumentException">Thrown when the key length is invalid.</exception>
-    internal static KalynaCore Create(ReadOnlySpan<byte> key)
+    internal static KalynaCore Create(ReadOnlySpan<byte> key, int blockSizeBytes)
     {
-        Span<byte> rkBytes = stackalloc byte[15 * 16];
-        int nr = ExpandKey(key, rkBytes);
+        int blockWords = blockSizeBytes / 8;
+        int keyWords = key.Length / 8;
 
         KalynaCore core = default;
+        core._blockWords = blockWords;
+        core._keyWords = keyWords;
+
+        int nr;
+        if (blockWords == 2)
+        {
+            Span<byte> rkBytes = stackalloc byte[15 * 16];
+            nr = ExpandKey(key, rkBytes);
+
+            core._rounds = nr;
+
+            KalynaCore* pCore128 = &core;
+            ulong* rk128 = pCore128->_roundKeys;
+            for (int i = 0; i <= nr; i++)
+            {
+                rk128[i * 2] = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16));
+                rk128[i * 2 + 1] = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16 + 8));
+            }
+
+            return core;
+        }
+
+        Span<ulong> roundKeyWords = stackalloc ulong[MaxRoundKeyWords];
+        nr = ExpandKeyGeneric(key, blockWords, roundKeyWords);
         core._rounds = nr;
 
-        KalynaCore* pCore = &core;
-        ulong* rk = pCore->_roundKeys;
-        for (int i = 0; i <= nr; i++)
+        KalynaCore* pCoreGeneric = &core;
+        ulong* rkGeneric = pCoreGeneric->_roundKeys;
+        int roundKeyWordsCount = (nr + 1) * blockWords;
+        for (int i = 0; i < roundKeyWordsCount; i++)
         {
-            rk[i * 2] = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16));
-            rk[i * 2 + 1] = BinaryPrimitives.ReadUInt64LittleEndian(rkBytes.Slice(i * 16 + 8));
+            rkGeneric[i] = roundKeyWords[i];
         }
 
         return core;
     }
 
     /// <summary>
-    /// Encrypts a single 16-byte block using Kalyna.
+    /// Encrypts a single Kalyna block.
     /// </summary>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     internal void EncryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
+        if (_blockWords != 2)
+        {
+            EncryptBlockGeneric(input, output);
+            return;
+        }
+
         ulong w0 = BinaryPrimitives.ReadUInt64LittleEndian(input);
         ulong w1 = BinaryPrimitives.ReadUInt64LittleEndian(input.Slice(8));
         EncryptBlock(ref w0, ref w1);
@@ -309,11 +344,17 @@ internal unsafe struct KalynaCore
     }
 
     /// <summary>
-    /// Decrypts a single 16-byte block using Kalyna.
+    /// Decrypts a single Kalyna block.
     /// </summary>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     internal void DecryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
+        if (_blockWords != 2)
+        {
+            DecryptBlockGeneric(input, output);
+            return;
+        }
+
         ulong w0 = BinaryPrimitives.ReadUInt64LittleEndian(input);
         ulong w1 = BinaryPrimitives.ReadUInt64LittleEndian(input.Slice(8));
         DecryptBlock(ref w0, ref w1);
@@ -444,6 +485,82 @@ internal unsafe struct KalynaCore
         }
     }
 
+    private void EncryptBlockGeneric(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        Span<ulong> state = stackalloc ulong[MaxRoundKeyWords / 19];
+        Span<ulong> blockState = state.Slice(0, _blockWords);
+
+        for (int i = 0; i < _blockWords; i++)
+        {
+            blockState[i] = BinaryPrimitives.ReadUInt64LittleEndian(input.Slice(i * 8));
+        }
+
+        fixed (KalynaCore* pCore = &this)
+        {
+            ulong* rk = pCore->_roundKeys;
+            AddRoundKey(blockState, rk, 0);
+
+            for (int round = 0;;)
+            {
+                SubBytes(blockState);
+                ShiftRows(blockState);
+                MixColumns(blockState);
+
+                if (++round == _rounds)
+                {
+                    break;
+                }
+
+                XorRoundKey(blockState, rk, round);
+            }
+
+            AddRoundKey(blockState, rk, _rounds);
+        }
+
+        for (int i = 0; i < _blockWords; i++)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(output.Slice(i * 8), blockState[i]);
+        }
+    }
+
+    private void DecryptBlockGeneric(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        Span<ulong> state = stackalloc ulong[MaxRoundKeyWords / 19];
+        Span<ulong> blockState = state.Slice(0, _blockWords);
+
+        for (int i = 0; i < _blockWords; i++)
+        {
+            blockState[i] = BinaryPrimitives.ReadUInt64LittleEndian(input.Slice(i * 8));
+        }
+
+        fixed (KalynaCore* pCore = &this)
+        {
+            ulong* rk = pCore->_roundKeys;
+            SubRoundKey(blockState, rk, _rounds);
+
+            for (int round = _rounds;;)
+            {
+                MixColumnsInv(blockState);
+                InvShiftRows(blockState);
+                InvSubBytes(blockState);
+
+                if (--round == 0)
+                {
+                    break;
+                }
+
+                XorRoundKey(blockState, rk, round);
+            }
+
+            SubRoundKey(blockState, rk, 0);
+        }
+
+        for (int i = 0; i < _blockWords; i++)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(output.Slice(i * 8), blockState[i]);
+        }
+    }
+
     private static int ExpandKey(ReadOnlySpan<byte> key, Span<byte> roundKeys)
     {
         int nr = key.Length switch {
@@ -467,6 +584,537 @@ internal unsafe struct KalynaCore
         }
 
         return nr;
+    }
+
+    private static int ExpandKeyGeneric(ReadOnlySpan<byte> key, int blockWords, Span<ulong> roundKeys)
+    {
+        int keyWords = key.Length / 8;
+        int nr = key.Length switch
+        {
+            32 => 14,
+            64 => 18,
+            _ => throw new ArgumentException("Key must be 32 or 64 bytes for the selected Kalyna block size.", nameof(key))
+        };
+
+        if (blockWords != 4 && blockWords != 8)
+            throw new ArgumentException("Block size must be 256 or 512 bits for the Kalyna-512 family.", nameof(blockWords));
+
+        if (keyWords != blockWords && keyWords != blockWords * 2)
+            throw new ArgumentException("Unsupported key length for the selected Kalyna block size.", nameof(key));
+
+        Span<ulong> workingKey = stackalloc ulong[keyWords];
+        for (int i = 0; i < keyWords; i++)
+        {
+            workingKey[i] = BinaryPrimitives.ReadUInt64LittleEndian(key.Slice(i * 8));
+        }
+
+        Span<ulong> tempKeys = stackalloc ulong[8];
+        WorkingKeyExpandKt(workingKey, blockWords, keyWords, tempKeys);
+        WorkingKeyExpandEven(workingKey, blockWords, keyWords, tempKeys, roundKeys, nr);
+        WorkingKeyExpandOdd(roundKeys, blockWords, nr);
+
+        return nr;
+    }
+
+    private static void WorkingKeyExpandKt(ReadOnlySpan<ulong> workingKey, int blockWords, int keyWords, Span<ulong> tempKeys)
+    {
+        Span<ulong> state = stackalloc ulong[8];
+        state.Clear();
+        Span<ulong> k0 = stackalloc ulong[8];
+        Span<ulong> k1 = stackalloc ulong[8];
+        Span<ulong> blockState = state.Slice(0, blockWords);
+
+        state[0] = (ulong)(blockWords + keyWords + 1);
+
+        if (keyWords == blockWords)
+        {
+            workingKey.Slice(0, blockWords).CopyTo(k0);
+            workingKey.Slice(0, blockWords).CopyTo(k1);
+        }
+        else
+        {
+            workingKey.Slice(0, blockWords).CopyTo(k0);
+            workingKey.Slice(blockWords, blockWords).CopyTo(k1);
+        }
+
+        for (int i = 0; i < blockWords; i++)
+        {
+            blockState[i] += k0[i];
+        }
+
+        SubBytes(blockState);
+        ShiftRows(blockState);
+        MixColumns(blockState);
+
+        for (int i = 0; i < blockWords; i++)
+        {
+            blockState[i] ^= k1[i];
+        }
+
+        SubBytes(blockState);
+        ShiftRows(blockState);
+        MixColumns(blockState);
+
+        for (int i = 0; i < blockWords; i++)
+        {
+            blockState[i] += k0[i];
+        }
+
+        SubBytes(blockState);
+        ShiftRows(blockState);
+        MixColumns(blockState);
+
+        blockState.CopyTo(tempKeys);
+    }
+
+    private static void WorkingKeyExpandEven(ReadOnlySpan<ulong> workingKey, int blockWords, int keyWords, ReadOnlySpan<ulong> tempKey, Span<ulong> roundKeys, int nr)
+    {
+        Span<ulong> state = stackalloc ulong[8];
+        Span<ulong> tmpRoundKey = stackalloc ulong[8];
+        Span<ulong> initialData = stackalloc ulong[8];
+        workingKey.CopyTo(initialData);
+
+        ulong tmv = 0x0001000100010001UL;
+        int round = 0;
+
+        while (true)
+        {
+            for (int i = 0; i < blockWords; i++)
+            {
+                tmpRoundKey[i] = tempKey[i] + tmv;
+            }
+
+            for (int i = 0; i < blockWords; i++)
+            {
+                state[i] = initialData[i] + tmpRoundKey[i];
+            }
+
+            SubBytes(state.Slice(0, blockWords));
+            ShiftRows(state.Slice(0, blockWords));
+            MixColumns(state.Slice(0, blockWords));
+
+            for (int i = 0; i < blockWords; i++)
+            {
+                state[i] ^= tmpRoundKey[i];
+            }
+
+            SubBytes(state.Slice(0, blockWords));
+            ShiftRows(state.Slice(0, blockWords));
+            MixColumns(state.Slice(0, blockWords));
+
+            for (int i = 0; i < blockWords; i++)
+            {
+                state[i] += tmpRoundKey[i];
+            }
+
+            state.Slice(0, blockWords).CopyTo(roundKeys.Slice(round * blockWords, blockWords));
+
+            if (round == nr)
+            {
+                break;
+            }
+
+            if (keyWords != blockWords)
+            {
+                round += 2;
+                tmv <<= 1;
+
+                for (int i = 0; i < blockWords; i++)
+                {
+                    tmpRoundKey[i] = tempKey[i] + tmv;
+                }
+
+                for (int i = 0; i < blockWords; i++)
+                {
+                    state[i] = initialData[blockWords + i] + tmpRoundKey[i];
+                }
+
+                SubBytes(state.Slice(0, blockWords));
+                ShiftRows(state.Slice(0, blockWords));
+                MixColumns(state.Slice(0, blockWords));
+
+                for (int i = 0; i < blockWords; i++)
+                {
+                    state[i] ^= tmpRoundKey[i];
+                }
+
+                SubBytes(state.Slice(0, blockWords));
+                ShiftRows(state.Slice(0, blockWords));
+                MixColumns(state.Slice(0, blockWords));
+
+                for (int i = 0; i < blockWords; i++)
+                {
+                    state[i] += tmpRoundKey[i];
+                }
+
+                state.Slice(0, blockWords).CopyTo(roundKeys.Slice(round * blockWords, blockWords));
+
+                if (round == nr)
+                {
+                    break;
+                }
+            }
+
+            round += 2;
+            tmv <<= 1;
+            RotateLeftWords(initialData.Slice(0, keyWords));
+        }
+    }
+
+    private static void WorkingKeyExpandOdd(Span<ulong> roundKeys, int blockWords, int nr)
+    {
+        for (int roundIndex = 1; roundIndex < nr; roundIndex += 2)
+        {
+            RotateRoundKey(roundKeys.Slice((roundIndex - 1) * blockWords, blockWords), roundKeys.Slice(roundIndex * blockWords, blockWords), blockWords);
+        }
+    }
+
+    private static void RotateLeftWords(Span<ulong> words)
+    {
+        ulong temp = words[0];
+        for (int i = 1; i < words.Length; i++)
+        {
+            words[i - 1] = words[i];
+        }
+
+        words[^1] = temp;
+    }
+
+    private static void RotateRoundKey(ReadOnlySpan<ulong> src, Span<ulong> dst, int blockWords)
+    {
+        switch (blockWords)
+        {
+            case 2:
+            {
+                ulong x0 = src[0], x1 = src[1];
+                dst[0] = (x0 >> 56) | (x1 << 8);
+                dst[1] = (x1 >> 56) | (x0 << 8);
+                break;
+            }
+            case 4:
+            {
+                ulong x0 = src[0], x1 = src[1], x2 = src[2], x3 = src[3];
+                dst[0] = (x1 >> 24) | (x2 << 40);
+                dst[1] = (x2 >> 24) | (x3 << 40);
+                dst[2] = (x3 >> 24) | (x0 << 40);
+                dst[3] = (x0 >> 24) | (x1 << 40);
+                break;
+            }
+            case 8:
+            {
+                ulong x0 = src[0], x1 = src[1], x2 = src[2], x3 = src[3];
+                ulong x4 = src[4], x5 = src[5], x6 = src[6], x7 = src[7];
+                dst[0] = (x2 >> 24) | (x3 << 40);
+                dst[1] = (x3 >> 24) | (x4 << 40);
+                dst[2] = (x4 >> 24) | (x5 << 40);
+                dst[3] = (x5 >> 24) | (x6 << 40);
+                dst[4] = (x6 >> 24) | (x7 << 40);
+                dst[5] = (x7 >> 24) | (x0 << 40);
+                dst[6] = (x0 >> 24) | (x1 << 40);
+                dst[7] = (x1 >> 24) | (x2 << 40);
+                break;
+            }
+            default:
+            {
+                throw new InvalidOperationException("Unsupported Kalyna block length.");
+            }
+        }
+    }
+
+    private void AddRoundKey(Span<ulong> state, ulong* roundKeys, int round)
+    {
+        int offset = round * _blockWords;
+        for (int i = 0; i < _blockWords; i++)
+        {
+            state[i] += roundKeys[offset + i];
+        }
+    }
+
+    private void SubRoundKey(Span<ulong> state, ulong* roundKeys, int round)
+    {
+        int offset = round * _blockWords;
+        for (int i = 0; i < _blockWords; i++)
+        {
+            state[i] -= roundKeys[offset + i];
+        }
+    }
+
+    private void XorRoundKey(Span<ulong> state, ulong* roundKeys, int round)
+    {
+        int offset = round * _blockWords;
+        for (int i = 0; i < _blockWords; i++)
+        {
+            state[i] ^= roundKeys[offset + i];
+        }
+    }
+
+    private static void SubBytes(Span<ulong> state)
+    {
+        for (int i = 0; i < state.Length; i++)
+        {
+            state[i] = SubstituteWord(state[i]);
+        }
+    }
+
+    private static void InvSubBytes(Span<ulong> state)
+    {
+        for (int i = 0; i < state.Length; i++)
+        {
+            state[i] = InverseSubstituteWord(state[i]);
+        }
+    }
+
+    private static void ShiftRows(Span<ulong> state)
+    {
+        switch (state.Length)
+        {
+            case 2:
+            {
+                ulong c0 = state[0], c1 = state[1];
+                ulong d = (c0 ^ c1) & 0xFFFFFFFF00000000UL;
+                c0 ^= d;
+                c1 ^= d;
+                state[0] = c0;
+                state[1] = c1;
+                break;
+            }
+            case 4:
+            {
+                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                ulong d;
+
+                d = (c0 ^ c2) & 0xFFFFFFFF00000000UL; c0 ^= d; c2 ^= d;
+                d = (c1 ^ c3) & 0x0000FFFFFFFF0000UL; c1 ^= d; c3 ^= d;
+
+                d = (c0 ^ c1) & 0xFFFF0000FFFF0000UL; c0 ^= d; c1 ^= d;
+                d = (c2 ^ c3) & 0xFFFF0000FFFF0000UL; c2 ^= d; c3 ^= d;
+
+                state[0] = c0;
+                state[1] = c1;
+                state[2] = c2;
+                state[3] = c3;
+                break;
+            }
+            case 8:
+            {
+                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                ulong c4 = state[4], c5 = state[5], c6 = state[6], c7 = state[7];
+                ulong d;
+
+                d = (c0 ^ c4) & 0xFFFFFFFF00000000UL; c0 ^= d; c4 ^= d;
+                d = (c1 ^ c5) & 0x00FFFFFFFF000000UL; c1 ^= d; c5 ^= d;
+                d = (c2 ^ c6) & 0x0000FFFFFFFF0000UL; c2 ^= d; c6 ^= d;
+                d = (c3 ^ c7) & 0x000000FFFFFFFF00UL; c3 ^= d; c7 ^= d;
+
+                d = (c0 ^ c2) & 0xFFFF0000FFFF0000UL; c0 ^= d; c2 ^= d;
+                d = (c1 ^ c3) & 0x00FFFF0000FFFF00UL; c1 ^= d; c3 ^= d;
+                d = (c4 ^ c6) & 0xFFFF0000FFFF0000UL; c4 ^= d; c6 ^= d;
+                d = (c5 ^ c7) & 0x00FFFF0000FFFF00UL; c5 ^= d; c7 ^= d;
+
+                d = (c0 ^ c1) & 0xFF00FF00FF00FF00UL; c0 ^= d; c1 ^= d;
+                d = (c2 ^ c3) & 0xFF00FF00FF00FF00UL; c2 ^= d; c3 ^= d;
+                d = (c4 ^ c5) & 0xFF00FF00FF00FF00UL; c4 ^= d; c5 ^= d;
+                d = (c6 ^ c7) & 0xFF00FF00FF00FF00UL; c6 ^= d; c7 ^= d;
+
+                state[0] = c0;
+                state[1] = c1;
+                state[2] = c2;
+                state[3] = c3;
+                state[4] = c4;
+                state[5] = c5;
+                state[6] = c6;
+                state[7] = c7;
+                break;
+            }
+            default:
+            {
+                throw new InvalidOperationException("Unsupported Kalyna block length.");
+            }
+        }
+    }
+
+    private static void InvShiftRows(Span<ulong> state)
+    {
+        switch (state.Length)
+        {
+            case 2:
+            {
+                ulong c0 = state[0], c1 = state[1];
+                ulong d = (c0 ^ c1) & 0xFFFFFFFF00000000UL;
+                c0 ^= d;
+                c1 ^= d;
+                state[0] = c0;
+                state[1] = c1;
+                break;
+            }
+            case 4:
+            {
+                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                ulong d;
+
+                d = (c0 ^ c1) & 0xFFFF0000FFFF0000UL; c0 ^= d; c1 ^= d;
+                d = (c2 ^ c3) & 0xFFFF0000FFFF0000UL; c2 ^= d; c3 ^= d;
+
+                d = (c0 ^ c2) & 0xFFFFFFFF00000000UL; c0 ^= d; c2 ^= d;
+                d = (c1 ^ c3) & 0x0000FFFFFFFF0000UL; c1 ^= d; c3 ^= d;
+
+                state[0] = c0;
+                state[1] = c1;
+                state[2] = c2;
+                state[3] = c3;
+                break;
+            }
+            case 8:
+            {
+                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                ulong c4 = state[4], c5 = state[5], c6 = state[6], c7 = state[7];
+                ulong d;
+
+                d = (c0 ^ c1) & 0xFF00FF00FF00FF00UL; c0 ^= d; c1 ^= d;
+                d = (c2 ^ c3) & 0xFF00FF00FF00FF00UL; c2 ^= d; c3 ^= d;
+                d = (c4 ^ c5) & 0xFF00FF00FF00FF00UL; c4 ^= d; c5 ^= d;
+                d = (c6 ^ c7) & 0xFF00FF00FF00FF00UL; c6 ^= d; c7 ^= d;
+
+                d = (c0 ^ c2) & 0xFFFF0000FFFF0000UL; c0 ^= d; c2 ^= d;
+                d = (c1 ^ c3) & 0x00FFFF0000FFFF00UL; c1 ^= d; c3 ^= d;
+                d = (c4 ^ c6) & 0xFFFF0000FFFF0000UL; c4 ^= d; c6 ^= d;
+                d = (c5 ^ c7) & 0x00FFFF0000FFFF00UL; c5 ^= d; c7 ^= d;
+
+                d = (c0 ^ c4) & 0xFFFFFFFF00000000UL; c0 ^= d; c4 ^= d;
+                d = (c1 ^ c5) & 0x00FFFFFFFF000000UL; c1 ^= d; c5 ^= d;
+                d = (c2 ^ c6) & 0x0000FFFFFFFF0000UL; c2 ^= d; c6 ^= d;
+                d = (c3 ^ c7) & 0x000000FFFFFFFF00UL; c3 ^= d; c7 ^= d;
+
+                state[0] = c0;
+                state[1] = c1;
+                state[2] = c2;
+                state[3] = c3;
+                state[4] = c4;
+                state[5] = c5;
+                state[6] = c6;
+                state[7] = c7;
+                break;
+            }
+            default:
+            {
+                throw new InvalidOperationException("Unsupported Kalyna block length.");
+            }
+        }
+    }
+
+    private static void MixColumns(Span<ulong> state)
+    {
+        for (int i = 0; i < state.Length; i++)
+        {
+            state[i] = MixColumn(state[i]);
+        }
+    }
+
+    private static void MixColumnsInv(Span<ulong> state)
+    {
+        for (int i = 0; i < state.Length; i++)
+        {
+            state[i] = MixColumnInv(state[i]);
+        }
+    }
+
+    private static ulong SubstituteWord(ulong value)
+    {
+        int lo = (int)value;
+        int hi = (int)(value >> 32);
+
+        byte t0 = S0[lo & 0xFF];
+        byte t1 = S1[(lo >> 8) & 0xFF];
+        byte t2 = S2[(lo >> 16) & 0xFF];
+        byte t3 = S3[(lo >> 24) & 0xFF];
+        lo = t0 | (t1 << 8) | (t2 << 16) | (t3 << 24);
+
+        byte t4 = S0[hi & 0xFF];
+        byte t5 = S1[(hi >> 8) & 0xFF];
+        byte t6 = S2[(hi >> 16) & 0xFF];
+        byte t7 = S3[(hi >> 24) & 0xFF];
+        hi = t4 | (t5 << 8) | (t6 << 16) | (t7 << 24);
+
+        return (uint)lo | ((ulong)(uint)hi << 32);
+    }
+
+    private static ulong InverseSubstituteWord(ulong value)
+    {
+        int lo = (int)value;
+        int hi = (int)(value >> 32);
+
+        byte t0 = IS0[lo & 0xFF];
+        byte t1 = IS1[(lo >> 8) & 0xFF];
+        byte t2 = IS2[(lo >> 16) & 0xFF];
+        byte t3 = IS3[(lo >> 24) & 0xFF];
+        lo = t0 | (t1 << 8) | (t2 << 16) | (t3 << 24);
+
+        byte t4 = IS0[hi & 0xFF];
+        byte t5 = IS1[(hi >> 8) & 0xFF];
+        byte t6 = IS2[(hi >> 16) & 0xFF];
+        byte t7 = IS3[(hi >> 24) & 0xFF];
+        hi = t4 | (t5 << 8) | (t6 << 16) | (t7 << 24);
+
+        return (uint)lo | ((ulong)(uint)hi << 32);
+    }
+
+    private static ulong MixColumn(ulong value)
+    {
+        ulong x1 = MulX(value);
+        ulong u = Rotate(8, value) ^ value;
+        u ^= Rotate(16, u);
+        u ^= Rotate(48, value);
+
+        ulong v = MulX2(u ^ value ^ x1);
+        return u ^ Rotate(32, v) ^ Rotate(40, x1) ^ Rotate(48, x1);
+    }
+
+    private static ulong MixColumnInv(ulong value)
+    {
+        ulong u0 = value;
+        u0 ^= Rotate(8, u0);
+        u0 ^= Rotate(32, u0);
+        u0 ^= Rotate(48, value);
+
+        ulong t = u0 ^ value;
+
+        ulong c48 = Rotate(48, value);
+        ulong c56 = Rotate(56, value);
+
+        ulong u7 = t ^ c56;
+        ulong u6 = Rotate(56, t);
+        u6 ^= MulX(u7);
+        ulong u5 = Rotate(16, t) ^ value;
+        u5 ^= Rotate(40, MulX(u6) ^ value);
+        ulong u4 = t ^ c48;
+        u4 ^= MulX(u5);
+        ulong u3 = Rotate(16, u0);
+        u3 ^= MulX(u4);
+        ulong u2 = t ^ Rotate(24, value) ^ c48 ^ c56;
+        u2 ^= MulX(u3);
+        ulong u1 = Rotate(32, t) ^ value ^ c56;
+        u1 ^= MulX(u2);
+        u0 ^= MulX(Rotate(40, u1));
+
+        return u0;
+    }
+
+    private static ulong MulX(ulong value)
+    {
+        return ((value & 0x7F7F7F7F7F7F7F7FUL) << 1)
+             ^ (((value & 0x8080808080808080UL) >> 7) * 0x1DUL);
+    }
+
+    private static ulong MulX2(ulong value)
+    {
+        return ((value & 0x3F3F3F3F3F3F3F3FUL) << 2)
+             ^ (((value & 0x8080808080808080UL) >> 6) * 0x1DUL)
+             ^ (((value & 0x4040404040404040UL) >> 6) * 0x1DUL);
+    }
+
+    private static ulong Rotate(int n, ulong value)
+    {
+        return (value >> n) | (value << (64 - n));
     }
 
     private static void SubBytes(Span<byte> state)
@@ -581,9 +1229,11 @@ internal unsafe struct KalynaCore
     }
 
     // Key expansion: compute intermediate key Kt
+    [SkipLocalsInit]
     private static void KeyExpandKt(ReadOnlySpan<byte> key, Span<byte> kt)
     {
         Span<byte> state = stackalloc byte[16];
+        state.Clear();
 
         // Initialize state with block size indicator
         int keyLen = key.Length;
@@ -619,9 +1269,11 @@ internal unsafe struct KalynaCore
     }
 
     // Key expansion for 128-bit key
+    [SkipLocalsInit]
     private static void KeyExpandEvenOdd128(ReadOnlySpan<byte> key, ReadOnlySpan<byte> kt, Span<byte> roundKeys, int nr)
     {
         Span<byte> state = stackalloc byte[16];
+        state.Clear();
         Span<byte> tmpRK = stackalloc byte[16];
         Span<byte> initialData = stackalloc byte[16];
 
@@ -682,9 +1334,11 @@ internal unsafe struct KalynaCore
     }
 
     // Key expansion for 256-bit key with 128-bit block
+    [SkipLocalsInit]
     private static void KeyExpandEvenOdd256(ReadOnlySpan<byte> key, ReadOnlySpan<byte> kt, Span<byte> roundKeys, int nr)
     {
         Span<byte> state = stackalloc byte[16];
+        state.Clear();
         Span<byte> tmpRK = stackalloc byte[16];
         Span<byte> initialData = stackalloc byte[32];
 

--- a/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
+++ b/src/Security/Cryptography/Cipher/Kalyna/KalynaCore.cs
@@ -500,7 +500,8 @@ internal unsafe struct KalynaCore
             ulong* rk = pCore->_roundKeys;
             AddRoundKey(blockState, rk, 0);
 
-            for (int round = 0;;)
+            int round = 0;
+            while (true)
             {
                 SubBytes(blockState);
                 ShiftRows(blockState);
@@ -538,7 +539,7 @@ internal unsafe struct KalynaCore
             ulong* rk = pCore->_roundKeys;
             SubRoundKey(blockState, rk, _rounds);
 
-            for (int round = _rounds;;)
+            for (int round = _rounds; ;)
             {
                 MixColumnsInv(blockState);
                 InvShiftRows(blockState);
@@ -589,8 +590,7 @@ internal unsafe struct KalynaCore
     private static int ExpandKeyGeneric(ReadOnlySpan<byte> key, int blockWords, Span<ulong> roundKeys)
     {
         int keyWords = key.Length / 8;
-        int nr = key.Length switch
-        {
+        int nr = key.Length switch {
             32 => 14,
             64 => 18,
             _ => throw new ArgumentException("Key must be 32 or 64 bytes for the selected Kalyna block size.", nameof(key))
@@ -785,39 +785,39 @@ internal unsafe struct KalynaCore
         switch (blockWords)
         {
             case 2:
-            {
-                ulong x0 = src[0], x1 = src[1];
-                dst[0] = (x0 >> 56) | (x1 << 8);
-                dst[1] = (x1 >> 56) | (x0 << 8);
-                break;
-            }
+                {
+                    ulong x0 = src[0], x1 = src[1];
+                    dst[0] = (x0 >> 56) | (x1 << 8);
+                    dst[1] = (x1 >> 56) | (x0 << 8);
+                    break;
+                }
             case 4:
-            {
-                ulong x0 = src[0], x1 = src[1], x2 = src[2], x3 = src[3];
-                dst[0] = (x1 >> 24) | (x2 << 40);
-                dst[1] = (x2 >> 24) | (x3 << 40);
-                dst[2] = (x3 >> 24) | (x0 << 40);
-                dst[3] = (x0 >> 24) | (x1 << 40);
-                break;
-            }
+                {
+                    ulong x0 = src[0], x1 = src[1], x2 = src[2], x3 = src[3];
+                    dst[0] = (x1 >> 24) | (x2 << 40);
+                    dst[1] = (x2 >> 24) | (x3 << 40);
+                    dst[2] = (x3 >> 24) | (x0 << 40);
+                    dst[3] = (x0 >> 24) | (x1 << 40);
+                    break;
+                }
             case 8:
-            {
-                ulong x0 = src[0], x1 = src[1], x2 = src[2], x3 = src[3];
-                ulong x4 = src[4], x5 = src[5], x6 = src[6], x7 = src[7];
-                dst[0] = (x2 >> 24) | (x3 << 40);
-                dst[1] = (x3 >> 24) | (x4 << 40);
-                dst[2] = (x4 >> 24) | (x5 << 40);
-                dst[3] = (x5 >> 24) | (x6 << 40);
-                dst[4] = (x6 >> 24) | (x7 << 40);
-                dst[5] = (x7 >> 24) | (x0 << 40);
-                dst[6] = (x0 >> 24) | (x1 << 40);
-                dst[7] = (x1 >> 24) | (x2 << 40);
-                break;
-            }
+                {
+                    ulong x0 = src[0], x1 = src[1], x2 = src[2], x3 = src[3];
+                    ulong x4 = src[4], x5 = src[5], x6 = src[6], x7 = src[7];
+                    dst[0] = (x2 >> 24) | (x3 << 40);
+                    dst[1] = (x3 >> 24) | (x4 << 40);
+                    dst[2] = (x4 >> 24) | (x5 << 40);
+                    dst[3] = (x5 >> 24) | (x6 << 40);
+                    dst[4] = (x6 >> 24) | (x7 << 40);
+                    dst[5] = (x7 >> 24) | (x0 << 40);
+                    dst[6] = (x0 >> 24) | (x1 << 40);
+                    dst[7] = (x1 >> 24) | (x2 << 40);
+                    break;
+                }
             default:
-            {
-                throw new InvalidOperationException("Unsupported Kalyna block length.");
-            }
+                {
+                    throw new InvalidOperationException("Unsupported Kalyna block length.");
+                }
         }
     }
 
@@ -869,67 +869,67 @@ internal unsafe struct KalynaCore
         switch (state.Length)
         {
             case 2:
-            {
-                ulong c0 = state[0], c1 = state[1];
-                ulong d = (c0 ^ c1) & 0xFFFFFFFF00000000UL;
-                c0 ^= d;
-                c1 ^= d;
-                state[0] = c0;
-                state[1] = c1;
-                break;
-            }
+                {
+                    ulong c0 = state[0], c1 = state[1];
+                    ulong d = (c0 ^ c1) & 0xFFFFFFFF00000000UL;
+                    c0 ^= d;
+                    c1 ^= d;
+                    state[0] = c0;
+                    state[1] = c1;
+                    break;
+                }
             case 4:
-            {
-                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
-                ulong d;
+                {
+                    ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                    ulong d;
 
-                d = (c0 ^ c2) & 0xFFFFFFFF00000000UL; c0 ^= d; c2 ^= d;
-                d = (c1 ^ c3) & 0x0000FFFFFFFF0000UL; c1 ^= d; c3 ^= d;
+                    d = (c0 ^ c2) & 0xFFFFFFFF00000000UL; c0 ^= d; c2 ^= d;
+                    d = (c1 ^ c3) & 0x0000FFFFFFFF0000UL; c1 ^= d; c3 ^= d;
 
-                d = (c0 ^ c1) & 0xFFFF0000FFFF0000UL; c0 ^= d; c1 ^= d;
-                d = (c2 ^ c3) & 0xFFFF0000FFFF0000UL; c2 ^= d; c3 ^= d;
+                    d = (c0 ^ c1) & 0xFFFF0000FFFF0000UL; c0 ^= d; c1 ^= d;
+                    d = (c2 ^ c3) & 0xFFFF0000FFFF0000UL; c2 ^= d; c3 ^= d;
 
-                state[0] = c0;
-                state[1] = c1;
-                state[2] = c2;
-                state[3] = c3;
-                break;
-            }
+                    state[0] = c0;
+                    state[1] = c1;
+                    state[2] = c2;
+                    state[3] = c3;
+                    break;
+                }
             case 8:
-            {
-                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
-                ulong c4 = state[4], c5 = state[5], c6 = state[6], c7 = state[7];
-                ulong d;
+                {
+                    ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                    ulong c4 = state[4], c5 = state[5], c6 = state[6], c7 = state[7];
+                    ulong d;
 
-                d = (c0 ^ c4) & 0xFFFFFFFF00000000UL; c0 ^= d; c4 ^= d;
-                d = (c1 ^ c5) & 0x00FFFFFFFF000000UL; c1 ^= d; c5 ^= d;
-                d = (c2 ^ c6) & 0x0000FFFFFFFF0000UL; c2 ^= d; c6 ^= d;
-                d = (c3 ^ c7) & 0x000000FFFFFFFF00UL; c3 ^= d; c7 ^= d;
+                    d = (c0 ^ c4) & 0xFFFFFFFF00000000UL; c0 ^= d; c4 ^= d;
+                    d = (c1 ^ c5) & 0x00FFFFFFFF000000UL; c1 ^= d; c5 ^= d;
+                    d = (c2 ^ c6) & 0x0000FFFFFFFF0000UL; c2 ^= d; c6 ^= d;
+                    d = (c3 ^ c7) & 0x000000FFFFFFFF00UL; c3 ^= d; c7 ^= d;
 
-                d = (c0 ^ c2) & 0xFFFF0000FFFF0000UL; c0 ^= d; c2 ^= d;
-                d = (c1 ^ c3) & 0x00FFFF0000FFFF00UL; c1 ^= d; c3 ^= d;
-                d = (c4 ^ c6) & 0xFFFF0000FFFF0000UL; c4 ^= d; c6 ^= d;
-                d = (c5 ^ c7) & 0x00FFFF0000FFFF00UL; c5 ^= d; c7 ^= d;
+                    d = (c0 ^ c2) & 0xFFFF0000FFFF0000UL; c0 ^= d; c2 ^= d;
+                    d = (c1 ^ c3) & 0x00FFFF0000FFFF00UL; c1 ^= d; c3 ^= d;
+                    d = (c4 ^ c6) & 0xFFFF0000FFFF0000UL; c4 ^= d; c6 ^= d;
+                    d = (c5 ^ c7) & 0x00FFFF0000FFFF00UL; c5 ^= d; c7 ^= d;
 
-                d = (c0 ^ c1) & 0xFF00FF00FF00FF00UL; c0 ^= d; c1 ^= d;
-                d = (c2 ^ c3) & 0xFF00FF00FF00FF00UL; c2 ^= d; c3 ^= d;
-                d = (c4 ^ c5) & 0xFF00FF00FF00FF00UL; c4 ^= d; c5 ^= d;
-                d = (c6 ^ c7) & 0xFF00FF00FF00FF00UL; c6 ^= d; c7 ^= d;
+                    d = (c0 ^ c1) & 0xFF00FF00FF00FF00UL; c0 ^= d; c1 ^= d;
+                    d = (c2 ^ c3) & 0xFF00FF00FF00FF00UL; c2 ^= d; c3 ^= d;
+                    d = (c4 ^ c5) & 0xFF00FF00FF00FF00UL; c4 ^= d; c5 ^= d;
+                    d = (c6 ^ c7) & 0xFF00FF00FF00FF00UL; c6 ^= d; c7 ^= d;
 
-                state[0] = c0;
-                state[1] = c1;
-                state[2] = c2;
-                state[3] = c3;
-                state[4] = c4;
-                state[5] = c5;
-                state[6] = c6;
-                state[7] = c7;
-                break;
-            }
+                    state[0] = c0;
+                    state[1] = c1;
+                    state[2] = c2;
+                    state[3] = c3;
+                    state[4] = c4;
+                    state[5] = c5;
+                    state[6] = c6;
+                    state[7] = c7;
+                    break;
+                }
             default:
-            {
-                throw new InvalidOperationException("Unsupported Kalyna block length.");
-            }
+                {
+                    throw new InvalidOperationException("Unsupported Kalyna block length.");
+                }
         }
     }
 
@@ -938,67 +938,67 @@ internal unsafe struct KalynaCore
         switch (state.Length)
         {
             case 2:
-            {
-                ulong c0 = state[0], c1 = state[1];
-                ulong d = (c0 ^ c1) & 0xFFFFFFFF00000000UL;
-                c0 ^= d;
-                c1 ^= d;
-                state[0] = c0;
-                state[1] = c1;
-                break;
-            }
+                {
+                    ulong c0 = state[0], c1 = state[1];
+                    ulong d = (c0 ^ c1) & 0xFFFFFFFF00000000UL;
+                    c0 ^= d;
+                    c1 ^= d;
+                    state[0] = c0;
+                    state[1] = c1;
+                    break;
+                }
             case 4:
-            {
-                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
-                ulong d;
+                {
+                    ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                    ulong d;
 
-                d = (c0 ^ c1) & 0xFFFF0000FFFF0000UL; c0 ^= d; c1 ^= d;
-                d = (c2 ^ c3) & 0xFFFF0000FFFF0000UL; c2 ^= d; c3 ^= d;
+                    d = (c0 ^ c1) & 0xFFFF0000FFFF0000UL; c0 ^= d; c1 ^= d;
+                    d = (c2 ^ c3) & 0xFFFF0000FFFF0000UL; c2 ^= d; c3 ^= d;
 
-                d = (c0 ^ c2) & 0xFFFFFFFF00000000UL; c0 ^= d; c2 ^= d;
-                d = (c1 ^ c3) & 0x0000FFFFFFFF0000UL; c1 ^= d; c3 ^= d;
+                    d = (c0 ^ c2) & 0xFFFFFFFF00000000UL; c0 ^= d; c2 ^= d;
+                    d = (c1 ^ c3) & 0x0000FFFFFFFF0000UL; c1 ^= d; c3 ^= d;
 
-                state[0] = c0;
-                state[1] = c1;
-                state[2] = c2;
-                state[3] = c3;
-                break;
-            }
+                    state[0] = c0;
+                    state[1] = c1;
+                    state[2] = c2;
+                    state[3] = c3;
+                    break;
+                }
             case 8:
-            {
-                ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
-                ulong c4 = state[4], c5 = state[5], c6 = state[6], c7 = state[7];
-                ulong d;
+                {
+                    ulong c0 = state[0], c1 = state[1], c2 = state[2], c3 = state[3];
+                    ulong c4 = state[4], c5 = state[5], c6 = state[6], c7 = state[7];
+                    ulong d;
 
-                d = (c0 ^ c1) & 0xFF00FF00FF00FF00UL; c0 ^= d; c1 ^= d;
-                d = (c2 ^ c3) & 0xFF00FF00FF00FF00UL; c2 ^= d; c3 ^= d;
-                d = (c4 ^ c5) & 0xFF00FF00FF00FF00UL; c4 ^= d; c5 ^= d;
-                d = (c6 ^ c7) & 0xFF00FF00FF00FF00UL; c6 ^= d; c7 ^= d;
+                    d = (c0 ^ c1) & 0xFF00FF00FF00FF00UL; c0 ^= d; c1 ^= d;
+                    d = (c2 ^ c3) & 0xFF00FF00FF00FF00UL; c2 ^= d; c3 ^= d;
+                    d = (c4 ^ c5) & 0xFF00FF00FF00FF00UL; c4 ^= d; c5 ^= d;
+                    d = (c6 ^ c7) & 0xFF00FF00FF00FF00UL; c6 ^= d; c7 ^= d;
 
-                d = (c0 ^ c2) & 0xFFFF0000FFFF0000UL; c0 ^= d; c2 ^= d;
-                d = (c1 ^ c3) & 0x00FFFF0000FFFF00UL; c1 ^= d; c3 ^= d;
-                d = (c4 ^ c6) & 0xFFFF0000FFFF0000UL; c4 ^= d; c6 ^= d;
-                d = (c5 ^ c7) & 0x00FFFF0000FFFF00UL; c5 ^= d; c7 ^= d;
+                    d = (c0 ^ c2) & 0xFFFF0000FFFF0000UL; c0 ^= d; c2 ^= d;
+                    d = (c1 ^ c3) & 0x00FFFF0000FFFF00UL; c1 ^= d; c3 ^= d;
+                    d = (c4 ^ c6) & 0xFFFF0000FFFF0000UL; c4 ^= d; c6 ^= d;
+                    d = (c5 ^ c7) & 0x00FFFF0000FFFF00UL; c5 ^= d; c7 ^= d;
 
-                d = (c0 ^ c4) & 0xFFFFFFFF00000000UL; c0 ^= d; c4 ^= d;
-                d = (c1 ^ c5) & 0x00FFFFFFFF000000UL; c1 ^= d; c5 ^= d;
-                d = (c2 ^ c6) & 0x0000FFFFFFFF0000UL; c2 ^= d; c6 ^= d;
-                d = (c3 ^ c7) & 0x000000FFFFFFFF00UL; c3 ^= d; c7 ^= d;
+                    d = (c0 ^ c4) & 0xFFFFFFFF00000000UL; c0 ^= d; c4 ^= d;
+                    d = (c1 ^ c5) & 0x00FFFFFFFF000000UL; c1 ^= d; c5 ^= d;
+                    d = (c2 ^ c6) & 0x0000FFFFFFFF0000UL; c2 ^= d; c6 ^= d;
+                    d = (c3 ^ c7) & 0x000000FFFFFFFF00UL; c3 ^= d; c7 ^= d;
 
-                state[0] = c0;
-                state[1] = c1;
-                state[2] = c2;
-                state[3] = c3;
-                state[4] = c4;
-                state[5] = c5;
-                state[6] = c6;
-                state[7] = c7;
-                break;
-            }
+                    state[0] = c0;
+                    state[1] = c1;
+                    state[2] = c2;
+                    state[3] = c3;
+                    state[4] = c4;
+                    state[5] = c5;
+                    state[6] = c6;
+                    state[7] = c7;
+                    break;
+                }
             default:
-            {
-                throw new InvalidOperationException("Unsupported Kalyna block length.");
-            }
+                {
+                    throw new InvalidOperationException("Unsupported Kalyna block length.");
+                }
         }
     }
 

--- a/src/Security/Cryptography/README.md
+++ b/src/Security/Cryptography/README.md
@@ -54,7 +54,7 @@ dotnet add package CryptoHives.Foundation.Security.Cryptography
 | MAC | HMAC-SHA-256/384/512, HMAC-SHA3-256, AES-CMAC, AES-GMAC, Poly1305, KMAC128/256, BLAKE2/3 keyed |
 | Cipher (AEAD) | AES-GCM (128/192/256), AES-CCM (128/192/256), ChaCha20-Poly1305, XChaCha20-Poly1305, Ascon-AEAD128 |
 | Cipher (block/stream) | AES-128/192/256 (ECB/CBC/CTR), ChaCha20 |
-| Cipher (regional) | SM4, ARIA, Camellia, Kuznyechik, Kalyna, SEED |
+| Cipher (regional) | SM4, ARIA, Camellia, Kuznyechik, Kalyna (128/256/512), SEED |
 | KDF | HKDF, KBKDF, ConcatKDF, PBKDF2 |
 
 ---

--- a/tests/Security/Cryptography/Benchmarks/Cipher/CipherAlgorithmType.cs
+++ b/tests/Security/Cryptography/Benchmarks/Cipher/CipherAlgorithmType.cs
@@ -334,6 +334,14 @@ public sealed class CipherAlgorithmType : IFormattable
     }
 
     /// <summary>
+    /// Returns Kalyna-512-CBC implementations for benchmarking.
+    /// </summary>
+    public static IEnumerable<CipherAlgorithmType> KalynaCbc512()
+    {
+        return FromRegistry("Kalyna-512-CBC", CipherAlgorithmRegistry.Mode.CBC, 512);
+    }
+
+    /// <summary>
     /// Returns SEED-CBC implementations for benchmarking.
     /// </summary>
     public static IEnumerable<CipherAlgorithmType> SeedCbc()
@@ -356,6 +364,7 @@ public sealed class CipherAlgorithmType : IFormattable
         foreach (var alg in KuznyechikCbc()) yield return alg;
         foreach (var alg in KalynaCbc128()) yield return alg;
         foreach (var alg in KalynaCbc256()) yield return alg;
+        foreach (var alg in KalynaCbc512()) yield return alg;
         foreach (var alg in SeedCbc()) yield return alg;
     }
 

--- a/tests/Security/Cryptography/Benchmarks/Cipher/RegionalCipherBenchmarks.cs
+++ b/tests/Security/Cryptography/Benchmarks/Cipher/RegionalCipherBenchmarks.cs
@@ -855,6 +855,90 @@ public class KalynaCbc256Benchmark : CipherBenchmarkBase
 }
 
 /// <summary>
+/// Benchmarks for Kalyna-512-CBC symmetric encryption (Ukraine, DSTU 7624:2014).
+/// </summary>
+[TestFixture]
+[TestFixtureSource(nameof(CipherAlgorithmTypeArgs))]
+[Config(typeof(CipherConfig))]
+[MemoryDiagnoser(displayGenColumns: false)]
+[HideColumns("Namespace")]
+[BenchmarkCategory("Cipher", "Regional", "Kalyna-512-CBC")]
+[NonParallelizable]
+public class KalynaCbc512Benchmark : CipherBenchmarkBase
+{
+    /// <inheritdoc cref="CipherBenchmarkBase"/>
+    public KalynaCbc512Benchmark() => TestDataSize = DataSize.K8;
+
+    /// <inheritdoc cref="CipherBenchmarkBase"/>
+    public KalynaCbc512Benchmark(CipherAlgorithmType algorithm)
+    {
+        TestCipherAlgorithm = algorithm;
+    }
+
+    [ParamsSource(nameof(Sizes))]
+    public DataSize TestDataSize { get; set; } = DataSize.K8;
+
+    [ParamsSource(nameof(Algorithms))]
+    public CipherAlgorithmType TestCipherAlgorithm { get; set; } = null!;
+
+    /// <inheritdoc cref="CipherBenchmarkBase"/>
+    public static IEnumerable<DataSize> Sizes() => DataSize.Standard;
+
+    /// <inheritdoc cref="CipherBenchmarkBase"/>
+    public static IEnumerable<CipherAlgorithmType> Algorithms() => CipherAlgorithmType.KalynaCbc512();
+
+    /// <inheritdoc cref="CipherBenchmarkBase"/>
+    public static IEnumerable<object[]> CipherAlgorithmTypeArgs()
+    {
+        foreach (var alg in Algorithms())
+            yield return new object[] { alg };
+    }
+
+    /// <inheritdoc/>
+    [OneTimeSetUp]
+    public override void GlobalSetup()
+    {
+        Bytes = TestDataSize.Bytes;
+        CipherAlgorithm = (SymmetricCipher)TestCipherAlgorithm.Create();
+        base.GlobalSetup();
+    }
+
+    [Test, Repeat(5)]
+    [NonParallelizable]
+    public void EncryptTest()
+    {
+        int result = Encrypt();
+        Assert.That(result, Is.GreaterThanOrEqualTo(InputData.Length));
+    }
+
+    /// <inheritdoc cref="CipherBenchmarkBase"/>
+    [Benchmark(Description = "Encrypt")]
+    public int Encrypt()
+    {
+        Encryptor!.Reset();
+        return Encryptor.TransformFinalBlock(InputData, OutputData);
+    }
+
+    [Test, Repeat(5)]
+    [NonParallelizable]
+    public void DecryptTest()
+    {
+        int result = Decrypt();
+        Assert.That(result, Is.EqualTo(InputData.Length));
+        var decryptedData = OutputData.AsSpan().Slice(0, result);
+        Assert.That(decryptedData.SequenceEqual(InputData), Is.True);
+    }
+
+    /// <inheritdoc cref="CipherBenchmarkBase"/>
+    [Benchmark(Description = "Decrypt")]
+    public int Decrypt()
+    {
+        Decryptor!.Reset();
+        return Decryptor.TransformFinalBlock(EncryptedData, OutputData);
+    }
+}
+
+/// <summary>
 /// Benchmarks for SEED-CBC symmetric encryption (Korea, KISA, RFC 4269).
 /// </summary>
 [TestFixture]

--- a/tests/Security/Cryptography/Cipher/CipherAlgorithmRegistry.cs
+++ b/tests/Security/Cryptography/Cipher/CipherAlgorithmRegistry.cs
@@ -1116,6 +1116,29 @@ public static class CipherAlgorithmRegistry
             () => BouncyCastleCipherAdapter.CreateCbc(new Dstu7624Engine(128), 32, "Kalyna-256-CBC"),
             Source.BouncyCastle));
 
+        // Kalyna-512-CBC - Managed
+        implementations.Add(new CipherImplementation(
+            "Kalyna-512-CBC",
+            "CryptoHives-Scalar",
+            512,
+            Mode.CBC,
+            () => {
+                var kal = CH.Cipher.Kalyna512.Create();
+                kal.Mode = CH.Cipher.CipherMode.CBC;
+                kal.Padding = CH.Cipher.PaddingMode.PKCS7;
+                return kal;
+            },
+            Source.Managed));
+
+        // Kalyna-512-CBC - BouncyCastle (Dstu7624Engine)
+        implementations.Add(new CipherImplementation(
+            "Kalyna-512-CBC",
+            "BouncyCastle",
+            512,
+            Mode.CBC,
+            () => BouncyCastleCipherAdapter.CreateCbc(new Dstu7624Engine(256), 64, "Kalyna-512-CBC"),
+            Source.BouncyCastle));
+
         // Kuznyechik-CBC - Managed (no BouncyCastle engine available)
         implementations.Add(new CipherImplementation(
             "Kuznyechik-CBC",

--- a/tests/Security/Cryptography/Cipher/CipherReferenceImplementationTests.cs
+++ b/tests/Security/Cryptography/Cipher/CipherReferenceImplementationTests.cs
@@ -196,7 +196,7 @@ public class CipherReferenceImplementationTests
         "AES-128-CBC", "AES-256-CBC",
         "SM4-CBC", "ARIA-128-CBC", "ARIA-256-CBC",
         "Camellia-128-CBC", "Camellia-256-CBC",
-        "Kalyna-128-CBC", "Kalyna-256-CBC",
+        "Kalyna-128-CBC", "Kalyna-256-CBC", "Kalyna-512-CBC",
         "SEED-CBC"
     ];
 

--- a/tests/Security/Cryptography/Cipher/Kalyna/KalynaTests.cs
+++ b/tests/Security/Cryptography/Cipher/Kalyna/KalynaTests.cs
@@ -97,6 +97,73 @@ public class KalynaTests
     }
 
     // ========================================================================
+    // Kalyna-512/256 (18 rounds)
+    // ========================================================================
+
+    /// <summary>
+    /// Verifies Kalyna-512 ECB round-trip with a 512-bit key.
+    /// </summary>
+    [Test]
+    public void RoundTripEcb512()
+    {
+        byte[] key = FromHex(
+            "000102030405060708090a0b0c0d0e0f" +
+            "101112131415161718191a1b1c1d1e1f" +
+            "202122232425262728292a2b2c2d2e2f" +
+            "303132333435363738393a3b3c3d3e3f");
+        byte[] plaintext = FromHex("404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f");
+
+        using var enc = Kalyna512.Create();
+        enc.Mode = CipherMode.ECB;
+        enc.Padding = PaddingMode.None;
+        enc.Key = key;
+        enc.IV = new byte[32];
+        byte[] ciphertext = enc.Encrypt(plaintext);
+
+        using var dec = Kalyna512.Create();
+        dec.Mode = CipherMode.ECB;
+        dec.Padding = PaddingMode.None;
+        dec.Key = key;
+        dec.IV = new byte[32];
+        byte[] decrypted = dec.Decrypt(ciphertext);
+
+        Assert.That(decrypted, Is.EqualTo(plaintext));
+    }
+
+    /// <summary>
+    /// Verifies Kalyna-512 CBC round-trip with PKCS7 padding.
+    /// </summary>
+    [Test]
+    public void RoundTripCbc512()
+    {
+        byte[] key = FromHex(
+            "000102030405060708090a0b0c0d0e0f" +
+            "101112131415161718191a1b1c1d1e1f" +
+            "202122232425262728292a2b2c2d2e2f" +
+            "303132333435363738393a3b3c3d3e3f");
+        byte[] iv = FromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        byte[] plaintext = FromHex(
+            "0123456789abcdeffedcba98765432100011223344556677fedcba9876543210" +
+            "8899aabbccddeeff0011223344556677");
+
+        using var enc = Kalyna512.Create();
+        enc.Mode = CipherMode.CBC;
+        enc.Padding = PaddingMode.PKCS7;
+        enc.Key = key;
+        enc.IV = iv;
+        byte[] ciphertext = enc.Encrypt(plaintext);
+
+        using var dec = Kalyna512.Create();
+        dec.Mode = CipherMode.CBC;
+        dec.Padding = PaddingMode.PKCS7;
+        dec.Key = key;
+        dec.IV = iv;
+        byte[] decrypted = dec.Decrypt(ciphertext);
+
+        Assert.That(decrypted, Is.EqualTo(plaintext));
+    }
+
+    // ========================================================================
     // CBC and CTR round-trips
     // ========================================================================
 
@@ -234,6 +301,34 @@ public class KalynaTests
     }
 
     /// <summary>
+    /// Cross-validates Kalyna-512 ECB with BouncyCastle Dstu7624Engine.
+    /// </summary>
+    [Test]
+    public void CrossValidateWithBouncyCastle512()
+    {
+        byte[] key = FromHex(
+            "000102030405060708090a0b0c0d0e0f" +
+            "101112131415161718191a1b1c1d1e1f" +
+            "202122232425262728292a2b2c2d2e2f" +
+            "303132333435363738393a3b3c3d3e3f");
+        byte[] plaintext = FromHex("404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f");
+
+        using var kalyna = Kalyna512.Create();
+        kalyna.Mode = CipherMode.ECB;
+        kalyna.Padding = PaddingMode.None;
+        kalyna.Key = key;
+        kalyna.IV = new byte[32];
+        byte[] managed = kalyna.Encrypt(plaintext);
+
+        var bcEngine = new Org.BouncyCastle.Crypto.Engines.Dstu7624Engine(256);
+        bcEngine.Init(true, new Org.BouncyCastle.Crypto.Parameters.KeyParameter(key));
+        byte[] bcOutput = new byte[32];
+        bcEngine.ProcessBlock(plaintext, 0, bcOutput, 0);
+
+        Assert.That(managed, Is.EqualTo(bcOutput), "Kalyna-512 output mismatch with BouncyCastle");
+    }
+
+    /// <summary>
     /// Cross-validates Kalyna-128/256 ECB decryption with BouncyCastle Dstu7624Engine.
     /// </summary>
     [Test]
@@ -364,11 +459,26 @@ public class KalynaTests
     }
 
     [Test]
+    public void AlgorithmNameIsKalyna512()
+    {
+        using var kalyna = Kalyna512.Create();
+        Assert.That(kalyna.AlgorithmName, Is.EqualTo("Kalyna-512"));
+    }
+
+    [Test]
     public void RejectsInvalidKeySize128()
     {
         using var kalyna = Kalyna128.Create();
         Assert.Throws<System.Security.Cryptography.CryptographicException>(
             () => kalyna.Key = new byte[24]);
+    }
+
+    [Test]
+    public void RejectsInvalidKeySize512()
+    {
+        using var kalyna = Kalyna512.Create();
+        Assert.Throws<System.Security.Cryptography.CryptographicException>(
+            () => kalyna.Key = new byte[48]);
     }
 
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/Kalyna/KalynaTests.cs
+++ b/tests/Security/Cryptography/Cipher/Kalyna/KalynaTests.cs
@@ -163,6 +163,48 @@ public class KalynaTests
         Assert.That(decrypted, Is.EqualTo(plaintext));
     }
 
+    /// <summary>
+    /// PKCS#7 padding must be rejected regardless of which byte in the pad is corrupted -
+    /// covers the constant-time padding check in the shared <c>BlockCipherTransform</c> base
+    /// at Kalyna-512's 32-byte block size (the other covering test, in Sm4Tests, only
+    /// exercises the common 16-byte block size). Uses a full block of plaintext so PKCS#7
+    /// adds a full 32-byte padding block; flipping a byte of the first ciphertext block
+    /// corrupts exactly the corresponding byte of the decrypted padding block via CBC's
+    /// XOR chaining, without touching the rest.
+    /// </summary>
+    [Test]
+    [TestCase(0, Description = "First byte of the pad block corrupted")]
+    [TestCase(16, Description = "Middle byte of the pad block corrupted")]
+    [TestCase(31, Description = "Pad-length byte itself corrupted")]
+    public void Kalyna512CbcCorruptedPadding_AnyPosition_Throws(int corruptIndexInPadBlock)
+    {
+        byte[] key = FromHex(
+            "000102030405060708090a0b0c0d0e0f" +
+            "101112131415161718191a1b1c1d1e1f" +
+            "202122232425262728292a2b2c2d2e2f" +
+            "303132333435363738393a3b3c3d3e3f");
+        byte[] iv = FromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        byte[] plaintext = new byte[32]; // exactly one block -> PKCS7 adds a full padding block
+
+        using var enc = Kalyna512.Create();
+        enc.Mode = CipherMode.CBC;
+        enc.Padding = PaddingMode.PKCS7;
+        enc.Key = key;
+        enc.IV = iv;
+        byte[] ciphertext = enc.Encrypt(plaintext);
+        Assert.That(ciphertext, Has.Length.EqualTo(64), "Expected two ciphertext blocks (data + full pad block).");
+
+        ciphertext[corruptIndexInPadBlock] ^= 0xFF;
+
+        using var dec = Kalyna512.Create();
+        dec.Mode = CipherMode.CBC;
+        dec.Padding = PaddingMode.PKCS7;
+        dec.Key = key;
+        dec.IV = iv;
+
+        Assert.Throws<System.Security.Cryptography.CryptographicException>(() => dec.Decrypt(ciphertext));
+    }
+
     // ========================================================================
     // CBC and CTR round-trips
     // ========================================================================


### PR DESCRIPTION
- Support for the Kalyna-512 block cipher variant and generalizes the `BlockCipherTransform` base class to support ciphers with variable block sizes. 
- Added a new `Kalyna512` class and updated documentation to include Kalyna-512, which uses a 256-bit block and a 512-bit key, matching the widest configuration in the DSTU 7624:2014 standard. 
- Refactored `BlockCipherTransform` to accept a configurable block size
- Updated `Kalyna128` and `Kalyna256` to explicitly specify a 16-byte block size.
