### PR TITLE
Add efficient threading support for the WaitAsync(TimeSpan timeout)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ The CryptoHives Open Source Initiative develops secure high-performance .NET lib
 **Repository Characteristics:**
 - **Size:** Medium-scale codebase with less than 10 C# projects
 - **Language:** C# with .NET 8.0/10.0 target framework, legacy .NET Standard 2.0/2.1 and .NET Framework 4.6.2/4.8 support
-- **Architecture:** Modular design with projects for memory management, threading, and security
+- **Architecture:** Modular design with projects for memory management, threading, security and more
 - **Type:** High-performance security focused class libraries and console applications
 - **License:** MIT License
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v5
         with:
-          # Fail on moderate or higher severity vulnerabilities
+          # Fail on moderate or higher severity vulnerabilities during development
           fail-on-severity: moderate
+          fail-on-scopes: development
           # Deny copyleft licenses that are incompatible with MIT
           deny-licenses: GPL-3.0, AGPL-3.0, GPL-2.0, LGPL-2.0, LGPL-2.1, LGPL-3.0
           # Allow common permissive licenses

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,16 +13,17 @@
     <PackageVersion Include="HashifyNET" Version="7.1.1" />
     <PackageVersion Include="IndexRange" Version="1.1.1" />
     <PackageVersion Include="Konscious.Security.Cryptography.Blake2" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" />

--- a/docfx/packages/threading.analyzers/CHT010.md
+++ b/docfx/packages/threading.analyzers/CHT010.md
@@ -1,0 +1,112 @@
+# CHT010: ValueTask captured in lambda/closure
+
+## Cause
+
+A `ValueTask` or `ValueTask<T>` variable is captured from an outer scope into a lambda expression or a local function.
+
+## Rule Description
+
+A `ValueTask` is a struct that can only be consumed once. When a `ValueTask` is captured in a closure (e.g., a lambda or a local function), it is potentially unsafe for two reasons:
+1. The closure might be invoked multiple times.
+2. The `ValueTask` may have been consumed by other code before the closure executes.
+
+Awaiting a captured `ValueTask` leads to undefined behavior, and when backed by an `IValueTaskSource`, the second await may throw `InvalidOperationException` or return incorrect results.
+
+## How to Fix
+
+### Option 1: Convert to Task at declaration
+
+If you need to use the result within a closure and ensure it can be accessed safely multiple times (or because the closure might be called multiple times), convert the `ValueTask` to a `Task` immediately:
+
+```csharp
+// Before
+ValueTask vt = GetValueTask();
+var myLambda = async () => {
+    // This is unsafe because 'vt' is a captured ValueTask
+    return await vt; 
+};
+
+// After
+Task t = GetValueTask().AsTask();
+var myLambda = async () => {
+    // This is safe because 't' is a Task
+    return await t; 
+};
+```
+
+### Option 2: Use Preserve()
+
+Use the `Preserve()` extension method for safe conversion. This is useful if you want to keep the `ValueTask` behavior but need to ensure it's safe to capture it for multiple consumes.
+
+```csharp
+using CryptoHives.Foundation.Threading;
+
+Task t = GetValueTask().Preserve();
+var myLambda = async () => {
+    // This is safe because .Preserve() allows multiple consumes
+    return await t; 
+};
+```
+
+### Option 3: Store the result
+
+If you only need the result of the `ValueTask`, await it once outside of the closure and store the resulting value:
+
+```csharp
+// Before
+ValueTask<int> vt = GetValueTask();
+var myLambda = async () => {
+    // This is unsafe
+    return await vt; 
+};
+
+// After
+int result = await GetValueTask().ConfigureAwait(false);
+var myLambda = () => {
+    // This is safe
+    return result;
+};
+```
+
+## When to Suppress
+
+Never suppress this diagnostic. Capturing a `ValueTask` in a closure without explicit preservation or conversion to a `Task` is a high-risk pattern that leads to undefined behavior.
+
+## Example
+
+### Violating Code
+
+```csharp
+public async Task ProcessAsync()
+{
+    ValueTask vt = DoWorkAsync();
+    
+    // Captured vt in lambda
+    var action = async () => {
+        await vt; // CHT010: vt is captured and potentially already consumed
+    };
+
+    await action();
+}
+```
+
+### Fixed Code
+
+```csharp
+public async Task ProcessAsync()
+{
+    Task t = DoWorkAsync().AsTask();
+    
+    // Captured t in lambda
+    var action = async () => {
+        await t; // OK - Task can be safely awaited multiple times
+    };
+
+    await action();
+}
+```
+
+## See Also
+
+- [Understanding ValueTask](https://devblogs.microsoft.com/dotnet/understanding-the-whys-whats-and-whens-of-valuetask/)
+- [CA2012: Use ValueTasks correctly](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2012)

--- a/docfx/packages/threading.analyzers/index.md
+++ b/docfx/packages/threading.analyzers/index.md
@@ -29,6 +29,7 @@ Or add to your project file:
 | [CHT007](CHT007.md) | Info | AsTask() stored before signaling (performance) |
 | [CHT008](CHT008.md) | Warning | ValueTask not awaited or consumed |
 | [CHT009](CHT009.md) | Info | `SemaphoreSlim(1, 1)` used as async lock; replace with `AsyncLock` |
+| [CHT010](CHT010.md) | Error | ValueTask captured in lambda/closure |
 
 ## Quick Reference
 
@@ -116,6 +117,7 @@ The analyzer package includes automatic code fixes for most diagnostics:
 | CHT007 | Await ValueTask directly |
 | CHT008 | Add await, Explicitly discard with _ = |
 | CHT009 | Replace with AsyncLock |
+| CHT010 | Convert to AsTask() at declaration, Use Preserve() |
 
 ## The Preserve() Method
 

--- a/docfx/packages/threading.analyzers/toc.yml
+++ b/docfx/packages/threading.analyzers/toc.yml
@@ -2,7 +2,7 @@
   href: index.md
 - name: Diagnostic Rules
   items:
-    - name: CHT001 - Multiple Await
+    - name: CHT001 - Multiple Await on ValueTask
       href: CHT001.md
     - name: CHT002 - Blocking GetResult
       href: CHT002.md
@@ -20,3 +20,5 @@
       href: CHT008.md
     - name: CHT009 - SemaphoreSlim as AsyncLock
       href: CHT009.md
+    - name: CHT010 - ValueTask capture in lambda/closure
+      href: CHT010.md

--- a/docfx/packages/threading/asyncautoresetevent.md
+++ b/docfx/packages/threading/asyncautoresetevent.md
@@ -1,4 +1,4 @@
-﻿# AsyncAutoResetEvent
+# AsyncAutoResetEvent
 
 ## Overview
 
@@ -22,6 +22,7 @@ public sealed class AsyncAutoResetEvent
 - **Local waiter optimization**: First queued waiter uses a pre-allocated local waiter to avoid allocations under low contention
 - **ValueTask-based API**: Low-allocation async operations
 - **Cancellation support**: Full `CancellationToken` support for queued waiters. Allocation free registration for .NET versions >= 6.0.
+- **Timeout support**: Direct `WaitAsync(TimeSpan)` overload — no `Task` conversion required. Allocates only one `CancellationTokenSource` per timed wait; disposed automatically on await.
 - **Thread-safe**: All operations are thread-safe
 - **FIFO queue**: Waiters are released in first-in-first-out order
 
@@ -107,6 +108,45 @@ await t;  // OK - Task may be awaited multiple times
 ValueTask vt = _event.WaitAsync();
 await vt;
 await vt;  // Throws InvalidOperationException!
+```
+
+### WaitAsync (timeout)
+
+```csharp
+public ValueTask WaitAsync(TimeSpan timeout)
+```
+
+Asynchronously waits for the event to be signaled, or throws `OperationCanceledException` if the timeout elapses first.
+
+**Parameters**:
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocating a `CancellationTokenSource`).
+
+**Returns**: A `ValueTask` that completes when the event is signaled.
+
+**Throws**:
+- `OperationCanceledException` — If the timeout elapses before the event is signaled.
+- `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
+
+**Allocation notes**:
+
+| Scenario | CancellationTokenSource allocated? |
+|---|---|
+| Event already signaled | No |
+| `Timeout.InfiniteTimeSpan` | No |
+| `TimeSpan.Zero` and not signaled | No (immediate exception) |
+| Finite positive timeout | Yes — one instance, disposed on await |
+
+**Examples**:
+
+```csharp
+// Preferred: direct timeout await — no Task conversion
+await _event.WaitAsync(TimeSpan.FromSeconds(5));
+
+// Previously required — now unnecessary:
+// await _event.WaitAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+// Infinite timeout delegates to WaitAsync() — no CTS allocation
+await _event.WaitAsync(Timeout.InfiniteTimeSpan);
 ```
 
 ### Set
@@ -300,6 +340,26 @@ Storing the `Task` result of `AsTask()` before `Set()` forces an asynchronous co
 ValueTask vt = _event.WaitAsync();
 await vt;
 await vt; // throws InvalidOperationException
+```
+
+### ✓ DO: Use `WaitAsync(TimeSpan)` for timed waits
+
+Avoid the `AsTask().WaitAsync(timeout)` pattern — it forces a `Task` allocation and may cause the 10x–100x slowdown described above. Use the direct timeout overload instead:
+
+```csharp
+// Good: direct timeout, ValueTask stays allocation-light
+try
+{
+    await _event.WaitAsync(TimeSpan.FromSeconds(2));
+    ProcessSignal();
+}
+catch (OperationCanceledException)
+{
+    HandleTimeout();
+}
+
+// Bad: allocates Task, may degrade performance under RunContinuationAsynchronously=true
+await _event.WaitAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
 ```
 
 ## Common Patterns

--- a/docfx/packages/threading/asyncautoresetevent.md
+++ b/docfx/packages/threading/asyncautoresetevent.md
@@ -22,7 +22,7 @@ public sealed class AsyncAutoResetEvent
 - **Local waiter optimization**: First queued waiter uses a pre-allocated local waiter to avoid allocations under low contention
 - **ValueTask-based API**: Low-allocation async operations
 - **Cancellation support**: Full `CancellationToken` support for queued waiters. Allocation free registration for .NET versions >= 6.0.
-- **Timeout support**: Direct `WaitAsync(TimeSpan)` overload — no `Task` conversion required. Allocates only one `CancellationTokenSource` per timed wait; disposed automatically on await.
+- **Timeout support**: Direct `WaitAsync(TimeSpan)` overload — no `Task` conversion required. Allocates only one `TimeProvider` per contended timed wait; disposed automatically.
 - **Thread-safe**: All operations are thread-safe
 - **FIFO queue**: Waiters are released in first-in-first-out order
 
@@ -113,13 +113,13 @@ await vt;  // Throws InvalidOperationException!
 ### WaitAsync (timeout)
 
 ```csharp
-public ValueTask WaitAsync(TimeSpan timeout)
+public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
 Asynchronously waits for the event to be signaled, or throws `OperationCanceledException` if the timeout elapses first.
 
 **Parameters**:
-- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocating a `CancellationTokenSource`).
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocation).
 
 **Returns**: A `ValueTask` that completes when the event is signaled.
 
@@ -129,7 +129,7 @@ Asynchronously waits for the event to be signaled, or throws `OperationCanceledE
 
 **Allocation notes**:
 
-| Scenario | CancellationTokenSource allocated? |
+| Scenario | TimeProvider allocated? |
 |---|---|
 | Event already signaled | No |
 | `Timeout.InfiniteTimeSpan` | No |
@@ -145,7 +145,7 @@ await _event.WaitAsync(TimeSpan.FromSeconds(5));
 // Previously required — now unnecessary:
 // await _event.WaitAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
 
-// Infinite timeout delegates to WaitAsync() — no CTS allocation
+// Infinite timeout delegates to WaitAsync() — no timer allocation
 await _event.WaitAsync(Timeout.InfiniteTimeSpan);
 ```
 

--- a/docfx/packages/threading/asyncautoresetevent.md
+++ b/docfx/packages/threading/asyncautoresetevent.md
@@ -149,6 +149,10 @@ await _event.WaitAsync(TimeSpan.FromSeconds(5));
 await _event.WaitAsync(Timeout.InfiniteTimeSpan);
 ```
 
+### Allocation Behavior
+
+Immediate waits are completely allocation-free using atomic operations. When the event is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<bool>` instances are reused to minimize allocation pressure across repeated operations.
+
 ### Set
 
 ```csharp
@@ -228,7 +232,6 @@ The benchmarks compare various `AsyncAutoResetEvent` implementations:
 - NitoAsyncAutoResetEvent: The implementation from Nito.AsyncEx library
 - AutoResetEvent: The .NET built-in `AutoResetEvent` which lacks the async API
 
-
 ### Set Operation Benchmark
 
 Measures the performance of signaling the event when no waiters are queued. There is no contention and no allocation cost in all implementations.
@@ -248,7 +251,7 @@ Measures the pattern where a waiter is queued before the event is signaled (asyn
 Each iteration level is also measured with a default and a cancellable token to show the overhead of cancellation support.
 Due to the different behavior of the pooled implementations with AsTask(), ValueTask and the RunContinuationAsynchronously flag, these variations are measured separately.
 The RefImpl and Nito implementations do not have the RunContinuationAsynchronously option and always complete asynchronously.
-ProtoPromise is now included as an additional low-allocation competitor and is often the fastest published implementation for the wait-then-set pattern. The caveat of the ProtoPromise library is the custom implementation of Promises as replacement for ValueTask and the custom cancelation tokens. The RefImpl implementation is also sometimes the fastest despite a memory allocation per waiter for a TaskCompletionSource. Also it does not support cancellation tokens and is out of contest for cancellable waits.
+ProtoPromise is now included as an additional low-allocation competitor and is often the fastest published implementation for the wait-then-set pattern. The caveat of the ProtoPromise library is the custom implementation of Promises as replacement for ValueTask and the custom cancellation tokens. The RefImpl implementation is also sometimes the fastest despite a memory allocation per waiter for a TaskCompletionSource. Also it does not support cancellation tokens and is out of contest for cancellable waits.
 The Nito.AsyncEx implementation uses a custom waiter type and allocates memory per waiter in any contested wait, beside being a lot slower than the pooled implementation.
 The pooled implementation starts to allocate memory only when the pool is exhausted (high contention), when the ValueTask is converted to Task by AsTask() or when cancellable tokens are used in legacy .NET versions prior to .NET 6 (due to registration overhead).
 

--- a/docfx/packages/threading/asyncbarrier.md
+++ b/docfx/packages/threading/asyncbarrier.md
@@ -1,4 +1,4 @@
-﻿# AsyncBarrier
+# AsyncBarrier
 
 A pooled, allocation-free async barrier that synchronizes multiple participants using ValueTask-based waiters.
 
@@ -142,6 +142,51 @@ Signals the barrier and waits for all participants to arrive.
 - `InvalidOperationException` - If more participants signal than the total number of registered participants.
 - `BarrierPostPhaseException` - If the post-phase action throws an exception.
 
+### SignalAndWaitAsync (timeout)
+
+```csharp
+public ValueTask SignalAndWaitAsync(TimeSpan timeout)
+```
+
+Signals the barrier and waits for all participants to arrive, or throws `OperationCanceledException` if the timeout elapses before all participants arrive.
+
+The last participant to arrive is never subject to the timeout — it releases all other waiters immediately. A `CancellationTokenSource` is allocated only for non-final participants with a finite positive timeout; it is disposed automatically when the returned `ValueTask` is awaited.
+
+**Parameters**:
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely.
+
+**Returns**: A `ValueTask` that completes when all participants have arrived.
+
+**Throws**:
+- `OperationCanceledException` — If the timeout elapses before all participants arrive.
+- `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
+- `InvalidOperationException` — If more participants signal than registered.
+- `BarrierPostPhaseException` — If the post-phase action throws.
+
+**Allocation notes**:
+
+| Scenario | CancellationTokenSource allocated? |
+|---|---|
+| Last (or only) participant | No |
+| `Timeout.InfiniteTimeSpan` | No |
+| `TimeSpan.Zero` and not last | No (immediate exception) |
+| Finite positive timeout, non-final | Yes — one instance, disposed on await |
+
+**Example**:
+
+```csharp
+try
+{
+    await _barrier.SignalAndWaitAsync(TimeSpan.FromSeconds(10));
+    await DoPhase2WorkAsync();
+}
+catch (OperationCanceledException)
+{
+    // Not all participants arrived in time
+    HandleTimeout();
+}
+```
+
 ### AddParticipant / AddParticipants
 
 ```csharp
@@ -232,6 +277,22 @@ When a waiting participant is cancelled:
 - The participant's `ParticipantsRemaining` count is restored
 - Other participants continue waiting
 - The barrier remains in a consistent state
+
+## Best Practices
+
+### ✓ DO: Use `SignalAndWaitAsync(TimeSpan)` to guard against slow participants
+
+```csharp
+try
+{
+    await _barrier.SignalAndWaitAsync(TimeSpan.FromSeconds(30));
+}
+catch (OperationCanceledException)
+{
+    // Phase did not complete in time; handle accordingly
+    HandleTimeout();
+}
+```
 
 ## Comparison with System.Threading.Barrier
 

--- a/docfx/packages/threading/asyncbarrier.md
+++ b/docfx/packages/threading/asyncbarrier.md
@@ -145,12 +145,12 @@ Signals the barrier and waits for all participants to arrive.
 ### SignalAndWaitAsync (timeout)
 
 ```csharp
-public ValueTask SignalAndWaitAsync(TimeSpan timeout)
+public ValueTask SignalAndWaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
 Signals the barrier and waits for all participants to arrive, or throws `OperationCanceledException` if the timeout elapses before all participants arrive.
 
-The last participant to arrive is never subject to the timeout — it releases all other waiters immediately. A `CancellationTokenSource` is allocated only for non-final participants with a finite positive timeout; it is disposed automatically when the returned `ValueTask` is awaited.
+The last participant to arrive is never subject to the timeout — it releases all other waiters immediately. A `TimeProvider` is allocated only for non-final participants with a finite positive timeout; it is disposed automatically when the returned `ValueTask` is awaited.
 
 **Parameters**:
 - `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely.
@@ -165,7 +165,7 @@ The last participant to arrive is never subject to the timeout — it releases a
 
 **Allocation notes**:
 
-| Scenario | CancellationTokenSource allocated? |
+| Scenario | TimeProvider allocated? |
 |---|---|
 | Last (or only) participant | No |
 | `Timeout.InfiniteTimeSpan` | No |

--- a/docfx/packages/threading/asyncbarrier.md
+++ b/docfx/packages/threading/asyncbarrier.md
@@ -187,6 +187,10 @@ catch (OperationCanceledException)
 }
 ```
 
+### Allocation Behavior
+
+Immediate acquisitions are completely allocation-free using atomic operations. When the barrier is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<bool>` instances are reused to minimize allocation pressure across repeated lock operations.
+
 ### AddParticipant / AddParticipants
 
 ```csharp

--- a/docfx/packages/threading/asynccountdownevent.md
+++ b/docfx/packages/threading/asynccountdownevent.md
@@ -136,6 +136,10 @@ catch (OperationCanceledException)
 }
 ```
 
+### Allocation Behavior
+
+Immediate acquisitions are completely allocation-free using atomic operations. When the countdown is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<bool>` instances are reused to minimize allocation pressure across repeated lock operations.
+
 ### Signal
 
 ```csharp

--- a/docfx/packages/threading/asynccountdownevent.md
+++ b/docfx/packages/threading/asynccountdownevent.md
@@ -1,4 +1,4 @@
-﻿# AsyncCountdownEvent
+# AsyncCountdownEvent
 
 A pooled, allocation-free async countdown event that signals when a count reaches zero using ValueTask-based waiters.
 
@@ -96,6 +96,46 @@ public ValueTask WaitAsync(CancellationToken cancellationToken = default)
 
 Asynchronously waits for the countdown to reach zero.
 
+### WaitAsync (timeout)
+
+```csharp
+public ValueTask WaitAsync(TimeSpan timeout)
+```
+
+Asynchronously waits for the countdown to reach zero, or throws `OperationCanceledException` if the timeout elapses first.
+
+**Parameters**:
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely.
+
+**Returns**: A `ValueTask` that completes when the count reaches zero.
+
+**Throws**:
+- `OperationCanceledException` — If the timeout elapses before the count reaches zero.
+- `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
+
+**Allocation notes**:
+
+| Scenario | CancellationTokenSource allocated? |
+|---|---|
+| Count already zero | No |
+| `Timeout.InfiniteTimeSpan` | No |
+| `TimeSpan.Zero` and count non-zero | No (immediate exception) |
+| Finite positive timeout | Yes — one instance, disposed on await |
+
+**Example**:
+
+```csharp
+try
+{
+    await _countdown.WaitAsync(TimeSpan.FromSeconds(30));
+    ProcessResults();
+}
+catch (OperationCanceledException)
+{
+    HandleTimeout();
+}
+```
+
 ### Signal
 
 ```csharp
@@ -176,6 +216,25 @@ The Nito.Async implementation can not be benchmarked due to its internal design 
 - Fan-out/fan-in coordination patterns
 - Batch processing with parallel workers
 - Scenarios where the countdown is frequently reset and reused
+
+## Best Practices
+
+### ✓ DO: Use `WaitAsync(TimeSpan)` to bound fan-in waits
+
+```csharp
+var countdown = new AsyncCountdownEvent(workers.Length);
+foreach (var w in workers)
+    _ = Task.Run(async () => { await w.RunAsync(); countdown.Signal(); });
+
+try
+{
+    await countdown.WaitAsync(TimeSpan.FromMinutes(1));
+}
+catch (OperationCanceledException)
+{
+    HandleTimeout();
+}
+```
 
 ## See Also
 

--- a/docfx/packages/threading/asynccountdownevent.md
+++ b/docfx/packages/threading/asynccountdownevent.md
@@ -99,7 +99,7 @@ Asynchronously waits for the countdown to reach zero.
 ### WaitAsync (timeout)
 
 ```csharp
-public ValueTask WaitAsync(TimeSpan timeout)
+public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
 Asynchronously waits for the countdown to reach zero, or throws `OperationCanceledException` if the timeout elapses first.
@@ -115,7 +115,7 @@ Asynchronously waits for the countdown to reach zero, or throws `OperationCancel
 
 **Allocation notes**:
 
-| Scenario | CancellationTokenSource allocated? |
+| Scenario | TimeProvider allocated? |
 |---|---|
 | Count already zero | No |
 | `Timeout.InfiniteTimeSpan` | No |
@@ -224,7 +224,9 @@ The Nito.Async implementation can not be benchmarked due to its internal design 
 ```csharp
 var countdown = new AsyncCountdownEvent(workers.Length);
 foreach (var w in workers)
+{
     _ = Task.Run(async () => { await w.RunAsync(); countdown.Signal(); });
+}
 
 try
 {

--- a/docfx/packages/threading/asynclock.md
+++ b/docfx/packages/threading/asynclock.md
@@ -112,6 +112,10 @@ catch (OperationCanceledException)
 }
 ```
 
+### Allocation Behavior
+
+Immediate acquisitions are completely allocation-free using atomic operations. When the lock is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<Releaser>` instances are reused to minimize allocation pressure across repeated lock operations.
+
 ```csharp
 public bool TryReset()
 ```

--- a/docfx/packages/threading/asynclock.md
+++ b/docfx/packages/threading/asynclock.md
@@ -72,13 +72,13 @@ Asynchronously acquires the lock. Returns a disposable that releases the lock wh
 ### LockAsync (timeout)
 
 ```csharp
-public ValueTask<Releaser> LockAsync(TimeSpan timeout)
+public ValueTask<Releaser> LockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
 Asynchronously acquires the lock, or throws `OperationCanceledException` if the timeout elapses before the lock becomes available.
 
 **Parameters**:
-- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `LockAsync()` without allocating a `CancellationTokenSource`).
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `LockAsync()` without allocating a `TimeProvider`).
 
 **Returns**: A `ValueTask<Releaser>` that completes when the lock is acquired. Dispose the result to release the lock.
 
@@ -88,7 +88,7 @@ Asynchronously acquires the lock, or throws `OperationCanceledException` if the 
 
 **Allocation notes**:
 
-| Scenario | CancellationTokenSource allocated? |
+| Scenario | TimeProvider allocated? |
 |---|---|
 | Lock immediately available | No |
 | `Timeout.InfiniteTimeSpan` | No |

--- a/docfx/packages/threading/asynclock.md
+++ b/docfx/packages/threading/asynclock.md
@@ -69,7 +69,48 @@ Asynchronously acquires the lock. Returns a disposable that releases the lock wh
 **Throws**:
 - `OperationCanceledException` - If the operation is canceled via the cancellation token.
 
-### TryReset
+### LockAsync (timeout)
+
+```csharp
+public ValueTask<Releaser> LockAsync(TimeSpan timeout)
+```
+
+Asynchronously acquires the lock, or throws `OperationCanceledException` if the timeout elapses before the lock becomes available.
+
+**Parameters**:
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `LockAsync()` without allocating a `CancellationTokenSource`).
+
+**Returns**: A `ValueTask<Releaser>` that completes when the lock is acquired. Dispose the result to release the lock.
+
+**Throws**:
+- `OperationCanceledException` — If the timeout elapses before the lock can be acquired.
+- `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
+
+**Allocation notes**:
+
+| Scenario | CancellationTokenSource allocated? |
+|---|---|
+| Lock immediately available | No |
+| `Timeout.InfiniteTimeSpan` | No |
+| `TimeSpan.Zero` and locked | No (immediate exception) |
+| Finite positive timeout | Yes — one instance, disposed on await |
+
+**Example**:
+
+```csharp
+try
+{
+    using (await _lock.LockAsync(TimeSpan.FromSeconds(2)))
+    {
+        await DoWorkAsync();
+    }
+}
+catch (OperationCanceledException)
+{
+    // Could not acquire lock within 2 seconds
+    HandleTimeout();
+}
+```
 
 ```csharp
 public bool TryReset()
@@ -201,6 +242,22 @@ Cancellation registrations allocate a small control structure. For hot-path code
 ### DO: Configure a larger pool under high contention
 
 If you expect many concurrent waiters, provide a custom object pool with a larger retention size so allocations are avoided when the pool can satisfy requests.
+
+### DO: Use `LockAsync(TimeSpan)` to bound wait time
+
+```csharp
+try
+{
+    using (await _lock.LockAsync(TimeSpan.FromSeconds(5)))
+    {
+        _data = await FetchAsync();
+    }
+}
+catch (OperationCanceledException)
+{
+    HandleTimeout();
+}
+```
 
 ### DON'T: Create new locks repeatedly
 

--- a/docfx/packages/threading/asyncmanualresetevent.md
+++ b/docfx/packages/threading/asyncmanualresetevent.md
@@ -1,4 +1,4 @@
-﻿# AsyncManualResetEvent
+# AsyncManualResetEvent
 
 ## Overview
 
@@ -104,6 +104,45 @@ await t;  // OK - Task may be awaited multiple times
 ValueTask vt = _event.WaitAsync();
 await vt;
 await vt;  // Throws InvalidOperationException!
+```
+
+### WaitAsync (timeout)
+
+```csharp
+public ValueTask WaitAsync(TimeSpan timeout)
+```
+
+Asynchronously waits for the event to be set, or throws `OperationCanceledException` if the timeout elapses first.
+
+**Parameters**:
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocating a `CancellationTokenSource`).
+
+**Returns**: A `ValueTask` that completes when the event is set.
+
+**Throws**:
+- `OperationCanceledException` — If the timeout elapses before the event is set.
+- `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
+
+**Allocation notes**:
+
+| Scenario | CancellationTokenSource allocated? |
+|---|---|
+| Event already signaled | No |
+| `Timeout.InfiniteTimeSpan` | No |
+| `TimeSpan.Zero` and not set | No (immediate exception) |
+| Finite positive timeout | Yes — one instance, disposed on await |
+
+**Examples**:
+
+```csharp
+// Preferred: direct timeout await — no Task conversion
+await _event.WaitAsync(TimeSpan.FromSeconds(5));
+
+// Previously required — now unnecessary:
+// await _event.WaitAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+// Infinite timeout delegates to WaitAsync() — no CTS allocation
+await _event.WaitAsync(Timeout.InfiniteTimeSpan);
 ```
 
 ### Set
@@ -304,6 +343,20 @@ await vt;  // Exception!
 Task t = _event.WaitAsync().AsTask();
 await t;
 await t;  // OK
+```
+
+### ✓ DO: Use `WaitAsync(TimeSpan)` for timed waits
+
+```csharp
+try
+{
+    await _event.WaitAsync(TimeSpan.FromSeconds(10));
+    ProcessData();
+}
+catch (OperationCanceledException)
+{
+    HandleTimeout();
+}
 ```
 
 ## Common Patterns

--- a/docfx/packages/threading/asyncmanualresetevent.md
+++ b/docfx/packages/threading/asyncmanualresetevent.md
@@ -109,13 +109,13 @@ await vt;  // Throws InvalidOperationException!
 ### WaitAsync (timeout)
 
 ```csharp
-public ValueTask WaitAsync(TimeSpan timeout)
+public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
 Asynchronously waits for the event to be set, or throws `OperationCanceledException` if the timeout elapses first.
 
 **Parameters**:
-- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocating a `CancellationTokenSource`).
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocating a `TimeProvider`).
 
 **Returns**: A `ValueTask` that completes when the event is set.
 
@@ -125,7 +125,7 @@ Asynchronously waits for the event to be set, or throws `OperationCanceledExcept
 
 **Allocation notes**:
 
-| Scenario | CancellationTokenSource allocated? |
+| Scenario | TimeProvider allocated? |
 |---|---|
 | Event already signaled | No |
 | `Timeout.InfiniteTimeSpan` | No |

--- a/docfx/packages/threading/asyncmanualresetevent.md
+++ b/docfx/packages/threading/asyncmanualresetevent.md
@@ -145,6 +145,10 @@ await _event.WaitAsync(TimeSpan.FromSeconds(5));
 await _event.WaitAsync(Timeout.InfiniteTimeSpan);
 ```
 
+### Allocation Behavior
+
+Immediate waits are completely allocation-free using atomic operations. When the event is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<bool>` instances are reused to minimize allocation pressure across repeated operations.
+
 ### Set
 
 ```csharp

--- a/docfx/packages/threading/asyncreaderwriterlock.md
+++ b/docfx/packages/threading/asyncreaderwriterlock.md
@@ -7,6 +7,8 @@ A pooled, allocation-free async reader-writer lock that supports multiple concur
 `AsyncReaderWriterLock` is an async-compatible reader-writer lock. It allows multiple readers to enter the lock concurrently, but only one writer can hold the lock exclusively. Writers are prioritized over readers to prevent writer starvation. One upgradeable reader at a time can share access with multiple other readers. Once the
 upgradeable reader is upgraded to writer, it may have to wait until all readers release the lock. An upgradeable reader may release the lock while still upgraded writers are queued for write access.
 
+An additional internal state, `UpgradedWriterWithoutReader`, is used when an upgradeable reader releases the lock before all concurrent readers have released while an upgrade to writer is in progress. This ensures correct handling of waiting writers under this scenario.
+
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │    ------------                                                             │
@@ -191,6 +193,10 @@ Asynchronously acquires a writer lock, or throws `OperationCanceledException` if
 | `Timeout.InfiniteTimeSpan` | No |
 | `TimeSpan.Zero` and contested | No (immediate exception) |
 | Finite positive timeout | Yes — one instance, disposed on await |
+
+### Allocation Behavior
+
+Immediate lock acquisitions via the fast path are completely allocation-free using atomic operations. When the lock is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<Releaser>` instances are reused to minimize allocation pressure across repeated lock operations.
 
 **Example**:
 

--- a/docfx/packages/threading/asyncreaderwriterlock.md
+++ b/docfx/packages/threading/asyncreaderwriterlock.md
@@ -137,6 +137,16 @@ public ValueTask<Releaser> ReaderLockAsync(CancellationToken cancellationToken =
 
 Asynchronously acquires a reader lock. Multiple readers can hold the lock concurrently.
 
+### ReaderLockAsync (timeout)
+
+```csharp
+public ValueTask<Releaser> ReaderLockAsync(TimeSpan timeout)
+```
+
+Asynchronously acquires a reader lock, or throws `OperationCanceledException` if the timeout elapses first.
+
+**Throws**: `OperationCanceledException` if the timeout elapses, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
+
 ### UpgradeableReaderLockAsync
 
 ```csharp
@@ -145,6 +155,16 @@ public ValueTask<Releaser> UpgradeableReaderLockAsync(CancellationToken cancella
 
 Asynchronously acquires an upgradeable reader lock. One upgradeable reader can coexist with other readers and may later be promoted to a writer lock.
 
+### UpgradeableReaderLockAsync (timeout)
+
+```csharp
+public ValueTask<Releaser> UpgradeableReaderLockAsync(TimeSpan timeout)
+```
+
+Asynchronously acquires an upgradeable reader lock, or throws `OperationCanceledException` if the timeout elapses first.
+
+**Throws**: `OperationCanceledException` if the timeout elapses, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
+
 ### WriterLockAsync
 
 ```csharp
@@ -152,6 +172,41 @@ public ValueTask<Releaser> WriterLockAsync(CancellationToken cancellationToken =
 ```
 
 Asynchronously acquires a writer lock. Only one writer can hold the lock.
+
+### WriterLockAsync (timeout)
+
+```csharp
+public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout)
+```
+
+Asynchronously acquires a writer lock, or throws `OperationCanceledException` if the timeout elapses first.
+
+**Throws**: `OperationCanceledException` if the timeout elapses, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
+
+**Allocation notes for all timeout overloads**:
+
+| Scenario | CancellationTokenSource allocated? |
+|---|---|
+| Lock immediately available | No |
+| `Timeout.InfiniteTimeSpan` | No |
+| `TimeSpan.Zero` and contested | No (immediate exception) |
+| Finite positive timeout | Yes — one instance, disposed on await |
+
+**Example**:
+
+```csharp
+try
+{
+    using (await _rwLock.ReaderLockAsync(TimeSpan.FromSeconds(5)))
+    {
+        return await ReadDataAsync();
+    }
+}
+catch (OperationCanceledException)
+{
+    HandleTimeout();
+}
+```
 
 ## Releaser
 
@@ -233,6 +288,24 @@ Measures the performance of acquiring an upgradeable reader lock, holding additi
 - Read-heavy workloads with occasional writes
 - Cache implementations with read/write patterns
 - Document or configuration stores
+
+## Best Practices
+
+### ✓ DO: Use timeout overloads to bound lock-wait time
+
+```csharp
+try
+{
+    using (await _rwLock.WriterLockAsync(TimeSpan.FromSeconds(5)))
+    {
+        await SaveDataAsync();
+    }
+}
+catch (OperationCanceledException)
+{
+    HandleTimeout();
+}
+```
 
 **Design Trade-offs:**
 

--- a/docfx/packages/threading/asyncreaderwriterlock.md
+++ b/docfx/packages/threading/asyncreaderwriterlock.md
@@ -176,7 +176,7 @@ Asynchronously acquires a writer lock. Only one writer can hold the lock.
 ### WriterLockAsync (timeout)
 
 ```csharp
-public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout)
+public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
 Asynchronously acquires a writer lock, or throws `OperationCanceledException` if the timeout elapses first.
@@ -185,7 +185,7 @@ Asynchronously acquires a writer lock, or throws `OperationCanceledException` if
 
 **Allocation notes for all timeout overloads**:
 
-| Scenario | CancellationTokenSource allocated? |
+| Scenario | TimeProvider allocated? |
 |---|---|
 | Lock immediately available | No |
 | `Timeout.InfiniteTimeSpan` | No |

--- a/docfx/packages/threading/asyncsemaphore.md
+++ b/docfx/packages/threading/asyncsemaphore.md
@@ -84,7 +84,7 @@ Asynchronously waits to acquire a permit from the semaphore.
 ### WaitAsync (timeout)
 
 ```csharp
-public ValueTask WaitAsync(TimeSpan timeout)
+public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
 Asynchronously waits to acquire a permit, or throws `OperationCanceledException` if the timeout elapses first.
@@ -100,7 +100,7 @@ Asynchronously waits to acquire a permit, or throws `OperationCanceledException`
 
 **Allocation notes**:
 
-| Scenario | CancellationTokenSource allocated? |
+| Scenario | TimeProvider allocated? |
 |---|---|
 | Permit immediately available | No |
 | `Timeout.InfiniteTimeSpan` | No |

--- a/docfx/packages/threading/asyncsemaphore.md
+++ b/docfx/packages/threading/asyncsemaphore.md
@@ -129,6 +129,10 @@ catch (OperationCanceledException)
 }
 ```
 
+### Allocation Behavior
+
+Immediate acquisitions are completely allocation-free using atomic operations. When the semaphore is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<bool>` instances are reused to minimize allocation pressure across repeated lock operations.
+
 ### Release
 
 ```csharp

--- a/docfx/packages/threading/asyncsemaphore.md
+++ b/docfx/packages/threading/asyncsemaphore.md
@@ -1,4 +1,4 @@
-﻿# AsyncSemaphore
+# AsyncSemaphore
 
 A pooled, allocation-free async semaphore that limits concurrent access using ValueTask-based waiters.
 
@@ -81,6 +81,54 @@ public ValueTask WaitAsync(CancellationToken cancellationToken = default)
 
 Asynchronously waits to acquire a permit from the semaphore.
 
+### WaitAsync (timeout)
+
+```csharp
+public ValueTask WaitAsync(TimeSpan timeout)
+```
+
+Asynchronously waits to acquire a permit, or throws `OperationCanceledException` if the timeout elapses first.
+
+**Parameters**:
+- `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely.
+
+**Returns**: A `ValueTask` that completes when a permit is acquired.
+
+**Throws**:
+- `OperationCanceledException` — If the timeout elapses before a permit becomes available.
+- `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
+
+**Allocation notes**:
+
+| Scenario | CancellationTokenSource allocated? |
+|---|---|
+| Permit immediately available | No |
+| `Timeout.InfiniteTimeSpan` | No |
+| `TimeSpan.Zero` and no permit | No (immediate exception) |
+| Finite positive timeout | Yes — one instance, disposed on await |
+
+**Example**:
+
+```csharp
+try
+{
+    await _semaphore.WaitAsync(TimeSpan.FromSeconds(5));
+    try
+    {
+        await DoWorkAsync();
+    }
+    finally
+    {
+        _semaphore.Release();
+    }
+}
+catch (OperationCanceledException)
+{
+    // Permit was not available within 5 seconds
+    HandleTimeout();
+}
+```
+
 ### Release
 
 ```csharp
@@ -140,7 +188,26 @@ Measures the performance of acquiring and releasing a single permit. In the curr
 | Allocation overhead | Minimal (pooled) | Higher (per wait) |
 | ValueTask support | Native | Via WaitAsync |
 | Cancellation | Full support | Full support |
+| Timeout support | Direct `WaitAsync(TimeSpan)` | Via `WaitAsync(int)` / CT |
 | Performance | Optimized | Standard |
+
+## Best Practices
+
+### ✓ DO: Use `WaitAsync(TimeSpan)` for timed acquisitions
+
+```csharp
+try
+{
+    await _semaphore.WaitAsync(TimeSpan.FromSeconds(2));
+    await DoWorkAsync();
+    _semaphore.Release();
+}
+catch (OperationCanceledException)
+{
+    // No permit available within the timeout
+    HandleTimeout();
+}
+```
 
 ## See Also
 

--- a/docfx/packages/threading/index.md
+++ b/docfx/packages/threading/index.md
@@ -1,4 +1,4 @@
-﻿# CryptoHives.Foundation.Threading Package
+# CryptoHives.Foundation.Threading Package
 
 ## Overview
 
@@ -9,14 +9,15 @@ In recent years, the introduction of `ValueTask` and `IValueTaskSource` has enab
 This library is the result of the research done by the *Keepers of the CryptoHives* into building efficient, pooled async synchronization primitives that leverage these modern .NET features.
 By demand, more primitives might be added in the future.
 
-## Key Features
+## Core Guarantees
 
 - **Pooled Primitives**: Synchronization objects backed by object pools
 - **ValueTask-based**: Low-allocation async operations
-- **High Performance**: Optimized for concurrent access patterns
+- **High Performance**: Optimized for concurrent access patterns using interlocked state transitions
 - **Thread-safe**: All operations are thread-safe
 - **Ease of use**: Drop-in replacement to replace other popular libraries by changing the namespace
 - **Cancellation support**: Full `CancellationToken` support across all primitives
+- **Timeout support**: Optional timeout parameters on all lock acquisition methods
 - **Configurable continuations**: Control synchronous vs asynchronous continuation execution
 - **Custom ObjectPools**: Supply your own object pools for fine-grained control
 - **Included Analyzers**: Roslyn analyzers automatically detect common ValueTask misuse patterns
@@ -71,16 +72,22 @@ using CryptoHives.Foundation.Threading.Pools;
 
 ## ⚠️ Known Issues and Caveats
 
-1. Strictly only **await a ValueTask once**. An additional await or AsTask() may throw an `InvalidOperationException`.
-2. Strictly only **use AsTask() once**, and only if you have to. An additional await or AsTask() may throw an `InvalidOperationException`. Adds also a Task allocation on contention.
-3. **RunContinuationsAsynchronously** is by default enabled. In rare cases perf degradation may occur if the Task derived from a ValueTask is not immediately awaited (see benchmarks).
-4. **Pool Exhaustion**: In extreme high-throughput scenarios with many waiters, the pool may exhaust. Monitor and adjust usage patterns accordingly. Use a custom pool if necessary.
-5. Always await a ValueTask or AsTask() waiter primitive, or the `IValueTaskSource` is not returned to the pool.
-6. **AsTask() Performance Warning**: When `RunContinuationAsynchronously=true` (default), storing the result of `AsTask()` before signaling causes severe performance degradation (10x-100x slower). Always await `ValueTask` directly when possible.
+1. **Strictly only await a ValueTask once**. An additional await or AsTask() may throw an `InvalidOperationException`.
+2. **Strictly only use AsTask() once**, and only if you have to. An additional await or AsTask() may throw an `InvalidOperationException`. Adds also a Task allocation on contention.
+3. **Pool Exhaustion**: In extreme high-throughput scenarios with many waiters, the pool may exhaust. Monitor and adjust usage patterns accordingly. Use a custom pool if necessary.
+4. **Architecture-Specific Performance**: Performance characteristics vary significantly between Windows x64 and Apple Silicon (M4). 
+    - **Windows x64**: Exhibits superior performance at low concurrency (1–2 waiters) due to efficient ThreadPool inline task scheduling.
+    - **macOS M4**: Exhibits superior performance at high concurrency (100+ waiters) and on uncontended paths due to ARM64 JIT optimizations.
+    - **Recommendation**: For maximum throughput at all contention levels, prefer `AsValueTask()` where possible.
+5. **Always Await**: Always await a `ValueTask` or `Task` waiter primitive; otherwise, the underlying `IValueTaskSource` is not returned to the pool, causing a leak.
 
-## Benchmarks
+## Performance Characteristics
 
-Microbenchmarks and contention tests with a discussion of the performance characteristics are available to validate performance and allocation characteristics.
+- **Pooled Primitives**: Synchronization objects backed by object pools to minimize GC pressure.
+- **ValueTask-based**: Low-allocation async operations that avoid heap allocations on the fast path.
+- **Lock-Free Fast Paths**: Optimized for uncontended access using atomic operations.
+- **Scheduling**: 
+    - Uses `RunContinuationsAsynchronously` by default to prevent deadlocks.
 
 Please be aware that not all new replacement classes behave better than existing popular implementations in all scenarios; But most of the time they do.
 
@@ -229,6 +236,50 @@ public async Task WriteAsync(CancellationToken ct)
 }
 ```
 
+## Timeout Support
+
+All synchronization primitives support optional timeout parameters to prevent indefinite waiting. This enables non-blocking attempts and timeout-based retry logic:
+
+```csharp
+// Non-blocking attempt using TimeSpan.Zero
+try
+{
+    using (await _lock.LockAsync(TimeSpan.Zero))
+    {
+        await DoWorkAsync();
+    }
+}
+catch (OperationCanceledException)
+{
+    // Lock not immediately available
+}
+```
+
+```csharp
+// Timeout-based acquisition with retry
+private readonly AsyncLock _lock = new AsyncLock();
+
+public async Task<bool> TryAcquireWithRetryAsync(TimeSpan timeout, int maxRetries, CancellationToken ct)
+{
+    for (int i = 0; i < maxRetries; i++)
+    {
+        try
+        {
+            using (await _lock.LockAsync(timeout, ct))
+            {
+                return await PerformWorkAsync();
+            }
+        }
+        catch (OperationCanceledException) when (i < maxRetries - 1)
+        {
+            // Timeout occurred, retry
+            continue;
+        }
+    }
+    return false; // All retries exhausted
+}
+```
+
 ## Benefits
 
 ### Reduced Allocations
@@ -264,7 +315,7 @@ public async Task WriteAsync(CancellationToken ct)
 3. **Do not reuse ValueTask**: Always await or AsTask() only once per ValueTask instance
 4. **Always Await ValueTask and Task**: If not awaited, resources are not returned to the pool
 5. **Avoid holding locks**: Keep critical sections as short as possible
-6. **Use cancellation**: Always pass CancellationToken for long waits
+6. **Use cancellation**: Always pass CancellationToken for long waits (remember, its almost free!)
 7. **ConfigureAwait(false)**: Use in library code to avoid context capture
 8. **Avoid AsTask() before signaling**: When `RunContinuationAsynchronously=true`, this causes severe performance degradation
 

--- a/src/Security/Cryptography/Cryptography.csproj
+++ b/src/Security/Cryptography/Cryptography.csproj
@@ -19,13 +19,6 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
   </PropertyGroup>
 
-  <!-- override to tag Cryptography library as beta until API surface is finalized -->
-  <PropertyGroup Condition="'$(NBGV_PublicRelease)' == 'True' AND '$(NBGV_PrereleaseVersion)' != '-preview'">
-    <Version>$(NBGV_Version)-alpha</Version>
-    <VersionSuffix>$(NBGV_VersionRevision)-alpha</VersionSuffix>
-    <PackageVersion>$(NBGV_Version)-alpha</PackageVersion>
-  </PropertyGroup>  
-  
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <PackageId>$(PackageId).Debug</PackageId>
   </PropertyGroup>

--- a/src/Threading.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Threading.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 0.3
+## Release 0.6
 
 ### New Rules
 
@@ -12,3 +12,4 @@ CHT005 | Usage | Warning | ValueTask.Result accessed directly
 CHT006 | Usage | Warning | ValueTask passed to potentially unsafe method
 CHT007 | Usage | Info | AsTask() stored before signaling (performance)
 CHT008 | Usage | Warning | ValueTask not awaited or consumed
+CHT009 | Usage | Info | SemaphoreSlim(1, 1) used as async lock; replace with AsyncLock

--- a/src/Threading.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Threading.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,5 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-CHT009 | Usage | Info | SemaphoreSlim(1, 1) used as async lock; replace with AsyncLock
+CHT010 | Usage | Error | ValueTask captured in lambda/closure
 

--- a/src/Threading.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Threading.Analyzers/DiagnosticDescriptors.cs
@@ -138,4 +138,18 @@ public static class DiagnosticDescriptors
         description: "SemaphoreSlim(1, 1) is commonly used as an async-compatible exclusive lock, but CryptoHives.Foundation.Threading.Async.Pooled.AsyncLock is purpose-built for this pattern: it uses pooled ValueTask sources to eliminate per-wait allocations and provides a deterministic Releaser struct that works with using declarations.",
         helpLinkUri: HelpLinkBase + "CHT009.html",
         customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
+
+    /// <summary>
+    /// CHT010: ValueTask captured in lambda/closure.
+    /// </summary>
+    public static readonly DiagnosticDescriptor CapturedInClosure = new(
+        id: DiagnosticIds.CapturedInClosure,
+        title: "ValueTask captured in lambda or closure",
+        messageFormat: "ValueTask '{0}' is captured in a lambda/closure and may be consumed multiple times",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Capturing a ValueTask in a lambda or local function is potentially unsafe because the lambda might be invoked multiple times, or the ValueTask may be consumed by other code before the lambda executes. If you need to use the result multiple times, convert it to a Task using .AsTask() or use .Preserve() to safely capture it for multiple consumes.",
+        helpLinkUri: HelpLinkBase + "CHT010.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 }

--- a/src/Threading.Analyzers/DiagnosticIds.cs
+++ b/src/Threading.Analyzers/DiagnosticIds.cs
@@ -11,45 +11,50 @@ public static class DiagnosticIds
     /// <summary>
     /// ValueTask awaited multiple times.
     /// </summary>
-    public const string MultipleAwait = "CHT001";
-
+    public const string MultipleAwait = "CHT001"; 
+  
     /// <summary>
     /// ValueTask.GetAwaiter().GetResult() used (blocking).
-    /// </summary>
-    public const string BlockingGetResult = "CHT002";
-
+    /// </summary> 
+    public const string BlockingGetResult = "CHT002"; 
+  
     /// <summary>
-    /// ValueTask stored in field (potential double consumption).
-    /// </summary>
-    public const string StoredInField = "CHT003";
-
+    /// ValueTask stored in field (potential double consumption). 
+    /// </summary> 
+    public const string StoredInField = "CHT003"; 
+  
     /// <summary>
-    /// ValueTask.AsTask() called multiple times.
-    /// </summary>
-    public const string MultipleAsTask = "CHT004";
-
+    /// ValueTask.AsTask() called multiple times. 
+    /// </summary> 
+    public const string MultipleAsTask = "CHT004"; 
+  
     /// <summary>
-    /// ValueTask.Result accessed directly (blocking and potential misuse).
-    /// </summary>
-    public const string DirectResultAccess = "CHT005";
-
+    /// ValueTask.Result accessed directly (blocking and potential misuse). 
+    /// </summary> 
+    public const string DirectResultAccess = "CHT005"; 
+  
     /// <summary>
-    /// ValueTask passed to method that may consume it multiple times.
-    /// </summary>
-    public const string PassedToUnsafeMethod = "CHT006";
-
+    /// ValueTask passed to method that may consume it multiple times. 
+    /// </summary> 
+    public const string PassedToUnsafeMethod = "CHT006"; 
+  
     /// <summary>
-    /// ValueTask.AsTask() stored before signaling can cause performance issues.
-    /// </summary>
-    public const string AsTaskStoredBeforeSignal = "CHT007";
-
+    /// ValueTask.AsTask() stored before signaling can cause performance issues. 
+    /// </summary> 
+    public const string AsTaskStoredBeforeSignal = "CHT007"; 
+  
     /// <summary>
-    /// ValueTask not awaited or converted to Task.
-    /// </summary>
-    public const string NotConsumed = "CHT008";
-
+    /// ValueTask not awaited or converted to Task. 
+    /// </summary> 
+    public const string NotConsumed = "CHT008"; 
+  
     /// <summary>
-    /// <c>SemaphoreSlim(1, 1)</c> used as an async lock; replace with <c>AsyncLock</c>.
-    /// </summary>
-    public const string SemaphoreSlimAsAsyncLock = "CHT009";
+    /// <c>SemaphoreSlim(1, 1)</c> used as an async lock; replace with <c>AsyncLock</c>. 
+    /// </summary> 
+    public const string SemaphoreSlimAsAsyncLock = "CHT009"; 
+  
+    /// <summary> 
+    /// ValueTask captured in lambda/closure. 
+    /// </summary> 
+    public const string CapturedInClosure = "CHT010"; 
 }

--- a/src/Threading.Analyzers/ValueTaskMisuseAnalyzer.cs
+++ b/src/Threading.Analyzers/ValueTaskMisuseAnalyzer.cs
@@ -43,7 +43,8 @@ public sealed class ValueTaskMisuseAnalyzer : DiagnosticAnalyzer
         DiagnosticDescriptors.DirectResultAccess,
         DiagnosticDescriptors.PassedToUnsafeMethod,
         DiagnosticDescriptors.AsTaskStoredBeforeSignal,
-        DiagnosticDescriptors.NotConsumed);
+        DiagnosticDescriptors.NotConsumed,
+        DiagnosticDescriptors.CapturedInClosure);
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -695,7 +696,7 @@ public sealed class ValueTaskMisuseAnalyzer : DiagnosticAnalyzer
 
                 // This is a captured variable from outer scope - flag it as potential misuse
                 var diagnostic = Diagnostic.Create(
-                    DiagnosticDescriptors.MultipleAwait,
+                    DiagnosticDescriptors.CapturedInClosure,
                     identifier.GetLocation(),
                     identifier.Identifier.Text);
                 _context.ReportDiagnostic(diagnostic);

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -199,7 +199,7 @@ public sealed class AsyncAutoResetEvent : IResettable
             return default;
         }
 
-        return WaitAsyncImpl(cancellationToken);
+        return WaitAsyncImpl(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
     /// <summary>
@@ -235,7 +235,7 @@ public sealed class AsyncAutoResetEvent : IResettable
         {
             if (timeout == Timeout.InfiniteTimeSpan)
             {
-                return WaitAsyncImpl(cancellationToken);
+                return WaitAsyncImpl(Timeout.InfiniteTimeSpan, cancellationToken);
             }
 
             if (timeout == TimeSpan.Zero)
@@ -250,7 +250,7 @@ public sealed class AsyncAutoResetEvent : IResettable
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImpl(CancellationToken cancellationToken = default)
+    private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
         _spinLock.Enter();
         try
@@ -273,37 +273,30 @@ public sealed class AsyncAutoResetEvent : IResettable
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
-            return QueueWaiter(waiter);
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
-    }
-
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
-    {
-        _spinLock.Enter();
-        try
-        {
-            // due to race conditions, _signaled may have changed until the lock is taken
-            if (Interlocked.Exchange(ref _signaled, 0) != 0)
+            if (timeout != Timeout.InfiniteTimeSpan)
             {
-                return default;
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
             }
 
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
+            if (cancellationToken.CanBeCanceled)
             {
-                waiter = _pool.GetPooledWaiter(this);
+#if NET6_0_OR_GREATER
+                // Use UnsafeRegister on .NET 6+ for allocation free registration
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
             }
-            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
 
-            waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
-                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
-
-            return QueueWaiter(waiter);
+            _waiters.Enqueue(waiter);
+            return new ValueTask(waiter, waiter.Version);
         }
         finally
         {
@@ -413,32 +406,6 @@ public sealed class AsyncAutoResetEvent : IResettable
 #endif
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-    }
-
-    /// <summary>
-    /// Queue and register the waiter if it can be canceled.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
-    {
-        if (waiter.CancellationToken.CanBeCanceled)
-        {
-#if NET6_0_OR_GREATER
-            // Use UnsafeRegister on .NET 6+ for allocation free registration
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-        }
-        else
-        {
-            Debug.Assert(waiter.CancellationTokenRegistration == default);
-        }
-
-        _waiters.Enqueue(waiter);
-        return new ValueTask(waiter, waiter.Version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -199,11 +199,61 @@ public sealed class AsyncAutoResetEvent : IResettable
             return default;
         }
 
-        return WaitAsyncImpl(cancellationToken);
+        return WaitAsyncImpl(null!, cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously waits for a signal to be received, or until the specified timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If the signal has already been received, the method returns a completed <see cref="ValueTask"/> immediately
+    /// without allocating any cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated
+    /// only when the event is not already signalled and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask"/> that completes when the signal is received.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before the event is signalled.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    public ValueTask WaitAsync(TimeSpan timeout)
+    {
+        // fast path without lock
+        if (Interlocked.Exchange(ref _signaled, 0) != 0)
+        {
+            return default;
+        }
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                return WaitAsyncImpl(null!, default);
+            }
+
+            if (timeout == TimeSpan.Zero)
+            {
+                return new ValueTask(Task.FromException(new OperationCanceledException()));
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        }
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        var timeoutCts = new CancellationTokenSource(timeout);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+        return WaitAsyncImpl(timeoutCts, timeoutCts.Token);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImpl(CancellationToken cancellationToken)
+    private ValueTask WaitAsyncImpl(CancellationTokenSource timeoutCts, CancellationToken cancellationToken)
     {
         _spinLock.Enter();
         try
@@ -211,6 +261,7 @@ public sealed class AsyncAutoResetEvent : IResettable
             // due to race conditions, _signaled may have changed until the lock is taken
             if (Interlocked.Exchange(ref _signaled, 0) != 0)
             {
+                timeoutCts?.Dispose();
                 return default;
             }
 
@@ -224,6 +275,7 @@ public sealed class AsyncAutoResetEvent : IResettable
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.TimeoutCts = timeoutCts;
             waiter.CancellationToken = cancellationToken;
 
             if (cancellationToken.CanBeCanceled)

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -199,7 +199,7 @@ public sealed class AsyncAutoResetEvent : IResettable
             return default;
         }
 
-        return WaitAsyncImpl(null!, cancellationToken);
+        return WaitAsyncImpl(cancellationToken);
     }
 
     /// <summary>
@@ -214,6 +214,7 @@ public sealed class AsyncAutoResetEvent : IResettable
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the attempt to wait for an event.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when the signal is received.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -222,7 +223,7 @@ public sealed class AsyncAutoResetEvent : IResettable
     /// Thrown when the timeout elapses before the event is signalled.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    public ValueTask WaitAsync(TimeSpan timeout)
+    public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         // fast path without lock
         if (Interlocked.Exchange(ref _signaled, 0) != 0)
@@ -234,7 +235,7 @@ public sealed class AsyncAutoResetEvent : IResettable
         {
             if (timeout == Timeout.InfiniteTimeSpan)
             {
-                return WaitAsyncImpl(null!, default);
+                return WaitAsyncImpl(cancellationToken);
             }
 
             if (timeout == TimeSpan.Zero)
@@ -245,15 +246,11 @@ public sealed class AsyncAutoResetEvent : IResettable
             throw new ArgumentOutOfRangeException(nameof(timeout));
         }
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
-        var timeoutCts = new CancellationTokenSource(timeout);
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-        return WaitAsyncImpl(timeoutCts, timeoutCts.Token);
+        return WaitAsyncImpl(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImpl(CancellationTokenSource timeoutCts, CancellationToken cancellationToken)
+    private ValueTask WaitAsyncImpl(CancellationToken cancellationToken = default)
     {
         _spinLock.Enter();
         try
@@ -261,7 +258,6 @@ public sealed class AsyncAutoResetEvent : IResettable
             // due to race conditions, _signaled may have changed until the lock is taken
             if (Interlocked.Exchange(ref _signaled, 0) != 0)
             {
-                timeoutCts?.Dispose();
                 return default;
             }
 
@@ -275,27 +271,39 @@ public sealed class AsyncAutoResetEvent : IResettable
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-            waiter.TimeoutCts = timeoutCts;
             waiter.CancellationToken = cancellationToken;
 
-            if (cancellationToken.CanBeCanceled)
+            return QueueWaiter(waiter);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        _spinLock.Enter();
+        try
+        {
+            // due to race conditions, _signaled may have changed until the lock is taken
+            if (Interlocked.Exchange(ref _signaled, 0) != 0)
             {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
+                return default;
             }
 
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
+            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
+            {
+                waiter = _pool.GetPooledWaiter(this);
+            }
+            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+
+            return QueueWaiter(waiter);
         }
         finally
         {
@@ -372,6 +380,20 @@ public sealed class AsyncAutoResetEvent : IResettable
         toReleaseChain?.SetChainResult(true);
     }
 
+    /// <summary>
+    /// Callback used with <see cref="TimeProvider"/> to trigger timeout.
+    /// </summary>
+    private void TimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<bool> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
 #if NET6_0_OR_GREATER
     private static readonly Action<object?, CancellationToken> _cancellationCallbackAction = static (state, ct) => {
         var waiter = (ManualResetValueTaskSource<bool>)state!;
@@ -389,15 +411,48 @@ public sealed class AsyncAutoResetEvent : IResettable
             return;
         }
 #endif
-        // O(1) removal from intrusive linked list.
-        ManualResetValueTaskSource<bool>? toCancel = null;
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
 
+    /// <summary>
+    /// Queue and register the waiter if it can be canceled.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
+        if (waiter.CancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        _waiters.Enqueue(waiter);
+        return new ValueTask(waiter, waiter.Version);
+    }
+
+    /// <summary>
+    /// O(1) removal from intrusive linked list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<bool>? RemoveWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
         _spinLock.Enter();
         try
         {
             if (_waiters.Remove(waiter))
             {
-                toCancel = waiter;
+                return waiter;
             }
         }
         finally
@@ -405,8 +460,6 @@ public sealed class AsyncAutoResetEvent : IResettable
             _spinLock.Exit();
         }
 
-#pragma warning disable CA1508 // Avoid dead conditional code
-        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-#pragma warning restore CA1508 // Avoid dead conditional code
+        return null;
     }
 }

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -25,6 +25,9 @@ using System.Threading.Tasks.Sources;
 /// implementations.
 /// </para>
 /// <para>
+/// <b>Optional timeout and cancellation token</b> parameters on <see cref="WaitAsync(TimeSpan, CancellationToken)"/>.
+/// </para>
+/// <para>
 /// <b>Important Usage Note:</b> Awaiting on <see cref="ValueTask"/> has its own caveats, as it 
 /// is a struct that can only be awaited or converted with AsTask() ONE single time.
 /// Additional attempts to await after the first await or additional conversions to AsTask() will throw 
@@ -38,6 +41,16 @@ using System.Threading.Tasks.Sources;
 /// may execute synchronously on the signaling thread, reducing context switching overhead but
 /// potentially increasing Set() call duration and could lead to deadlocks because the waiting code
 /// may be executed directly by the signaling thread.
+/// </para>
+/// <para>
+/// <b>Allocation Behavior:</b> Immediate acquisitions are completely allocation-free using atomic 
+/// operations. When the lock is contended, waiting without a timeout is allocation-free on .NET 6.0+ 
+/// (using <c>UnsafeRegister</c> for cancellation), while older frameworks may allocate for cancellation 
+/// registration. Specifying a finite timeout allocates a timer that is automatically disposed when the 
+/// operation completes. Exception and task allocations occur only if a timeout actually elapses or 
+/// cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled 
+/// <see cref="IValueTaskSource{T}"/> instances are reused to minimize allocation pressure across 
+/// repeated lock operations.
 /// </para>
 /// <para>
 /// <b>Performance Warning - AsTask() Usage:</b> When <see cref="RunContinuationAsynchronously"/>

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -33,6 +33,10 @@ using System.Threading.Tasks.Sources;
 /// receive a <see cref="BarrierPostPhaseException"/>.
 /// </para>
 /// <para>
+/// <b>Optional timeout and cancellation token</b> parameters on
+/// <see cref="SignalAndWaitAsync(TimeSpan, CancellationToken)"/>.
+/// </para>
+/// <para>
 /// <b>Important Usage Note:</b> Awaiting on <see cref="ValueTask"/> has its own caveats, as it
 /// is a struct that can only be awaited or converted with AsTask() ONE single time.
 /// Additional attempts to await after the first await or additional conversions to AsTask() will throw
@@ -42,6 +46,16 @@ using System.Threading.Tasks.Sources;
 /// <b>Continuation Scheduling:</b> The <see cref="RunContinuationAsynchronously"/> property
 /// controls how continuations are executed when all participants arrive. When set to <see langword="true"/>
 /// (default), continuations are forced to queue to the thread pool.
+/// </para>
+/// <para>
+/// <b>Allocation Behavior:</b> Immediate acquisitions are completely allocation-free using atomic 
+/// operations. When the barrier is contended, waiting without a timeout is allocation-free on .NET 6.0+ 
+/// (using <c>UnsafeRegister</c> for cancellation), while older frameworks may allocate for cancellation 
+/// registration. Specifying a finite timeout allocates a timer that is automatically disposed when the 
+/// operation completes. Exception and task allocations occur only if a timeout actually elapses or 
+/// cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled 
+/// <see cref="IValueTaskSource{TResult}"/> instances are reused to minimize allocation pressure across 
+/// repeated lock operations.
 /// </para>
 /// <example>
 /// <code>

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -199,8 +199,8 @@ public sealed class AsyncBarrier
                     _postPhaseAction(this);
                 }
                 catch (Exception ex) when (ex is not OutOfMemoryException
-                                           && ex is not StackOverflowException
-                                           && ex is not AccessViolationException)
+                    && ex is not StackOverflowException
+                    && ex is not AccessViolationException)
                 {
                     postPhaseException = new BarrierPostPhaseException(ex);
                 }
@@ -272,6 +272,12 @@ public sealed class AsyncBarrier
 
             if (_participantsRemaining > 0)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _participantsRemaining++;
+                    return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
+                }
+
                 if (timeout == TimeSpan.Zero)
                 {
                     _participantsRemaining++;

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -241,6 +241,111 @@ public sealed class AsyncBarrier
     }
 
     /// <summary>
+    /// Signals the barrier and waits for all participants to arrive, or until the specified timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If this is the last participant, the barrier is released immediately without any timeout overhead.
+    /// A <see cref="CancellationTokenSource"/> is allocated only when this is not the last participant and
+    /// a finite positive timeout is requested; it is disposed automatically when the returned
+    /// <see cref="ValueTask"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait for all participants. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask"/> that completes when all participants have arrived.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before all participants arrive.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown when more participants signal than expected.</exception>
+    /// <exception cref="BarrierPostPhaseException">Thrown when the post-phase action throws an exception.</exception>
+    public ValueTask SignalAndWaitAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return SignalAndWaitAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        ManualResetValueTaskSource<bool>? toReleaseChain = null;
+        Exception? postPhaseException = null;
+
+        _spinLock.Enter();
+        try
+        {
+            if (_participantsRemaining <= 0)
+            {
+                throw new InvalidOperationException("The number of threads using the barrier exceeded the total number of registered participants.");
+            }
+
+            _participantsRemaining--;
+
+            if (_participantsRemaining > 0)
+            {
+                if (timeout == TimeSpan.Zero)
+                {
+                    _participantsRemaining++;
+                    return new ValueTask(Task.FromException(new OperationCanceledException()));
+                }
+
+                var timeoutCts = new CancellationTokenSource(timeout);
+                CancellationToken cancellationToken = timeoutCts.Token;
+
+                PooledManualResetValueTaskSource<bool> waiter;
+                waiter = _pool.GetPooledWaiter(this);
+                waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+                waiter.CancellationToken = cancellationToken;
+                waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+
+                _waiters.Enqueue(waiter);
+                return new ValueTask(waiter, waiter.Version);
+            }
+
+            // Last participant - execute post-phase action, then release all waiters and advance phase
+            if (_postPhaseAction is not null)
+            {
+                try
+                {
+                    _postPhaseAction(this);
+                }
+                catch (Exception ex)
+                {
+                    postPhaseException = new BarrierPostPhaseException(ex);
+                }
+            }
+
+            _participantsRemaining = _participantCount;
+            _currentPhase++;
+
+            toReleaseChain = _waiters.DetachAll(out _);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+
+        if (postPhaseException is not null)
+        {
+            WaiterQueue<bool>.SetChainException(toReleaseChain, postPhaseException);
+            return new ValueTask(Task.FromException(postPhaseException));
+        }
+
+        toReleaseChain?.SetChainResult(true);
+        return default;
+    }
+
+    /// <summary>
     /// Notifies the <see cref="AsyncBarrier"/> that there will be an additional participant.
     /// </summary>
     /// <returns>The phase number of the barrier when the participant is added.</returns>

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -198,7 +198,9 @@ public sealed class AsyncBarrier
                 {
                     _postPhaseAction(this);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OutOfMemoryException
+                                           && ex is not StackOverflowException
+                                           && ex is not AccessViolationException)
                 {
                     postPhaseException = new BarrierPostPhaseException(ex);
                 }

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -495,8 +495,8 @@ public sealed class AsyncBarrier
             waiter.CancellationTokenRegistration =
                 waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
 #else
-                waiter.CancellationTokenRegistration =
-                    waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
 #endif
         }
         else

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -8,6 +8,7 @@ namespace CryptoHives.Foundation.Threading.Async.Pooled;
 using CryptoHives.Foundation.Threading.Pools;
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
@@ -183,28 +184,11 @@ public sealed class AsyncBarrier
                     return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
                 }
 
-                PooledManualResetValueTaskSource<bool> waiter;
-                waiter = _pool.GetPooledWaiter(this);
+                PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this);
                 waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
                 waiter.CancellationToken = cancellationToken;
 
-                if (cancellationToken.CanBeCanceled)
-                {
-#if NET6_0_OR_GREATER
-                    waiter.CancellationTokenRegistration =
-                        cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                    waiter.CancellationTokenRegistration =
-                        cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-                }
-                else
-                {
-                    Debug.Assert(waiter.CancellationTokenRegistration == default);
-                }
-
-                _waiters.Enqueue(waiter);
-                return new ValueTask(waiter, waiter.Version);
+                return QueueWaiter(waiter);
             }
 
             // Last participant - execute post-phase action, then release all waiters and advance phase
@@ -252,6 +236,7 @@ public sealed class AsyncBarrier
     /// <param name="timeout">
     /// The maximum time to wait for all participants. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when all participants have arrived.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -261,11 +246,11 @@ public sealed class AsyncBarrier
     /// </exception>
     /// <exception cref="InvalidOperationException">Thrown when more participants signal than expected.</exception>
     /// <exception cref="BarrierPostPhaseException">Thrown when the post-phase action throws an exception.</exception>
-    public ValueTask SignalAndWaitAsync(TimeSpan timeout)
+    public ValueTask SignalAndWaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return SignalAndWaitAsync();
+            return SignalAndWaitAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -291,25 +276,14 @@ public sealed class AsyncBarrier
                     return new ValueTask(Task.FromException(new OperationCanceledException()));
                 }
 
-                var timeoutCts = new CancellationTokenSource(timeout);
-                CancellationToken cancellationToken = timeoutCts.Token;
-
-                PooledManualResetValueTaskSource<bool> waiter;
-                waiter = _pool.GetPooledWaiter(this);
+                PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this); ;
                 waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+
                 waiter.CancellationToken = cancellationToken;
-                waiter.TimeoutCts = timeoutCts;
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-
-                _waiters.Enqueue(waiter);
-                return new ValueTask(waiter, waiter.Version);
+                return QueueWaiter(waiter);
             }
 
             // Last participant - execute post-phase action, then release all waiters and advance phase
@@ -472,6 +446,20 @@ public sealed class AsyncBarrier
         toRelease?.SetChainResult(true);
     }
 
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void TimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<bool> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
 #if NET6_0_OR_GREATER
     private static readonly Action<object?, CancellationToken> _cancellationCallbackAction = static (state, ct) => {
         var waiter = (ManualResetValueTaskSource<bool>)state!;
@@ -490,15 +478,49 @@ public sealed class AsyncBarrier
         }
 #endif
 
-        ManualResetValueTaskSource<bool>? toCancel = null;
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
 
+    /// <summary>
+    /// Queue and register the waiter if it can be canceled.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
+        if (waiter.CancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                waiter.CancellationTokenRegistration =
+                    waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        _waiters.Enqueue(waiter);
+        return new ValueTask(waiter, waiter.Version);
+    }
+
+    /// <summary>
+    /// O(1) removal from intrusive linked list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<bool>? RemoveWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
         _spinLock.Enter();
         try
         {
             if (_waiters.Remove(waiter))
             {
-                toCancel = waiter;
                 _participantsRemaining++;
+                return waiter;
             }
         }
         finally
@@ -506,9 +528,6 @@ public sealed class AsyncBarrier
             _spinLock.Exit();
         }
 
-
-#pragma warning disable CA1508 // Avoid dead conditional code
-        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-#pragma warning restore CA1508 // Avoid dead conditional code
+        return null;
     }
 }

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -24,6 +24,9 @@ using System.Threading.Tasks.Sources;
 /// of <see cref="TaskCompletionSource{TResult}"/> and <see cref="Task"/>.
 /// </para>
 /// <para>
+/// <b>Optional timeout and cancellation token</b> parameters on <see cref="WaitAsync(TimeSpan, CancellationToken)"/>.
+/// </para>
+/// <para>
 /// <b>Important Usage Note:</b> Awaiting on <see cref="ValueTask"/> has its own caveats, as it
 /// is a struct that can only be awaited or converted with AsTask() ONE single time.
 /// Additional attempts to await after the first await or additional conversions to AsTask() will throw
@@ -33,6 +36,16 @@ using System.Threading.Tasks.Sources;
 /// <b>Continuation Scheduling:</b> The <see cref="RunContinuationAsynchronously"/> property
 /// controls how continuations are executed when the countdown reaches zero. When set to <see langword="true"/>
 /// (default), continuations are forced to queue to the thread pool.
+/// </para>
+/// <para>
+/// <b>Allocation Behavior:</b> Immediate acquisitions are completely allocation-free using atomic 
+/// operations. When the countdown is contended, waiting without a timeout is allocation-free on .NET 6.0+ 
+/// (using <c>UnsafeRegister</c> for cancellation), while older frameworks may allocate for cancellation 
+/// registration. Specifying a finite timeout allocates a timer that is automatically disposed when the 
+/// operation completes. Exception and task allocations occur only if a timeout actually elapses or 
+/// cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled 
+/// <see cref="IValueTaskSource{TResult}"/> instances are reused to minimize allocation pressure across 
+/// repeated lock operations.
 /// </para>
 /// <example>
 /// <code>

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -181,6 +181,86 @@ public sealed class AsyncCountdownEvent
     }
 
     /// <summary>
+    /// Asynchronously waits for the countdown to reach zero, or until the specified timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If the countdown has already reached zero, the method returns a completed <see cref="ValueTask"/> immediately
+    /// without allocating any cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated
+    /// only when the countdown is non-zero and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask"/> that completes when the countdown reaches zero.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before the countdown reaches zero.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public ValueTask WaitAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return WaitAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        if (Volatile.Read(ref _currentCount) == 0)
+        {
+            return default;
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return new ValueTask(Task.FromException(new OperationCanceledException()));
+        }
+
+        return WaitAsyncImplWithTimeout(timeout);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout)
+    {
+        var timeoutCts = new CancellationTokenSource(timeout);
+        CancellationToken cancellationToken = timeoutCts.Token;
+
+        _spinLock.Enter();
+        try
+        {
+            if (_currentCount == 0)
+            {
+                timeoutCts.Dispose();
+                return default;
+            }
+
+            PooledManualResetValueTaskSource<bool> waiter;
+            waiter = _pool.GetPooledWaiter(this);
+            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+
+            _waiters.Enqueue(waiter);
+            return new ValueTask(waiter, waiter.Version);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    /// <summary>
     /// Decrements the countdown by one.
     /// </summary>
     /// <remarks>

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -151,28 +151,11 @@ public sealed class AsyncCountdownEvent
                 return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
             }
 
-            PooledManualResetValueTaskSource<bool> waiter;
-            waiter = _pool.GetPooledWaiter(this);
+            PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this);
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
+            return QueueWaiter(waiter);
         }
         finally
         {
@@ -192,6 +175,7 @@ public sealed class AsyncCountdownEvent
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when the countdown reaches zero.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -200,11 +184,11 @@ public sealed class AsyncCountdownEvent
     /// Thrown when the timeout elapses before the countdown reaches zero.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask WaitAsync(TimeSpan timeout)
+    public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return WaitAsync();
+            return WaitAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -219,21 +203,17 @@ public sealed class AsyncCountdownEvent
             return new ValueTask(Task.FromException(new OperationCanceledException()));
         }
 
-        return WaitAsyncImplWithTimeout(timeout);
+        return WaitAsyncImplWithTimeout(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout)
+    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var timeoutCts = new CancellationTokenSource(timeout);
-        CancellationToken cancellationToken = timeoutCts.Token;
-
         _spinLock.Enter();
         try
         {
             if (_currentCount == 0)
             {
-                timeoutCts.Dispose();
                 return default;
             }
 
@@ -241,18 +221,10 @@ public sealed class AsyncCountdownEvent
             waiter = _pool.GetPooledWaiter(this);
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutCts = timeoutCts;
+            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-#if NET6_0_OR_GREATER
-            waiter.CancellationTokenRegistration =
-                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
+            return QueueWaiter(waiter);
         }
         finally
         {
@@ -425,6 +397,20 @@ public sealed class AsyncCountdownEvent
 
     }
 
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void TimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<bool> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
 #if NET6_0_OR_GREATER
     private static readonly Action<object?, CancellationToken> _cancellationCallbackAction = static (state, ct) => {
         var waiter = (ManualResetValueTaskSource<bool>)state!;
@@ -443,14 +429,48 @@ public sealed class AsyncCountdownEvent
         }
 #endif
 
-        ManualResetValueTaskSource<bool>? toCancel = null;
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
 
+    /// <summary>
+    /// Queue and register the waiter if it can be canceled.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
+        if (waiter.CancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        _waiters.Enqueue(waiter);
+        return new ValueTask(waiter, waiter.Version);
+    }
+
+    /// <summary>
+    /// O(1) removal from intrusive linked list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<bool>? RemoveWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
         _spinLock.Enter();
         try
         {
             if (_waiters.Remove(waiter))
             {
-                toCancel = waiter;
+                return waiter;
             }
         }
         finally
@@ -458,6 +478,6 @@ public sealed class AsyncCountdownEvent
             _spinLock.Exit();
         }
 
-        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+        return null;
     }
 }

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -132,35 +132,7 @@ public sealed class AsyncCountdownEvent
             return default;
         }
 
-        return WaitAsyncImpl(cancellationToken);
-    }
-
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImpl(CancellationToken cancellationToken)
-    {
-        _spinLock.Enter();
-        try
-        {
-            if (_currentCount == 0)
-            {
-                return default;
-            }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
-            }
-
-            PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this);
-            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-            waiter.CancellationToken = cancellationToken;
-
-            return QueueWaiter(waiter);
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
+        return WaitAsyncImpl(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
     /// <summary>
@@ -186,12 +158,7 @@ public sealed class AsyncCountdownEvent
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
-        if (timeout == Timeout.InfiniteTimeSpan)
-        {
-            return WaitAsync(cancellationToken);
-        }
-
-        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan) throw new ArgumentOutOfRangeException(nameof(timeout));
 
         if (Volatile.Read(ref _currentCount) == 0)
         {
@@ -203,11 +170,11 @@ public sealed class AsyncCountdownEvent
             return new ValueTask(Task.FromException(new OperationCanceledException()));
         }
 
-        return WaitAsyncImplWithTimeout(timeout, cancellationToken);
+        return WaitAsyncImpl(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
+    private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
         _spinLock.Enter();
         try
@@ -217,14 +184,40 @@ public sealed class AsyncCountdownEvent
                 return default;
             }
 
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
+            }
+
             PooledManualResetValueTaskSource<bool> waiter;
             waiter = _pool.GetPooledWaiter(this);
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
-                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-            return QueueWaiter(waiter);
+            if (timeout != Timeout.InfiniteTimeSpan)
+            {
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+#if NET6_0_OR_GREATER
+                // Use UnsafeRegister on .NET 6+ for allocation free registration
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+            }
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
+
+            _waiters.Enqueue(waiter);
+            return new ValueTask(waiter, waiter.Version);
         }
         finally
         {
@@ -431,32 +424,6 @@ public sealed class AsyncCountdownEvent
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-    }
-
-    /// <summary>
-    /// Queue and register the waiter if it can be canceled.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
-    {
-        if (waiter.CancellationToken.CanBeCanceled)
-        {
-#if NET6_0_OR_GREATER
-            // Use UnsafeRegister on .NET 6+ for allocation free registration
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-        }
-        else
-        {
-            Debug.Assert(waiter.CancellationTokenRegistration == default);
-        }
-
-        _waiters.Enqueue(waiter);
-        return new ValueTask(waiter, waiter.Version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -243,6 +243,92 @@ public sealed class AsyncLock : IResettable
     }
 
     /// <summary>
+    /// Asynchronously acquires the lock, or throws if the lock cannot be acquired before the timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If the lock is immediately available, the method completes synchronously without allocating any
+    /// cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated only when the
+    /// lock cannot be acquired immediately and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask{Releaser}"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ValueTask{Releaser}"/> that completes when the lock is acquired.
+    /// Dispose the returned releaser to release the lock.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public ValueTask<Releaser> LockAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return LockAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        if (Interlocked.Exchange(ref _taken, 1) == 0)
+        {
+            return new ValueTask<Releaser>(new Releaser(this));
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+        }
+
+        return LockAsyncImplWithTimeout(timeout);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask<Releaser> LockAsyncImplWithTimeout(TimeSpan timeout)
+    {
+        var timeoutCts = new CancellationTokenSource(timeout);
+        CancellationToken cancellationToken = timeoutCts.Token;
+
+        _spinLock.Enter();
+        try
+        {
+            if (Interlocked.Exchange(ref _taken, 1) == 0)
+            {
+                timeoutCts.Dispose();
+                return new ValueTask<Releaser>(new Releaser(this));
+            }
+
+            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            {
+                waiter = _pool.GetPooledWaiter(this);
+                waiter.RunContinuationsAsynchronously = true;
+            }
+
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+
+            _waiters.Enqueue(waiter);
+            return new ValueTask<Releaser>(waiter, waiter.Version);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    /// <summary>
     /// Whether the lock is currently held.
     /// </summary>
     public bool IsTaken => _taken != 0;

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -12,12 +12,28 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
 
 /// <summary>
 /// An allocation-free async-compatible exclusive lock implemented with pooled ValueTask sources.
 /// Note that this lock is <b>not</b> recursive!
 /// </summary>
 /// <remarks>
+/// /// <para>
+/// <b>Optional timeout and cancellation token</b> parameters on <see cref="LockAsync(TimeSpan, CancellationToken)"/>.
+/// </para>
+/// 
+/// <para>
+/// <b>Allocation Behavior:</b> Immediate acquisitions are completely allocation-free using atomic 
+/// operations. When the lock is contended, waiting without a timeout is allocation-free on .NET 6.0+ 
+/// (using <c>UnsafeRegister</c> for cancellation), while older frameworks may allocate for cancellation 
+/// registration. Specifying a finite timeout allocates a timer that is automatically disposed when the 
+/// operation completes. Exception and task allocations occur only if a timeout actually elapses or 
+/// cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled 
+/// <see cref="IValueTaskSource{Releaser}"/> instances are reused to minimize allocation pressure across 
+/// repeated lock operations.
+/// </para>
+/// 
 /// <example>
 /// <para>The vast majority of use cases are to just replace a <c>lock</c> statement. 
 /// That is, with the original code looking like this:</para>

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -217,24 +217,7 @@ public sealed class AsyncLock : IResettable
 
             waiter.CancellationToken = cancellationToken;
 
-            // Use UnsafeRegister on .NET 6+ for performance
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration = cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration = cancellationToken.Register(
-                    CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
+            return QueueWaiter(waiter);
         }
         finally
         {
@@ -254,6 +237,7 @@ public sealed class AsyncLock : IResettable
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>
     /// A <see cref="ValueTask{Releaser}"/> that completes when the lock is acquired.
     /// Dispose the returned releaser to release the lock.
@@ -265,11 +249,11 @@ public sealed class AsyncLock : IResettable
     /// Thrown when the timeout elapses before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask<Releaser> LockAsync(TimeSpan timeout)
+    public ValueTask<Releaser> LockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return LockAsync();
+            return LockAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -284,21 +268,17 @@ public sealed class AsyncLock : IResettable
             return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
         }
 
-        return LockAsyncImplWithTimeout(timeout);
+        return LockAsyncImplWithTimeout(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> LockAsyncImplWithTimeout(TimeSpan timeout)
+    private ValueTask<Releaser> LockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var timeoutCts = new CancellationTokenSource(timeout);
-        CancellationToken cancellationToken = timeoutCts.Token;
-
         _spinLock.Enter();
         try
         {
             if (Interlocked.Exchange(ref _taken, 1) == 0)
             {
-                timeoutCts.Dispose();
                 return new ValueTask<Releaser>(new Releaser(this));
             }
 
@@ -309,18 +289,10 @@ public sealed class AsyncLock : IResettable
             }
 
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutCts = timeoutCts;
+            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-#if NET6_0_OR_GREATER
-            waiter.CancellationTokenRegistration =
-                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
+            return QueueWaiter(waiter);
         }
         finally
         {
@@ -364,6 +336,20 @@ public sealed class AsyncLock : IResettable
         toRelease.SetResult(new Releaser(this));
     }
 
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void TimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<Releaser> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
 #if NET6_0_OR_GREATER
     private static readonly Action<object?, CancellationToken> _cancellationCallbackAction = static (state, ct) => {
         var waiter = (ManualResetValueTaskSource<Releaser>)state!;
@@ -382,14 +368,48 @@ public sealed class AsyncLock : IResettable
         }
 #endif
 
-        // O(1) removal from intrusive linked list.
-        ManualResetValueTaskSource<Releaser>? toCancel = null;
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
+
+    /// <summary>
+    /// Queue and register the waiter if it can be canceled.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ValueTask<Releaser> QueueWaiter(ManualResetValueTaskSource<Releaser> waiter)
+    {
+        if (waiter.CancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        _waiters.Enqueue(waiter);
+        return new ValueTask<Releaser>(waiter, waiter.Version);
+    }
+
+    /// <summary>
+    /// O(1) removal from intrusive linked list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<Releaser>? RemoveWaiter(ManualResetValueTaskSource<Releaser> waiter)
+    {
         _spinLock.Enter();
         try
         {
             if (_waiters.Remove(waiter))
             {
-                toCancel = waiter;
+                return waiter;
             }
         }
         finally
@@ -397,9 +417,6 @@ public sealed class AsyncLock : IResettable
             _spinLock.Exit();
         }
 
-
-#pragma warning disable CA1508 // Avoid dead conditional code
-        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-#pragma warning restore CA1508 // Avoid dead conditional code
+        return null;
     }
 }

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -190,39 +190,7 @@ public sealed class AsyncLock : IResettable
             return new ValueTask<Releaser>(new Releaser(this));
         }
 
-        return LockAsyncImpl(cancellationToken);
-    }
-
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> LockAsyncImpl(CancellationToken cancellationToken)
-    {
-        _spinLock.Enter();
-        try
-        {
-            if (Interlocked.Exchange(ref _taken, 1) == 0)
-            {
-                return new ValueTask<Releaser>(new Releaser(this));
-            }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
-            }
-
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
-            {
-                waiter = _pool.GetPooledWaiter(this);
-                waiter.RunContinuationsAsynchronously = true;
-            }
-
-            waiter.CancellationToken = cancellationToken;
-
-            return QueueWaiter(waiter);
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
+        return LockAsyncImpl(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
     /// <summary>
@@ -251,12 +219,7 @@ public sealed class AsyncLock : IResettable
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask<Releaser> LockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
-        if (timeout == Timeout.InfiniteTimeSpan)
-        {
-            return LockAsync(cancellationToken);
-        }
-
-        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan) throw new ArgumentOutOfRangeException(nameof(timeout));
 
         if (Interlocked.Exchange(ref _taken, 1) == 0)
         {
@@ -268,11 +231,11 @@ public sealed class AsyncLock : IResettable
             return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
         }
 
-        return LockAsyncImplWithTimeout(timeout, cancellationToken);
+        return LockAsyncImpl(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> LockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
+    private ValueTask<Releaser> LockAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
         _spinLock.Enter();
         try
@@ -282,6 +245,11 @@ public sealed class AsyncLock : IResettable
                 return new ValueTask<Releaser>(new Releaser(this));
             }
 
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
+            }
+
             if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
@@ -289,10 +257,31 @@ public sealed class AsyncLock : IResettable
             }
 
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
-                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-            return QueueWaiter(waiter);
+            if (timeout != Timeout.InfiniteTimeSpan)
+            {
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+#if NET6_0_OR_GREATER
+                // Use UnsafeRegister on .NET 6+ for allocation free registration
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+            }
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
+
+            _waiters.Enqueue(waiter);
+            return new ValueTask<Releaser>(waiter, waiter.Version);
         }
         finally
         {
@@ -370,32 +359,6 @@ public sealed class AsyncLock : IResettable
 
         ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-    }
-
-    /// <summary>
-    /// Queue and register the waiter if it can be canceled.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ValueTask<Releaser> QueueWaiter(ManualResetValueTaskSource<Releaser> waiter)
-    {
-        if (waiter.CancellationToken.CanBeCanceled)
-        {
-#if NET6_0_OR_GREATER
-            // Use UnsafeRegister on .NET 6+ for allocation free registration
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-        }
-        else
-        {
-            Debug.Assert(waiter.CancellationTokenRegistration == default);
-        }
-
-        _waiters.Enqueue(waiter);
-        return new ValueTask<Releaser>(waiter, waiter.Version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -25,6 +25,9 @@ using System.Threading.Tasks.Sources;
 /// are signalled than with a native <see cref="TaskCompletionSource{Boolean}"/> implementation.
 /// </para>
 /// <para>
+/// <b>Optional timeout and cancellation token</b> parameters on <see cref="WaitAsync(TimeSpan, CancellationToken)"/>.
+/// </para>
+/// <para>
 /// <b>Important Usage Note:</b> Awaiting on <see cref="ValueTask"/> has its own caveats, as it 
 /// is a struct that can only be awaited or converted with AsTask() ONE single time.
 /// Additional attempts to await after the first await or additional conversions to AsTask() will throw 
@@ -38,6 +41,16 @@ using System.Threading.Tasks.Sources;
 /// may execute synchronously on the signaling thread, reducing context switching overhead but
 /// potentially increasing Set() call duration and could lead to deadlocks because the waiting code
 /// may be executed directly by the signaling thread.
+/// </para>
+/// <para>
+/// <b>Allocation Behavior:</b> Immediate acquisitions are completely allocation-free using atomic 
+/// operations. When the lock is contended, waiting without a timeout is allocation-free on .NET 6.0+ 
+/// (using <c>UnsafeRegister</c> for cancellation), while older frameworks may allocate for cancellation 
+/// registration. Specifying a finite timeout allocates a timer that is automatically disposed when the 
+/// operation completes. Exception and task allocations occur only if a timeout actually elapses or 
+/// cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled 
+/// <see cref="IValueTaskSource{T}"/> instances are reused to minimize allocation pressure across 
+/// repeated lock operations.
 /// </para>
 /// <para>
 /// <b>Performance Warning - AsTask() Usage:</b> When <see cref="RunContinuationAsynchronously"/>

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -214,24 +214,7 @@ public sealed class AsyncManualResetEvent : IResettable
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
+            return QueueWaiter(waiter);
         }
         finally
         {
@@ -251,6 +234,7 @@ public sealed class AsyncManualResetEvent : IResettable
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when the event is set.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -259,11 +243,11 @@ public sealed class AsyncManualResetEvent : IResettable
     /// Thrown when the timeout elapses before the event is set.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask WaitAsync(TimeSpan timeout)
+    public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return WaitAsync();
+            return WaitAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -278,21 +262,17 @@ public sealed class AsyncManualResetEvent : IResettable
             return new ValueTask(Task.FromException(new OperationCanceledException()));
         }
 
-        return WaitAsyncImplWithTimeout(timeout);
+        return WaitAsyncImplWithTimeout(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout)
+    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var timeoutCts = new CancellationTokenSource(timeout);
-        CancellationToken cancellationToken = timeoutCts.Token;
-
         _spinLock.Enter();
         try
         {
             if (_signaled)
             {
-                timeoutCts.Dispose();
                 return default;
             }
 
@@ -302,18 +282,11 @@ public sealed class AsyncManualResetEvent : IResettable
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutCts = timeoutCts;
+            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-#if NET6_0_OR_GREATER
-            waiter.CancellationTokenRegistration =
-                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
 
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
+            return QueueWaiter(waiter);
         }
         finally
         {
@@ -374,6 +347,20 @@ public sealed class AsyncManualResetEvent : IResettable
     /// </summary>
     internal bool InternalWaiterInUse => _localWaiter.InUse;
 
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void TimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<bool> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
 #if NET6_0_OR_GREATER
     private static readonly Action<object?, CancellationToken> _cancellationCallbackAction = static (state, ct) => {
         var waiter = (ManualResetValueTaskSource<bool>)state!;
@@ -392,14 +379,48 @@ public sealed class AsyncManualResetEvent : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<bool>? toCancel = null;
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
 
+    /// <summary>
+    /// Queue and register the waiter if it can be canceled.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
+        if (waiter.CancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        _waiters.Enqueue(waiter);
+        return new ValueTask(waiter, waiter.Version);
+    }
+
+    /// <summary>
+    /// O(1) removal from intrusive linked list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<bool>? RemoveWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
         _spinLock.Enter();
         try
         {
             if (_waiters.Remove(waiter))
             {
-                toCancel = waiter;
+                return waiter;
             }
         }
         finally
@@ -407,8 +428,6 @@ public sealed class AsyncManualResetEvent : IResettable
             _spinLock.Exit();
         }
 
-#pragma warning disable CA1508 // Avoid dead conditional code
-        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-#pragma warning restore CA1508 // Avoid dead conditional code
+        return null;
     }
 }

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -194,32 +194,12 @@ public sealed class AsyncManualResetEvent : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     public ValueTask WaitAsync(CancellationToken cancellationToken = default)
     {
-        _spinLock.Enter();
-        try
+        if (_signaled)
         {
-            if (_signaled)
-            {
-                return default;
-            }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
-            }
-
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
-            {
-                waiter = _pool.GetPooledWaiter(this);
-            }
-            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-            waiter.CancellationToken = cancellationToken;
-
-            return QueueWaiter(waiter);
+            return default;
         }
-        finally
-        {
-            _spinLock.Exit();
-        }
+
+        return WaitAsyncImpl(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
     /// <summary>
@@ -245,12 +225,7 @@ public sealed class AsyncManualResetEvent : IResettable
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
-        if (timeout == Timeout.InfiniteTimeSpan)
-        {
-            return WaitAsync(cancellationToken);
-        }
-
-        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan) throw new ArgumentOutOfRangeException(nameof(timeout));
 
         if (_signaled)
         {
@@ -262,11 +237,11 @@ public sealed class AsyncManualResetEvent : IResettable
             return new ValueTask(Task.FromException(new OperationCanceledException()));
         }
 
-        return WaitAsyncImplWithTimeout(timeout, cancellationToken);
+        return WaitAsyncImpl(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
+    private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
         _spinLock.Enter();
         try
@@ -276,17 +251,42 @@ public sealed class AsyncManualResetEvent : IResettable
                 return default;
             }
 
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
+            }
+
             if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
-                TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
+            if (timeout != Timeout.InfiniteTimeSpan)
+            {
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+            }
 
-            return QueueWaiter(waiter);
+            if (cancellationToken.CanBeCanceled)
+            {
+#if NET6_0_OR_GREATER
+                // Use UnsafeRegister on .NET 6+ for allocation free registration
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+            }
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
+
+            _waiters.Enqueue(waiter);
+            return new ValueTask(waiter, waiter.Version);
         }
         finally
         {
@@ -381,32 +381,6 @@ public sealed class AsyncManualResetEvent : IResettable
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-    }
-
-    /// <summary>
-    /// Queue and register the waiter if it can be canceled.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
-    {
-        if (waiter.CancellationToken.CanBeCanceled)
-        {
-#if NET6_0_OR_GREATER
-            // Use UnsafeRegister on .NET 6+ for allocation free registration
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-        }
-        else
-        {
-            Debug.Assert(waiter.CancellationTokenRegistration == default);
-        }
-
-        _waiters.Enqueue(waiter);
-        return new ValueTask(waiter, waiter.Version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -240,6 +240,88 @@ public sealed class AsyncManualResetEvent : IResettable
     }
 
     /// <summary>
+    /// Asynchronously waits for the event to be set, or until the specified timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If the event is already signalled, the method returns a completed <see cref="ValueTask"/> immediately
+    /// without allocating any cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated
+    /// only when the event is not already signalled and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask"/> that completes when the event is set.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before the event is set.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public ValueTask WaitAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return WaitAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        if (_signaled)
+        {
+            return default;
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return new ValueTask(Task.FromException(new OperationCanceledException()));
+        }
+
+        return WaitAsyncImplWithTimeout(timeout);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout)
+    {
+        var timeoutCts = new CancellationTokenSource(timeout);
+        CancellationToken cancellationToken = timeoutCts.Token;
+
+        _spinLock.Enter();
+        try
+        {
+            if (_signaled)
+            {
+                timeoutCts.Dispose();
+                return default;
+            }
+
+            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
+            {
+                waiter = _pool.GetPooledWaiter(this);
+            }
+            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+
+            _waiters.Enqueue(waiter);
+            return new ValueTask(waiter, waiter.Version);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    /// <summary>
     /// Signals the event, releasing all waiting threads if any are queued.
     /// </summary>
     /// <remarks>

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -582,6 +582,98 @@ public sealed class AsyncReaderWriterLock : IResettable
     }
 
     /// <summary>
+    /// Asynchronously acquires a reader lock, or throws if it cannot be acquired before the timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If the lock is immediately available, the method completes synchronously without allocating
+    /// any cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated only when
+    /// the lock cannot be acquired immediately and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask{Releaser}"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the reader lock is acquired.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public ValueTask<Releaser> ReaderLockAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return ReaderLockAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        if (Interlocked.CompareExchange(ref _status, (int)LockState.Reader, (int)LockState.Uncontested) == (int)LockState.Uncontested)
+        {
+            return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Reader));
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+        }
+
+        return ReaderLockAsyncImplWithTimeout(timeout);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask<Releaser> ReaderLockAsyncImplWithTimeout(TimeSpan timeout)
+    {
+        var timeoutCts = new CancellationTokenSource(timeout);
+        CancellationToken cancellationToken = timeoutCts.Token;
+
+        _spinLock.Enter();
+        try
+        {
+            if (_waitingWriters.Count == 0 && _waitingUpgradedWriters.Count == 0)
+            {
+                int status = Interlocked.CompareExchange(ref _status, (int)LockState.Reader, (int)LockState.Uncontested);
+                if (status is >= ((int)LockState.Uncontested) and < MaxReaderCount or
+                    >= ((int)LockState.UpgradeableReader) and < ((int)LockState.UpgradeableReader + MaxReaderCount))
+                {
+                    if (status > (int)LockState.Uncontested)
+                    {
+                        Interlocked.Increment(ref _status);
+                    }
+
+                    timeoutCts.Dispose();
+                    return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Reader));
+                }
+            }
+
+            if (!_localReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            {
+                waiter = _pool.GetPooledWaiter(this);
+            }
+            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_readerCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(ReaderCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+
+            _waitingReaders.Enqueue(waiter);
+            return new ValueTask<Releaser>(waiter, waiter.Version);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    /// <summary>
     /// Asynchronously acquires an upgradeable reader lock.
     /// </summary>
     /// <remarks>
@@ -661,6 +753,97 @@ public sealed class AsyncReaderWriterLock : IResettable
     }
 
     /// <summary>
+    /// Asynchronously acquires an upgradeable reader lock, or throws if it cannot be acquired before the timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If the lock is immediately available, the method completes synchronously without allocating
+    /// any cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated only when
+    /// the lock cannot be acquired immediately and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask{Releaser}"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the upgradeable reader lock is acquired.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public ValueTask<Releaser> UpgradeableReaderLockAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return UpgradeableReaderLockAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        if (Interlocked.CompareExchange(ref _status, (int)LockState.UpgradeableReader, (int)LockState.Uncontested) == (int)LockState.Uncontested)
+        {
+            return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.UpgradeableReader));
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+        }
+
+        return UpgradeableReaderLockAsyncImplWithTimeout(timeout);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask<Releaser> UpgradeableReaderLockAsyncImplWithTimeout(TimeSpan timeout)
+    {
+        var timeoutCts = new CancellationTokenSource(timeout);
+        CancellationToken cancellationToken = timeoutCts.Token;
+
+        _spinLock.Enter();
+        try
+        {
+            if (_waitingWriters.Count == 0 && _waitingUpgradedWriters.Count == 0)
+            {
+                int status = Interlocked.CompareExchange(ref _status, (int)LockState.UpgradeableReader, (int)LockState.Uncontested);
+                if (status is >= ((int)LockState.Uncontested) and < MaxReaderCount)
+                {
+                    if (status > (int)LockState.Uncontested)
+                    {
+                        Interlocked.Add(ref _status, (int)LockState.UpgradeableReader);
+                    }
+
+                    timeoutCts.Dispose();
+                    return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.UpgradeableReader));
+                }
+            }
+
+            if (!_localUpgradeableReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            {
+                waiter = _pool.GetPooledWaiter(this);
+            }
+            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_upgradeableReaderCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(UpgradeableReaderCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+
+            _waitingUpgradeableReaders.Enqueue(waiter);
+            return new ValueTask<Releaser>(waiter, waiter.Version);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    /// <summary>
     /// Asynchronously acquires a writer lock.
     /// </summary>
     /// <remarks>
@@ -719,6 +902,88 @@ public sealed class AsyncReaderWriterLock : IResettable
             {
                 Debug.Assert(waiter.CancellationTokenRegistration == default);
             }
+
+            _waitingWriters.Enqueue(waiter);
+            return new ValueTask<Releaser>(waiter, waiter.Version);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously acquires a writer lock, or throws if it cannot be acquired before the timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If the lock is immediately available, the method completes synchronously without allocating
+    /// any cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated only when
+    /// the lock cannot be acquired immediately and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask{Releaser}"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the writer lock is acquired.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return WriterLockAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        if (Interlocked.CompareExchange(ref _status, (int)LockState.Writer, (int)LockState.Uncontested) == (int)LockState.Uncontested)
+        {
+            return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Writer));
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+        }
+
+        return WriterLockAsyncImplWithTimeout(timeout);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask<Releaser> WriterLockAsyncImplWithTimeout(TimeSpan timeout)
+    {
+        var timeoutCts = new CancellationTokenSource(timeout);
+        CancellationToken cancellationToken = timeoutCts.Token;
+
+        _spinLock.Enter();
+        try
+        {
+            if (Interlocked.CompareExchange(ref _status, (int)LockState.Writer, (int)LockState.Uncontested) == (int)LockState.Uncontested)
+            {
+                timeoutCts.Dispose();
+                return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Writer));
+            }
+
+            if (!_localWriterWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            {
+                waiter = _pool.GetPooledWaiter(this);
+            }
+            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_writerCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(WriterCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
 
             _waitingWriters.Enqueue(waiter);
             return new ValueTask<Releaser>(waiter, waiter.Version);

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #pragma warning disable CA1034 // Nested types should not be visible
-#pragma warning disable CA1508 // Avoid dead conditional code
 
 namespace CryptoHives.Foundation.Threading.Async.Pooled;
 
@@ -175,10 +174,10 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// pool efficiency and increased the memory usage, so a single struct
     /// with an enum to distinguish the different usage scenarios had been
     /// chosen as a good balance between usability and performance.
-    /// Since any releaser can call the <see cref="UpgradeToWriterLockAsync"/>
+    /// Since any releaser can call the <see cref="UpgradeToWriterLockAsync(CancellationToken)"/>
     /// method, an <see cref="InvalidOperationException"/> is thrown if the
-    /// method is
-    /// called on a releaser that is not for the upgradeable reader state.
+    /// method is called on a releaser that is not for the upgradeable
+    /// reader state.
     /// </remarks>
     public readonly struct Releaser
         : IDisposable, IAsyncDisposable, IEquatable<Releaser>
@@ -275,7 +274,37 @@ public sealed class AsyncReaderWriterLock : IResettable
                 throw new InvalidOperationException("Releaser is not in the upgradeable reader state.");
             }
 
-            return _owner.UpgradeToWriterLockAsync(cancellationToken);
+            return _owner.UpgradeToWriterLockImpl(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+
+        /// <summary>
+        /// Upgrades an upgradable reader to a writer lock.
+        /// </summary>
+        /// <remarks>
+        /// This method must only be called when the Releaser instance is in the upgradeable reader
+        /// state. Failing to release the write lock by disposing the returned releaser may result in
+        /// deadlocks.
+        /// </remarks>
+        /// <param name="timeout">
+        /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the attempt to upgrade to the write lock.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the current instance is not in the upgradeable reader state.</exception>
+        public ValueTask<Releaser> UpgradeToWriterLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            if (_owner is null)
+            {
+                throw new InvalidOperationException("Releaser does not have an associated lock.");
+            }
+
+            if (_releaserType != ReleaserType.UpgradeableReader)
+            {
+                throw new InvalidOperationException("Releaser is not in the upgradeable reader state.");
+            }
+
+            if (timeout != Timeout.InfiniteTimeSpan && timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+            return _owner.UpgradeToWriterLockImpl(timeout, cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -593,6 +622,7 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the reader lock is acquired.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -601,11 +631,11 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// Thrown when the timeout elapses before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask<Releaser> ReaderLockAsync(TimeSpan timeout)
+    public ValueTask<Releaser> ReaderLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return ReaderLockAsync();
+            return ReaderLockAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -617,18 +647,15 @@ public sealed class AsyncReaderWriterLock : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
         }
 
-        return ReaderLockAsyncImplWithTimeout(timeout);
+        return ReaderLockAsyncImplWithTimeout(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> ReaderLockAsyncImplWithTimeout(TimeSpan timeout)
+    private ValueTask<Releaser> ReaderLockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var timeoutCts = new CancellationTokenSource(timeout);
-        CancellationToken cancellationToken = timeoutCts.Token;
-
         _spinLock.Enter();
         try
         {
@@ -643,7 +670,6 @@ public sealed class AsyncReaderWriterLock : IResettable
                         Interlocked.Increment(ref _status);
                     }
 
-                    timeoutCts.Dispose();
                     return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Reader));
                 }
             }
@@ -654,15 +680,23 @@ public sealed class AsyncReaderWriterLock : IResettable
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutCts = timeoutCts;
+            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                ReaderTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
+            if (cancellationToken.CanBeCanceled)
+            {
 #if NET6_0_OR_GREATER
-            waiter.CancellationTokenRegistration =
-                cancellationToken.UnsafeRegister(_readerCancellationCallbackAction, waiter);
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_readerCancellationCallbackAction, waiter);
 #else
-            waiter.CancellationTokenRegistration =
-                cancellationToken.Register(ReaderCancellationCallback, waiter, useSynchronizationContext: false);
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(ReaderCancellationCallback, waiter, useSynchronizationContext: false);
 #endif
+            }
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
 
             _waitingReaders.Enqueue(waiter);
             return new ValueTask<Releaser>(waiter, waiter.Version);
@@ -764,6 +798,7 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the upgradeable reader lock is acquired.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -772,11 +807,11 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// Thrown when the timeout elapses before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask<Releaser> UpgradeableReaderLockAsync(TimeSpan timeout)
+    public ValueTask<Releaser> UpgradeableReaderLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return UpgradeableReaderLockAsync();
+            return UpgradeableReaderLockAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -788,18 +823,15 @@ public sealed class AsyncReaderWriterLock : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
         }
 
-        return UpgradeableReaderLockAsyncImplWithTimeout(timeout);
+        return UpgradeableReaderLockAsyncImplWithTimeout(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> UpgradeableReaderLockAsyncImplWithTimeout(TimeSpan timeout)
+    private ValueTask<Releaser> UpgradeableReaderLockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var timeoutCts = new CancellationTokenSource(timeout);
-        CancellationToken cancellationToken = timeoutCts.Token;
-
         _spinLock.Enter();
         try
         {
@@ -813,7 +845,6 @@ public sealed class AsyncReaderWriterLock : IResettable
                         Interlocked.Add(ref _status, (int)LockState.UpgradeableReader);
                     }
 
-                    timeoutCts.Dispose();
                     return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.UpgradeableReader));
                 }
             }
@@ -824,15 +855,23 @@ public sealed class AsyncReaderWriterLock : IResettable
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutCts = timeoutCts;
+            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                UpgradeableReaderTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
+            if (cancellationToken.CanBeCanceled)
+            {
 #if NET6_0_OR_GREATER
-            waiter.CancellationTokenRegistration =
-                cancellationToken.UnsafeRegister(_upgradeableReaderCancellationCallbackAction, waiter);
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_upgradeableReaderCancellationCallbackAction, waiter);
 #else
-            waiter.CancellationTokenRegistration =
-                cancellationToken.Register(UpgradeableReaderCancellationCallback, waiter, useSynchronizationContext: false);
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(UpgradeableReaderCancellationCallback, waiter, useSynchronizationContext: false);
 #endif
+            }
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
 
             _waitingUpgradeableReaders.Enqueue(waiter);
             return new ValueTask<Releaser>(waiter, waiter.Version);
@@ -924,6 +963,7 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the writer lock is acquired.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -932,11 +972,11 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// Thrown when the timeout elapses before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout)
+    public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return WriterLockAsync();
+            return WriterLockAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -948,24 +988,20 @@ public sealed class AsyncReaderWriterLock : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
         }
 
-        return WriterLockAsyncImplWithTimeout(timeout);
+        return WriterLockAsyncImplWithTimeout(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> WriterLockAsyncImplWithTimeout(TimeSpan timeout)
+    private ValueTask<Releaser> WriterLockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var timeoutCts = new CancellationTokenSource(timeout);
-        CancellationToken cancellationToken = timeoutCts.Token;
-
         _spinLock.Enter();
         try
         {
             if (Interlocked.CompareExchange(ref _status, (int)LockState.Writer, (int)LockState.Uncontested) == (int)LockState.Uncontested)
             {
-                timeoutCts.Dispose();
                 return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Writer));
             }
 
@@ -975,7 +1011,8 @@ public sealed class AsyncReaderWriterLock : IResettable
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutCts = timeoutCts;
+            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                WriterTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
 #if NET6_0_OR_GREATER
             waiter.CancellationTokenRegistration =
@@ -1000,9 +1037,12 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <remarks>
     /// Only a reader holding an upgradeable reader lock can call this method to upgrade to a writer lock.
     /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
     /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the writer lock is acquired.</returns>
-    private ValueTask<Releaser> UpgradeToWriterLockAsync(CancellationToken cancellationToken = default)
+    private ValueTask<Releaser> UpgradeToWriterLockImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
         // no fast path because the upgrade always transitions from a contested state
 
@@ -1020,12 +1060,23 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
+            if (timeout == TimeSpan.Zero)
+            {
+                return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
+            }
+
             if (!_localUpgradedWriterWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
+
+            if (timeout != Timeout.InfiniteTimeSpan)
+            {
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    UpgradedWriterTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+            }
 
             if (cancellationToken.CanBeCanceled)
             {
@@ -1189,7 +1240,6 @@ public sealed class AsyncReaderWriterLock : IResettable
         ManualResetValueTaskSource<Releaser>? readerChain = null;
         ManualResetValueTaskSource<Releaser>? toWake = null;
         Releaser releaser = default;
-        int readerCount = 0;
 
         _spinLock.Enter();
         try
@@ -1214,7 +1264,7 @@ public sealed class AsyncReaderWriterLock : IResettable
 
                 if (_waitingReaders.Count > 0)
                 {
-                    readerChain = _waitingReaders.DetachUpTo(MaxReaderCount, out readerCount);
+                    readerChain = _waitingReaders.DetachUpTo(MaxReaderCount, out int readerCount);
                     newStatus += readerCount;
                 }
 
@@ -1298,6 +1348,20 @@ public sealed class AsyncReaderWriterLock : IResettable
         readerChain?.SetChainResult(new Releaser(this, Releaser.ReleaserType.Reader));
     }
 
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void ReaderTimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<Releaser> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingReaders, waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
 #if NET6_0_OR_GREATER
     private static readonly Action<object?, CancellationToken> _readerCancellationCallbackAction = static (state, ct) => {
         var waiter = (ManualResetValueTaskSource<Releaser>)state!;
@@ -1316,22 +1380,22 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = null;
-
-        _spinLock.Enter();
-        try
-        {
-            if (_waitingReaders.Remove(waiter))
-            {
-                toCancel = waiter;
-            }
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
-
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingReaders, waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
+
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void UpgradeableReaderTimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<Releaser> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradeableReaders, waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
     }
 
 #if NET6_0_OR_GREATER
@@ -1352,22 +1416,22 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = null;
-
-        _spinLock.Enter();
-        try
-        {
-            if (_waitingUpgradeableReaders.Remove(waiter))
-            {
-                toCancel = waiter;
-            }
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
-
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradeableReaders, waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
+
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void WriterTimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<Releaser> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingWriters, waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
     }
 
 #if NET6_0_OR_GREATER
@@ -1388,22 +1452,22 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = null;
-
-        _spinLock.Enter();
-        try
-        {
-            if (_waitingWriters.Remove(waiter))
-            {
-                toCancel = waiter;
-            }
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
-
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingWriters, waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
+
+    /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void UpgradedWriterTimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<Releaser> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradedWriters, waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
     }
 
 #if NET6_0_OR_GREATER
@@ -1424,14 +1488,22 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = null;
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradedWriters, waiter);
+        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
 
+    /// <summary>
+    /// O(1) removal from intrusive linked list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<Releaser>? RemoveWaiter(WaiterQueue<Releaser> waiterQueue, ManualResetValueTaskSource<Releaser> waiter)
+    {
         _spinLock.Enter();
         try
         {
-            if (_waitingUpgradedWriters.Remove(waiter))
+            if (waiterQueue.Remove(waiter))
             {
-                toCancel = waiter;
+                return waiter;
             }
         }
         finally
@@ -1439,6 +1511,6 @@ public sealed class AsyncReaderWriterLock : IResettable
             _spinLock.Exit();
         }
 
-        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+        return null;
     }
 }

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -674,6 +674,11 @@ public sealed class AsyncReaderWriterLock : IResettable
                 }
             }
 
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
+            }
+
             if (!_localReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
@@ -849,6 +854,11 @@ public sealed class AsyncReaderWriterLock : IResettable
                 }
             }
 
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
+            }
+
             if (!_localUpgradeableReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
@@ -1003,6 +1013,11 @@ public sealed class AsyncReaderWriterLock : IResettable
             if (Interlocked.CompareExchange(ref _status, (int)LockState.Writer, (int)LockState.Uncontested) == (int)LockState.Uncontested)
             {
                 return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Writer));
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
             if (!_localWriterWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -1117,7 +1117,7 @@ public sealed class AsyncReaderWriterLock : IResettable
         _spinLock.Enter();
         try
         {
-            Debug.Assert(_status >= (int)LockState.Reader, "Reader lock should be held.");
+            if (_status < (int)LockState.Reader) throw new ObjectDisposedException(nameof(AsyncReaderWriterLock), "Reader lock should be held.");
 
             // A reader or writer could steal the status here if we first transition to uncontested state.
             // Check first if there is a waiting writer or upgraded writer and directly transition to

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -16,7 +16,8 @@ using System.Threading.Tasks.Sources;
 
 /// <summary>
 /// An async reader-writer lock which uses a pooled approach to implement waiters
-/// for <see cref="ValueTask"/> to reduce memory allocations.
+/// for <see cref="ValueTask"/> to reduce memory allocations. Supports optional timeout
+/// and cancellation token parameters on all lock acquisition methods.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -59,6 +60,36 @@ using System.Threading.Tasks.Sources;
 /// controls how continuations are executed when the lock is released. When set to <see langword="true"/>
 /// (default), continuations are forced to queue to the thread pool.
 /// </para>
+/// <para>
+/// <b>Allocation Behavior:</b> Lock acquisition is optimized for minimal allocations:
+/// <list type="bullet">
+/// <item>
+///   <description>
+///   <b>Immediate acquisition (fast path):</b> Completely allocation-free using atomic operations.
+///   </description>
+/// </item>
+/// <item>
+///   <description>
+///   <b>Waiting with cancellation token:</b> Allocation-free on .NET 6.0+ when using cancellation tokens 
+///   (via <c>UnsafeRegister</c>). On older frameworks, a cancellation registration allocation may occur.
+///   </description>
+/// </item>
+/// <item>
+///   <description>
+///   <b>Waiting with timeout:</b> A timer is allocated when the lock cannot be acquired immediately 
+///   and a finite timeout is specified. The timer is automatically disposed when the operation completes.
+///   </description>
+/// </item>
+/// <item>
+///   <description>
+///   <b>On timeout or cancellation:</b> An exception and task wrapper are allocated only if the 
+///   wait is actually cancelled or times out. Successful acquisitions incur no additional allocations.
+///   </description>
+/// </item>
+/// </list>
+/// Pooled <see cref="IValueTaskSource{TResult}"/> instances are reused to minimize allocation pressure 
+/// for repeated lock operations.
+/// </para>
 /// <example>
 /// <code>
 /// private readonly AsyncReaderWriterLock _rwLock = new AsyncReaderWriterLock();
@@ -72,9 +103,9 @@ using System.Threading.Tasks.Sources;
 ///     }
 /// }
 ///
-/// public async Task WriteAsync(CancellationToken ct)
+/// public async Task WriteAsync(TimeSpan timeout, CancellationToken ct)
 /// {
-///     using (await _rwLock.WriterLockAsync(ct))
+///     using (await _rwLock.WriterLockAsync(timeout, ct))
 ///     {
 ///         // Exclusive access - no other readers or writers
 ///         await WriteDataAsync();

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -1045,7 +1045,6 @@ public sealed class AsyncReaderWriterLock : IResettable
     private ValueTask<Releaser> UpgradeToWriterLockImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
         // no fast path because the upgrade always transitions from a contested state
-
         _spinLock.Enter();
         try
         {
@@ -1358,7 +1357,7 @@ public sealed class AsyncReaderWriterLock : IResettable
             return;
         }
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingReaders, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveReadersWaiter(waiter);
         toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
     }
 
@@ -1380,7 +1379,7 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingReaders, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveReadersWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
     }
 
@@ -1394,8 +1393,27 @@ public sealed class AsyncReaderWriterLock : IResettable
             return;
         }
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradeableReaders, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveUpgradeableReadersWaiter(waiter);
         toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<Releaser>? RemoveReadersWaiter(ManualResetValueTaskSource<Releaser> waiter)
+    {
+        _spinLock.Enter();
+        try
+        {
+            if (_waitingReaders.Remove(waiter))
+            {
+                return waiter;
+            }
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+
+        return null;
     }
 
 #if NET6_0_OR_GREATER
@@ -1416,13 +1434,29 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradeableReaders, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveUpgradeableReadersWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
     }
 
-    /// <summary>
-    /// Callback used with <see cref="Timer"/> to trigger timeout.
-    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<Releaser>? RemoveUpgradeableReadersWaiter(ManualResetValueTaskSource<Releaser> waiter)
+    {
+        _spinLock.Enter();
+        try
+        {
+            if (_waitingUpgradeableReaders.Remove(waiter))
+            {
+                return waiter;
+            }
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+
+        return null;
+    }
+
     private void WriterTimerCallback(object? state)
     {
         if (state is not ManualResetValueTaskSource<Releaser> waiter)
@@ -1430,7 +1464,7 @@ public sealed class AsyncReaderWriterLock : IResettable
             return;
         }
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingWriters, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWritersWaiter(waiter);
         toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
     }
 
@@ -1452,13 +1486,29 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingWriters, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWritersWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
     }
 
-    /// <summary>
-    /// Callback used with <see cref="Timer"/> to trigger timeout.
-    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<Releaser>? RemoveWritersWaiter(ManualResetValueTaskSource<Releaser> waiter)
+    {
+        _spinLock.Enter();
+        try
+        {
+            if (_waitingWriters.Remove(waiter))
+            {
+                return waiter;
+            }
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+
+        return null;
+    }
+
     private void UpgradedWriterTimerCallback(object? state)
     {
         if (state is not ManualResetValueTaskSource<Releaser> waiter)
@@ -1466,7 +1516,7 @@ public sealed class AsyncReaderWriterLock : IResettable
             return;
         }
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradedWriters, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveUpgradedWritersWaiter(waiter);
         toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
     }
 
@@ -1488,20 +1538,17 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 #endif
 
-        ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(_waitingUpgradedWriters, waiter);
+        ManualResetValueTaskSource<Releaser>? toCancel = RemoveUpgradedWritersWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
     }
 
-    /// <summary>
-    /// O(1) removal from intrusive linked list.
-    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ManualResetValueTaskSource<Releaser>? RemoveWaiter(WaiterQueue<Releaser> waiterQueue, ManualResetValueTaskSource<Releaser> waiter)
+    private ManualResetValueTaskSource<Releaser>? RemoveUpgradedWritersWaiter(ManualResetValueTaskSource<Releaser> waiter)
     {
         _spinLock.Enter();
         try
         {
-            if (waiterQueue.Remove(waiter))
+            if (_waitingUpgradedWriters.Remove(waiter))
             {
                 return waiter;
             }

--- a/src/Threading/Async/Pooled/AsyncSemaphore.cs
+++ b/src/Threading/Async/Pooled/AsyncSemaphore.cs
@@ -182,6 +182,108 @@ public sealed class AsyncSemaphore
     }
 
     /// <summary>
+    /// Asynchronously waits to acquire a permit from the semaphore, or until the specified timeout elapses.
+    /// </summary>
+    /// <remarks>
+    /// If a permit is available, the method returns a completed <see cref="ValueTask"/> immediately
+    /// without allocating any cancellation infrastructure. A <see cref="CancellationTokenSource"/> is allocated
+    /// only when no permit is available and a finite positive timeout is requested; it is disposed
+    /// automatically when the returned <see cref="ValueTask"/> is awaited.
+    /// </remarks>
+    /// <param name="timeout">
+    /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
+    /// </param>
+    /// <returns>A <see cref="ValueTask"/> that completes when a permit is acquired.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the timeout elapses before a permit becomes available.
+    /// </exception>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    public ValueTask WaitAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            return WaitAsync();
+        }
+
+        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        // fast path without lock
+        while (true)
+        {
+            int observed = Volatile.Read(ref _currentCount);
+            if (observed <= 0)
+            {
+                break;
+            }
+
+            if (Interlocked.CompareExchange(ref _currentCount, observed - 1, observed) == observed)
+            {
+                return default;
+            }
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return new ValueTask(Task.FromException(new OperationCanceledException()));
+        }
+
+        return WaitAsyncImplWithTimeout(timeout);
+    }
+
+    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
+    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout)
+    {
+        var timeoutCts = new CancellationTokenSource(timeout);
+        CancellationToken cancellationToken = timeoutCts.Token;
+
+        _spinLock.Enter();
+        try
+        {
+            // due to race conditions, count may have changed until the lock is taken
+            while (true)
+            {
+                int observed = Volatile.Read(ref _currentCount);
+                if (observed <= 0)
+                {
+                    break;
+                }
+
+                if (Interlocked.CompareExchange(ref _currentCount, observed - 1, observed) == observed)
+                {
+                    timeoutCts.Dispose();
+                    return default;
+                }
+            }
+
+            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
+            {
+                waiter = _pool.GetPooledWaiter(this);
+            }
+            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.CancellationToken = cancellationToken;
+            waiter.TimeoutCts = timeoutCts;
+
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+
+            _waiters.Enqueue(waiter);
+            return new ValueTask(waiter, waiter.Version);
+        }
+        finally
+        {
+            _spinLock.Exit();
+        }
+    }
+
+    /// <summary>
     /// Releases a permit back to the semaphore.
     /// </summary>
     /// <remarks>

--- a/src/Threading/Async/Pooled/AsyncSemaphore.cs
+++ b/src/Threading/Async/Pooled/AsyncSemaphore.cs
@@ -219,6 +219,11 @@ public sealed class AsyncSemaphore
                 }
             }
 
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask(Task.FromCanceled(cancellationToken));
+            }
+
             if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);

--- a/src/Threading/Async/Pooled/AsyncSemaphore.cs
+++ b/src/Threading/Async/Pooled/AsyncSemaphore.cs
@@ -136,50 +136,9 @@ public sealed class AsyncSemaphore
             // retry until race condition succeeds
         }
 
-        return WaitAsyncImpl(cancellationToken);
+        return WaitAsyncImpl(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImpl(CancellationToken cancellationToken)
-    {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
-        }
-
-        _spinLock.Enter();
-        try
-        {
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
-            {
-                waiter = _pool.GetPooledWaiter(this);
-            }
-            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-            waiter.CancellationToken = cancellationToken;
-
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
-    }
 
     /// <summary>
     /// Asynchronously waits to acquire a permit from the semaphore, or until the specified timeout elapses.
@@ -193,6 +152,7 @@ public sealed class AsyncSemaphore
     /// <param name="timeout">
     /// The maximum time to wait. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely.
     /// </param>
+    /// <param name="cancellationToken">The cancellation token used to cancel the wait.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when a permit is acquired.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
@@ -201,11 +161,11 @@ public sealed class AsyncSemaphore
     /// Thrown when the timeout elapses before a permit becomes available.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
-    public ValueTask WaitAsync(TimeSpan timeout)
+    public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         if (timeout == Timeout.InfiniteTimeSpan)
         {
-            return WaitAsync();
+            return WaitAsync(cancellationToken);
         }
 
         if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -227,17 +187,19 @@ public sealed class AsyncSemaphore
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask(Task.FromException(new OperationCanceledException()));
+            return new ValueTask(Task.FromException(ManualResetValueTaskSource<bool>.OperationCanceled));
         }
 
-        return WaitAsyncImplWithTimeout(timeout);
+        return WaitAsyncImpl(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask WaitAsyncImplWithTimeout(TimeSpan timeout)
+    private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var timeoutCts = new CancellationTokenSource(timeout);
-        CancellationToken cancellationToken = timeoutCts.Token;
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
+        }
 
         _spinLock.Enter();
         try
@@ -253,7 +215,6 @@ public sealed class AsyncSemaphore
 
                 if (Interlocked.CompareExchange(ref _currentCount, observed - 1, observed) == observed)
                 {
-                    timeoutCts.Dispose();
                     return default;
                 }
             }
@@ -263,16 +224,29 @@ public sealed class AsyncSemaphore
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-            waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutCts = timeoutCts;
 
+            if (timeout != Timeout.InfiniteTimeSpan)
+            {
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+            }
+
+            waiter.CancellationToken = cancellationToken;
+            if (cancellationToken.CanBeCanceled)
+            {
 #if NET6_0_OR_GREATER
-            waiter.CancellationTokenRegistration =
-                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+                // Use UnsafeRegister on .NET 6+ for allocation free registration
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
 #else
-            waiter.CancellationTokenRegistration =
-                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
 #endif
+            }
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
 
             _waiters.Enqueue(waiter);
             return new ValueTask(waiter, waiter.Version);
@@ -331,6 +305,20 @@ public sealed class AsyncSemaphore
     }
 
     /// <summary>
+    /// Callback used with <see cref="Timer"/> to trigger timeout.
+    /// </summary>
+    private void TimerCallback(object? state)
+    {
+        if (state is not ManualResetValueTaskSource<bool> waiter)
+        {
+            return;
+        }
+
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+    }
+
+    /// <summary>
     /// Gets a value indicating whether the local waiter is currently in use.
     /// </summary>
     internal bool InternalWaiterInUse => _localWaiter.InUse;
@@ -353,15 +341,22 @@ public sealed class AsyncSemaphore
         }
 #endif
 
-        // O(1) removal from intrusive linked list.
-        ManualResetValueTaskSource<bool>? toCancel = null;
+        ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
+        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
+    }
 
+    /// <summary>
+    /// O(1) removal from intrusive linked list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ManualResetValueTaskSource<bool>? RemoveWaiter(ManualResetValueTaskSource<bool> waiter)
+    {
         _spinLock.Enter();
         try
         {
             if (_waiters.Remove(waiter))
             {
-                toCancel = waiter;
+                return waiter;
             }
         }
         finally
@@ -369,8 +364,6 @@ public sealed class AsyncSemaphore
             _spinLock.Exit();
         }
 
-#pragma warning disable CA1508 // Avoid dead conditional code
-        toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-#pragma warning restore CA1508 // Avoid dead conditional code
+        return null;
     }
 }

--- a/src/Threading/Async/Pooled/AsyncSemaphore.cs
+++ b/src/Threading/Async/Pooled/AsyncSemaphore.cs
@@ -22,6 +22,9 @@ using System.Threading.Tasks.Sources;
 /// of <see cref="TaskCompletionSource{TResult}"/> and <see cref="Task"/>.
 /// </para>
 /// <para>
+/// <b>Optional timeout and cancellation token</b> parameters on <see cref="WaitAsync(TimeSpan, CancellationToken)"/>.
+/// </para>
+/// <para>
 /// <b>Important Usage Note:</b> Awaiting on <see cref="ValueTask"/> has its own caveats, as it
 /// is a struct that can only be awaited or converted with AsTask() ONE single time.
 /// Additional attempts to await after the first await or additional conversions to AsTask() will throw
@@ -32,6 +35,16 @@ using System.Threading.Tasks.Sources;
 /// controls how continuations are executed when a permit is released. When set to <see langword="true"/>
 /// (default), continuations are forced to queue to the thread pool, preventing the releasing thread from
 /// being blocked by continuation execution.
+/// </para>
+/// <para>
+/// <b>Allocation Behavior:</b> Immediate acquisitions are completely allocation-free using atomic 
+/// operations. When the semaphore is contended, waiting without a timeout is allocation-free on .NET 6.0+ 
+/// (using <c>UnsafeRegister</c> for cancellation), while older frameworks may allocate for cancellation 
+/// registration. Specifying a finite timeout allocates a timer that is automatically disposed when the 
+/// operation completes. Exception and task allocations occur only if a timeout actually elapses or 
+/// cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled 
+/// <see cref="IValueTaskSource{TResult}"/> instances are reused to minimize allocation pressure across 
+/// repeated lock operations.
 /// </para>
 /// <example>
 /// <code>

--- a/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
@@ -100,7 +100,6 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
         _core.Reset();
         _cancellationTokenRegistration = default;
         ITimer? timer = Interlocked.Exchange(ref _timeoutTimer, null);
-        // TODO: Change(Infinite,Infinite) first to stop it, then Dispose
         timer?.Dispose();
         Next = null;
         Prev = null;

--- a/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
@@ -23,6 +23,7 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
     private ManualResetValueTaskSourceCore<T> _core;
     private CancellationToken _cancellationToken;
     private CancellationTokenRegistration _cancellationTokenRegistration;
+    private CancellationTokenSource? _timeoutCts;
     private int _inUse;
 
     /// <summary>
@@ -68,6 +69,13 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
     }
 
     /// <inheritdoc/>
+    public override CancellationTokenSource? TimeoutCts
+    {
+        get => _timeoutCts;
+        set => _timeoutCts = value;
+    }
+
+    /// <inheritdoc/>
     public override bool RunContinuationsAsynchronously
     {
         get => _core.RunContinuationsAsynchronously;
@@ -91,6 +99,7 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
     {
         _core.Reset();
         _cancellationTokenRegistration = default;
+        _timeoutCts = null;
         Next = null;
         Prev = null;
         return Interlocked.Exchange(ref _inUse, 0) == 1;
@@ -106,6 +115,7 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
         finally
         {
             _cancellationTokenRegistration.Dispose();
+            _timeoutCts?.Dispose();
             TryReset();
         }
     }

--- a/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
@@ -101,7 +101,7 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
         _cancellationTokenRegistration = default;
         ITimer? timer = Interlocked.Exchange(ref _timeoutTimer, null);
         // TODO: Change(Infinite,Infinite) first to stop it, then Dispose
-        timer?.Dispose();   
+        timer?.Dispose();
         Next = null;
         Prev = null;
         return Interlocked.Exchange(ref _inUse, 0) == 1;

--- a/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
@@ -99,7 +99,8 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
     {
         _core.Reset();
         _cancellationTokenRegistration = default;
-        _timeoutCts = null;
+        CancellationTokenSource? timeoutCts = Interlocked.Exchange(ref _timeoutCts, null);
+        timeoutCts?.Dispose();
         Next = null;
         Prev = null;
         return Interlocked.Exchange(ref _inUse, 0) == 1;
@@ -115,7 +116,6 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
         finally
         {
             _cancellationTokenRegistration.Dispose();
-            _timeoutCts?.Dispose();
             TryReset();
         }
     }

--- a/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/LocalManualResetValueTaskSource{T}.cs
@@ -23,7 +23,7 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
     private ManualResetValueTaskSourceCore<T> _core;
     private CancellationToken _cancellationToken;
     private CancellationTokenRegistration _cancellationTokenRegistration;
-    private CancellationTokenSource? _timeoutCts;
+    private ITimer? _timeoutTimer;
     private int _inUse;
 
     /// <summary>
@@ -69,10 +69,10 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
     }
 
     /// <inheritdoc/>
-    public override CancellationTokenSource? TimeoutCts
+    public override ITimer? TimeoutTimer
     {
-        get => _timeoutCts;
-        set => _timeoutCts = value;
+        get => _timeoutTimer;
+        set => _timeoutTimer = value;
     }
 
     /// <inheritdoc/>
@@ -99,8 +99,9 @@ public sealed class LocalManualResetValueTaskSource<T> : ManualResetValueTaskSou
     {
         _core.Reset();
         _cancellationTokenRegistration = default;
-        CancellationTokenSource? timeoutCts = Interlocked.Exchange(ref _timeoutCts, null);
-        timeoutCts?.Dispose();
+        ITimer? timer = Interlocked.Exchange(ref _timeoutTimer, null);
+        // TODO: Change(Infinite,Infinite) first to stop it, then Dispose
+        timer?.Dispose();   
         Next = null;
         Prev = null;
         return Interlocked.Exchange(ref _inUse, 0) == 1;

--- a/src/Threading/Pools/ManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/ManualResetValueTaskSource{T}.cs
@@ -23,6 +23,11 @@ using System.Threading.Tasks.Sources;
 public abstract class ManualResetValueTaskSource<T> : IValueTaskSource<T>, IValueTaskSource, IResettable
 {
     /// <summary>
+    /// Shared operation cancelled exception.
+    /// </summary>
+    internal static OperationCanceledException OperationCanceled = new("The operation timed out.");
+
+    /// <summary>
     /// Link to the next node in the intrusive <see cref="WaiterQueue{T}"/>.
     /// </summary>
     internal ManualResetValueTaskSource<T>? Next { get; set; }
@@ -68,13 +73,13 @@ public abstract class ManualResetValueTaskSource<T> : IValueTaskSource<T>, IValu
     public abstract CancellationTokenRegistration CancellationTokenRegistration { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="CancellationTokenSource"/> used to enforce a timeout on the wait operation.
+    /// Gets or sets the <see cref="TimeoutTimer"/> used to enforce a timeout on the wait operation.
     /// </summary>
     /// <remarks>
     /// Set to a non-<see langword="null"/> value when the waiter is created with a timeout.
     /// The source is disposed automatically by <see cref="GetResult"/> and cleared by <see cref="TryReset"/>.
     /// </remarks>
-    public abstract CancellationTokenSource? TimeoutCts { get; set; }
+    public abstract ITimer? TimeoutTimer { get; set; }
 
     /// <summary>
     /// Signals the completion of an operation, setting the result to T.

--- a/src/Threading/Pools/ManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/ManualResetValueTaskSource{T}.cs
@@ -68,6 +68,15 @@ public abstract class ManualResetValueTaskSource<T> : IValueTaskSource<T>, IValu
     public abstract CancellationTokenRegistration CancellationTokenRegistration { get; set; }
 
     /// <summary>
+    /// Gets or sets the <see cref="CancellationTokenSource"/> used to enforce a timeout on the wait operation.
+    /// </summary>
+    /// <remarks>
+    /// Set to a non-<see langword="null"/> value when the waiter is created with a timeout.
+    /// The source is disposed automatically by <see cref="GetResult"/> and cleared by <see cref="TryReset"/>.
+    /// </remarks>
+    public abstract CancellationTokenSource? TimeoutCts { get; set; }
+
+    /// <summary>
     /// Signals the completion of an operation, setting the result to T.
     /// </summary>
     /// <remarks>

--- a/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
@@ -25,7 +25,7 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
     private ManualResetValueTaskSourceCore<T> _core;
     private CancellationTokenRegistration _cancellationTokenRegistration;
     private CancellationToken _cancellationToken;
-    private CancellationTokenSource? _timeoutCts;
+    private ITimer? _timeoutTimer;
     private ObjectPool<PooledManualResetValueTaskSource<T>>? _ownerPool;
     private object? _owner;
 
@@ -60,10 +60,10 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
     }
 
     /// <inheritdoc/>
-    public override CancellationTokenSource? TimeoutCts
+    public override ITimer? TimeoutTimer
     {
-        get => _timeoutCts;
-        set => _timeoutCts = value;
+        get => _timeoutTimer;
+        set => _timeoutTimer = value;
     }
 
     /// <inheritdoc/>
@@ -94,8 +94,8 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
         _ownerPool = null;
         _core.Reset();
         _cancellationTokenRegistration = default;
-        CancellationTokenSource? timeoutCts = Interlocked.Exchange(ref _timeoutCts, null);
-        timeoutCts?.Dispose();
+        ITimer? timer = Interlocked.Exchange(ref _timeoutTimer, null);
+        timer?.Dispose();   // Change(Infinite,Infinite) first to stop it, then Dispose
         Next = null;
         Prev = null;
         return true;

--- a/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
@@ -25,6 +25,7 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
     private ManualResetValueTaskSourceCore<T> _core;
     private CancellationTokenRegistration _cancellationTokenRegistration;
     private CancellationToken _cancellationToken;
+    private CancellationTokenSource? _timeoutCts;
     private ObjectPool<PooledManualResetValueTaskSource<T>>? _ownerPool;
     private object? _owner;
 
@@ -59,6 +60,13 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
     }
 
     /// <inheritdoc/>
+    public override CancellationTokenSource? TimeoutCts
+    {
+        get => _timeoutCts;
+        set => _timeoutCts = value;
+    }
+
+    /// <inheritdoc/>
     public override bool RunContinuationsAsynchronously
     {
         get => _core.RunContinuationsAsynchronously;
@@ -84,6 +92,7 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
     public override bool TryReset()
     {
         _ownerPool = null;
+        _timeoutCts = null;
         _core.Reset();
         _cancellationTokenRegistration = default;
         Next = null;
@@ -101,6 +110,7 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
         finally
         {
             _cancellationTokenRegistration.Dispose();
+            _timeoutCts?.Dispose();
             _ownerPool?.Return(this);
         }
     }

--- a/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
@@ -95,7 +95,7 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
         _core.Reset();
         _cancellationTokenRegistration = default;
         ITimer? timer = Interlocked.Exchange(ref _timeoutTimer, null);
-        timer?.Dispose();   // Change(Infinite,Infinite) first to stop it, then Dispose
+        timer?.Dispose();
         Next = null;
         Prev = null;
         return true;

--- a/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/PooledManualResetValueTaskSource{T}.cs
@@ -92,9 +92,10 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
     public override bool TryReset()
     {
         _ownerPool = null;
-        _timeoutCts = null;
         _core.Reset();
         _cancellationTokenRegistration = default;
+        CancellationTokenSource? timeoutCts = Interlocked.Exchange(ref _timeoutCts, null);
+        timeoutCts?.Dispose();
         Next = null;
         Prev = null;
         return true;
@@ -110,7 +111,6 @@ public sealed class PooledManualResetValueTaskSource<T> : ManualResetValueTaskSo
         finally
         {
             _cancellationTokenRegistration.Dispose();
-            _timeoutCts?.Dispose();
             _ownerPool?.Return(this);
         }
     }

--- a/src/Threading/README.md
+++ b/src/Threading/README.md
@@ -12,9 +12,54 @@ developed and maintained by **The Keepers of the CryptoHives**.
 
 High-performance, pooled async synchronization primitives for .NET — designed to eliminate `Task` and `TaskCompletionSource<T>` allocations on the hot path.
 
+## Classes
+
+### Synchronization Primitives
+
+Namespace: `CryptoHives.Foundation.Threading.Async.Pooled`
+
+| Class | Description | 
+|-------|-------------|
+| [AsyncLock](https://cryptohives.github.io/Foundation/packages/threading/asynclock.html) | Pooled async mutual exclusion lock
+| [AsyncAutoResetEvent](https://cryptohives.github.io/Foundation/packages/threading/asyncautoresetevent.html) | Pooled async auto-reset event (one waiter per signal)
+| [AsyncManualResetEvent](https://cryptohives.github.io/Foundation/packages/threading/asyncmanualresetevent.html) | Pooled async manual-reset event (all waiters per signal)
+| [AsyncSemaphore](https://cryptohives.github.io/Foundation/packages/threading/asyncsemaphore.html) | Pooled async semaphore with configurable permit count
+| [AsyncCountdownEvent](https://cryptohives.github.io/Foundation/packages/threading/asynccountdownevent.html) | Pooled async countdown event (signals when count reaches zero)
+| [AsyncBarrier](https://cryptohives.github.io/Foundation/packages/threading/asyncbarrier.html) | Pooled async barrier (synchronizes multiple participants)
+| [AsyncReaderWriterLock](https://cryptohives.github.io/Foundation/packages/threading/asyncreaderwriterlock.html) | Pooled async reader-writer lock (multiple readers or single writer)
+
 All primitives are backed by `ObjectPool<T>` and return `ValueTask<T>` to minimize per-operation allocations in high-throughput scenarios.
 
+### Pooling Support Classes
+
+Namespace: `CryptoHives.Foundation.Threading.Pools`
+
+| Class | Description | Namespace |
+|-------|-------------|-----------|
+| `IGetPooledManualResetValueTaskSource<T>` | Interface to get pooled `IValueTaskSource<T>` implementations (providers return `PooledManualResetValueTaskSource<T>` instances)
+| `ManualResetValueTaskSource<T>` | Abstract base for pooled `IValueTaskSource<T>` implementations 
+| `PooledManualResetValueTaskSource<T>` | Pooled `IValueTaskSource<T>` implementation with automatic pool return 
+| `LocalManualResetValueTaskSource<T>` | Object-local `IValueTaskSource<T>` without pool integration 
+| `PooledValueTaskSourceObjectPolicy<T>` | Object pool policy for `PooledManualResetValueTaskSource<T>` 
+| `ValueTaskSourceObjectPool<T>` | Specialized provider that implements `IGetPooledManualResetValueTaskSource<T>` and returns pooled task sources
+| `ValueTaskSourceObjectPools` | Static helper with shared pool instances and constants
+
 > **Included:** This package automatically bundles [CryptoHives.Foundation.Threading.Analyzers](https://www.nuget.org/packages/CryptoHives.Foundation.Threading.Analyzers) — Roslyn analyzers that detect common `ValueTask` misuse patterns at compile time, applied transitively to all consumers.
+
+---
+
+## ✨ Key Features
+
+- **Pooled primitives** — synchronization objects backed by `Microsoft.Extensions.ObjectPool`
+- **`ValueTask`-based APIs** — minimal/no memory allocations with object pools
+- **`CancellationToken` support** — full cancellation across all primitives, allocation-free on modern .NET
+- **`ConfigureAwait` support** — works naturally with `.ConfigureAwait(false)` in library code
+- **Timeout support**: all lock acquisition methods support timeout parameters
+- **Configurable continuations** — control synchronous vs. asynchronous continuation scheduling
+- **Custom pools** — supply your own `IGetPooledManualResetValueTaskSource<T>` for fine-grained control
+- **Drop-in replacement** — change namespace, keep the same `using`-based patterns
+- **Custom ObjectPools**: Supply your own object pools for fine-grained control
+- **Included analyzers** — ValueTask misuse caught at compile time
 
 ---
 
@@ -23,19 +68,6 @@ All primitives are backed by `ObjectPool<T>` and return `ValueTask<T>` to minimi
 ```bash
 dotnet add package CryptoHives.Foundation.Threading
 ```
-
----
-
-## ✨ Key Features
-
-- **Pooled primitives** — synchronization objects backed by `Microsoft.Extensions.ObjectPool`
-- **`ValueTask`-based APIs** — avoid `Task` allocations when operations complete synchronously
-- **`CancellationToken` support** — full cancellation across all primitives, allocation-free on modern .NET
-- **`ConfigureAwait` support** — works naturally with `.ConfigureAwait(false)` in library code
-- **Configurable continuations** — control synchronous vs. asynchronous continuation scheduling
-- **Custom pools** — supply your own `IGetPooledManualResetValueTaskSource<T>` for fine-grained control
-- **Drop-in replacement** — change namespace, keep the same `using`-based patterns
-- **Included analyzers** — ValueTask misuse caught at compile time
 
 ---
 

--- a/src/Threading/Threading.csproj
+++ b/src/Threading/Threading.csproj
@@ -34,12 +34,14 @@
       <ItemGroup>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
         <PackageReference Include="Microsoft.Bcl.HashCode" />
+        <PackageReference Include="Microsoft.Bcl.TimeProvider" />
         <PackageReference Include="System.Memory" />
         <PackageReference Include="System.Threading.Tasks.Extensions" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'netstandard2.1'">
       <ItemGroup>
+        <PackageReference Include="Microsoft.Bcl.TimeProvider" />
         <PackageReference Include="System.Memory" />
       </ItemGroup>
     </When>
@@ -47,6 +49,7 @@
       <ItemGroup>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
         <PackageReference Include="Microsoft.Bcl.HashCode" />
+        <PackageReference Include="Microsoft.Bcl.TimeProvider" />
         <PackageReference Include="System.Memory" />
         <PackageReference Include="System.Threading.Tasks.Extensions" />
       </ItemGroup>

--- a/tests/Threading.Analyzers/ValueTaskMisuseAnalyzerTests.cs
+++ b/tests/Threading.Analyzers/ValueTaskMisuseAnalyzerTests.cs
@@ -524,7 +524,7 @@ public class TestClass
         await lambda();
     }
 }";
-        var expected = Diagnostic(DiagnosticDescriptors.MultipleAwait)
+        var expected = Diagnostic(DiagnosticDescriptors.CapturedInClosure)
             .WithLocation(0)
             .WithArguments("vt");
 
@@ -547,7 +547,7 @@ public class TestClass
         await lambda();
     }
 }";
-        var expected = Diagnostic(DiagnosticDescriptors.MultipleAwait)
+        var expected = Diagnostic(DiagnosticDescriptors.CapturedInClosure)
             .WithLocation(0)
             .WithArguments("vt");
 
@@ -569,6 +569,28 @@ public class TestClass
         ValueTask vt = default;
         ValueTask preserved = vt.Preserve();
         Func<Task> lambda = async () => await preserved;
+        await lambda();
+        await lambda();
+    }
+}";
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task CapturedAsTaskValueTaskInLambdaNoDiagnostic()
+    {
+        // If the converted ValueTask to Task is captured, it's safe to await in the lambda
+        var code = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public async Task TestMethod()
+    {
+        ValueTask vt = default;
+        Task task = vt.AsTask();
+        Func<Task> lambda = async () => await task;
         await lambda();
         await lambda();
     }

--- a/tests/Threading.Analyzers/ValueTaskMisuseAnalyzerTests.cs
+++ b/tests/Threading.Analyzers/ValueTaskMisuseAnalyzerTests.cs
@@ -609,6 +609,60 @@ public class TestClass
     }
 
     [Test]
+    public async Task ValueTaskMultipleAwaitPropertyAccessIsIgnored()
+    {
+        // This test verifies that access to the ValueTask properties is not detected as multiple await
+
+        // Pattern: Access on original ValueTask properties
+        string code = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public async Task OriginalPooledSourceThrowsOnMultipleAwaitWithoutPreserve()
+    {
+        ValueTask<int> vt = new ValueTask<int>(42);
+
+        bool IsCompleted = vt.IsCompleted;
+
+        // should not be flagged
+        int result = await vt;
+       
+    }
+}";
+
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task ValueTaskMultipleAwaitedVariablesIsIgnored()
+    {
+        // This test verifies that access to the ValueTask properties is not detected as multiple await
+        // Pattern: Await on multiple ValueTasks
+        string code = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public async Task OriginalPooledSourceThrowsOnMultipleAwaitWithoutPreserve()
+    {
+        ValueTask<int> vt1 = new ValueTask<int>(42);
+        ValueTask<int> vt2 = new ValueTask<int>(42);
+        ValueTask<int> vt3 = new ValueTask<int>(42);
+
+        // should not be flagged
+        int result1 = await vt1;
+        int result2 = await vt2;
+        int result3 = await vt3;
+    }
+}";
+
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+
+    [Test]
     public async Task ValueTaskPreserveTestsMultipleAwaitOnPreservedIsAllowed()
     {
         // This test verifies that Preserve() properly allows multiple awaits

--- a/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
@@ -160,7 +160,9 @@ public class AsyncAutoResetEventTests
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter2.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         ev.Set();
         await waiter1.ConfigureAwait(false);
@@ -188,8 +190,10 @@ public class AsyncAutoResetEventTests
         await AsyncAssert.CancelAsync(cts1).ConfigureAwait(false);
         await AsyncAssert.CancelAsync(cts3).ConfigureAwait(false);
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter1.ConfigureAwait(false));
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter3.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         ev.Set();
         await waiter2.ConfigureAwait(false);
@@ -254,12 +258,16 @@ public class AsyncAutoResetEventTests
         cts.CancelAfter(TimeSpan.FromMilliseconds(500));
 
         // pooled waiter is canceled during wait, then returned to pool
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await vt2.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         Assert.That(ev.IsSet, Is.False);
 
         // internal waiter hits cancel and is returned to local 
         ev.Set();
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
@@ -574,7 +582,9 @@ public class AsyncAutoResetEventTests
         {
             ValueTask vt = ev.WaitAsync(cts.Token);
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
             Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         }
 
         using (Assert.EnterMultipleScope())
@@ -730,8 +740,10 @@ public class AsyncAutoResetEventTests
         var waiter1 = ev.WaitAsync(TimeSpan.FromMilliseconds(200));
         var waiter2 = ev.WaitAsync(TimeSpan.FromMilliseconds(200));
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter1.ConfigureAwait(false));
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter2.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         await Task.Delay(50).ConfigureAwait(false);
 

--- a/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
@@ -546,5 +546,111 @@ public class AsyncAutoResetEventTests
         Assert.That(ev.IsSet, Is.False);
         Assert.That(ev.RunContinuationAsynchronously, Is.True);
     }
+
+    [Test]
+    public async Task WaitAsyncWithTimeoutCompletesWhenSignalledBeforeTimeout()
+    {
+        var tpvts = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: tpvts);
+
+        _ = Task.Run(async () => { await Task.Delay(50).ConfigureAwait(false); ev.Set(); });
+
+        await ev.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        Assert.That(ev.InternalWaiterInUse, Is.False);
+        Assert.That(tpvts.ActiveCount, Is.Zero);
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task WaitAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var ev = new AsyncAutoResetEvent();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await ev.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(ev.InternalWaiterInUse, Is.False);
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutThrowsImmediatelyWhenNotSignalled()
+    {
+        var ev = new AsyncAutoResetEvent();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutCompletesImmediatelyWhenSignalled()
+    {
+        var ev = new AsyncAutoResetEvent(initialState: true);
+
+        await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false);
+
+        Assert.That(ev.IsSet, Is.False);
+    }
+
+    [Test]
+    public void WaitAsyncWithNegativeTimeoutThrows()
+    {
+        var ev = new AsyncAutoResetEvent();
+
+#pragma warning disable VSTHRD110 // Observe the awaitable result
+        Assert.Throws<ArgumentOutOfRangeException>(() => ev.WaitAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task WaitAsyncWithInfiniteTimeoutBehavesLikeWaitAsync()
+    {
+        var ev = new AsyncAutoResetEvent();
+
+        ev.Set();
+
+        await ev.WaitAsync(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+
+        Assert.That(ev.IsSet, Is.False);
+    }
+
+    [Test]
+    public async Task WaitAsyncWithTimeoutPooledWaitersAreReturnedOnSignal()
+    {
+        var tpvts = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: tpvts);
+
+        // Force use of pooled waiter by exhausting the local waiter with a first pending wait.
+        var waiter1 = ev.WaitAsync(TimeSpan.FromSeconds(5));
+        var waiter2 = ev.WaitAsync(TimeSpan.FromSeconds(5));
+
+        ev.Set();
+        ev.Set();
+
+        await waiter1.ConfigureAwait(false);
+        await waiter2.ConfigureAwait(false);
+
+        Assert.That(ev.InternalWaiterInUse, Is.False);
+        Assert.That(tpvts.ActiveCount, Is.Zero);
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task WaitAsyncWithTimeoutPooledWaitersAreReturnedOnTimeout()
+    {
+        var tpvts = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: tpvts);
+
+        var waiter1 = ev.WaitAsync(TimeSpan.FromMilliseconds(200));
+        var waiter2 = ev.WaitAsync(TimeSpan.FromMilliseconds(200));
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter1.ConfigureAwait(false));
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter2.ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(ev.InternalWaiterInUse, Is.False);
+        Assert.That(tpvts.ActiveCount, Is.Zero);
+    }
 }
 

--- a/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
@@ -10,7 +10,6 @@ namespace Threading.Tests.Async.Pooled;
 using CryptoHives.Foundation.Threading.Async.Pooled;
 using NUnit.Framework;
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Threading.Tests.Pools;
@@ -109,10 +108,8 @@ public class AsyncAutoResetEventTests
     [Test]
     public void ConstructorWithCustomPool()
     {
-        var customPool = new TestObjectPool<bool>();
+        using var customPool = new TestObjectPool<bool>();
         var ev = new AsyncAutoResetEvent(pool: customPool);
-
-        Assert.That(customPool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -153,8 +150,8 @@ public class AsyncAutoResetEventTests
     [Test]
     public async Task CancellationOfMiddleWaiterInQueue()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         var waiter1 = ev.WaitAsync();
         using var cts = new CancellationTokenSource();
@@ -171,14 +168,14 @@ public class AsyncAutoResetEventTests
         ev.Set();
         await waiter3.ConfigureAwait(false);
 
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
     public async Task MultipleCancellationsOfDifferentWaiters()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         using var cts1 = new CancellationTokenSource();
         using var cts2 = new CancellationTokenSource();
@@ -197,7 +194,7 @@ public class AsyncAutoResetEventTests
         ev.Set();
         await waiter2.ConfigureAwait(false);
 
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -217,8 +214,8 @@ public class AsyncAutoResetEventTests
     [Test]
     public void WaitAsyncUnsetReturnsNonCompletedValueTask()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         ValueTask vt = ev.WaitAsync();
         using (Assert.EnterMultipleScope())
@@ -226,38 +223,55 @@ public class AsyncAutoResetEventTests
             Assert.That(vt.IsCompleted, Is.False);
 
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
-    public void WaitAsyncUnsetUsesInternalAndPooledValueTaskSource()
+    [CancelAfter(10000)]
+    public async Task WaitAsyncCancelReturnsToPool(CancellationToken ct)
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var cts = new CancellationTokenSource();
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(initialState: false, pool: pool);
 
-        ValueTask vt = ev.WaitAsync();
+        ValueTask vt = ev.WaitAsync(cts.Token);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(vt.IsCompleted, Is.False);
             Assert.That(ev.InternalWaiterInUse, Is.True);
         }
 
-        ValueTask vt2 = ev.WaitAsync();
+        ValueTask vt2 = ev.WaitAsync(cts.Token);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(vt2.IsCompleted, Is.False);
-
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(1));
+        }
+
+        // cancel
+        cts.CancelAfter(TimeSpan.FromMilliseconds(500));
+
+        // pooled waiter is canceled during wait, then returned to pool
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await vt2.ConfigureAwait(false));
+        Assert.That(ev.IsSet, Is.False);
+
+        // internal waiter hits cancel and is returned to local 
+        ev.Set();
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(ev.IsSet, Is.True);
         }
     }
 
     [Test]
     public async Task WaitAsyncSetCompletesValueTask()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(initialState: false, pool: pool);
 
         ValueTask vt = ev.WaitAsync();
         using (Assert.EnterMultipleScope())
@@ -271,7 +285,7 @@ public class AsyncAutoResetEventTests
         {
             Assert.That(vt2.IsCompleted, Is.False);
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(1));
         }
 
         ev.Set();
@@ -279,7 +293,7 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(1));
         }
 
         ev.Set();
@@ -287,15 +301,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task WaitAsyncUnsetNeverCompletesAsync()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         Task t = ev.WaitAsync().AsTask();
 
@@ -306,15 +320,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task WaitAsyncSetCompletesImmediatelyAndResets()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(initialState: true, pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(initialState: true, pool: pool);
 
         ValueTask vt = ev.WaitAsync();
         Assert.That(vt.IsCompleted, Is.True);
@@ -335,15 +349,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task SetWithNoWaitersSetsSignalForNextWaiter()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         ev.Set();
 
@@ -367,15 +381,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test, CancelAfter(5000)]
     public async Task SetReleasesQueuedWaiter()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         ValueTask waiter = ev.WaitAsync();
         Assert.That(waiter.IsCompleted, Is.False);
@@ -401,7 +415,7 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -411,8 +425,8 @@ public class AsyncAutoResetEventTests
     [TestCase(5)]
     public async Task PulseAllReleasesAllQueuedWaiters(int numberOfWaiters)
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         var valueTasks = new ValueTask[numberOfWaiters];
         var tasks = new Task[numberOfWaiters];
@@ -425,7 +439,7 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
         }
 
         for (int i = 0; i < numberOfWaiters; i++)
@@ -441,7 +455,7 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters * 2 - 1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(numberOfWaiters * 2 - 1));
         }
 
         ev.PulseAll();
@@ -477,15 +491,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task PulseAllWithNoWaitersSetsSignalForNextWaiter()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         ev.PulseAll();
 
@@ -509,15 +523,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Theory]
     public async Task WaitAsyncWithCancellationTokenCancels(bool useAsTask)
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
         using var cts = new CancellationTokenSource();
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -535,15 +549,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Theory]
     public async Task WaitAsyncWithCancellationTokenCancelsWhileQueued(bool useAsTask)
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(initialState: false, pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(initialState: false, pool: pool);
         using var cts = new CancellationTokenSource();
 
         if (useAsTask)
@@ -566,15 +580,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Theory]
     public async Task WaitAsyncWithCancellationTokenSucceedsIfNotCancelled(bool useAsTask)
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
         using var cts = new CancellationTokenSource();
 
         _ = Task.Run(async () => { await Task.Delay(100).ConfigureAwait(false); ev.Set(); });
@@ -592,7 +606,7 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -616,8 +630,8 @@ public class AsyncAutoResetEventTests
     [Test]
     public async Task WaitAsyncWithTimeoutCompletesWhenSignalledBeforeTimeout()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         _ = Task.Run(async () => { await Task.Delay(50).ConfigureAwait(false); ev.Set(); });
 
@@ -626,7 +640,7 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -687,8 +701,8 @@ public class AsyncAutoResetEventTests
     [Test]
     public async Task WaitAsyncWithTimeoutPooledWaitersAreReturnedOnSignal()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         // Force use of pooled waiter by exhausting the local waiter with a first pending wait.
         var waiter1 = ev.WaitAsync(TimeSpan.FromSeconds(5));
@@ -703,15 +717,15 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test, CancelAfter(3000)]
     public async Task WaitAsyncWithTimeoutPooledWaitersAreReturnedOnTimeout()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncAutoResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncAutoResetEvent(pool: pool);
 
         var waiter1 = ev.WaitAsync(TimeSpan.FromMilliseconds(200));
         var waiter2 = ev.WaitAsync(TimeSpan.FromMilliseconds(200));
@@ -724,7 +738,7 @@ public class AsyncAutoResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 }

--- a/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
@@ -23,8 +23,11 @@ public class AsyncAutoResetEventTests
     public async Task IsSetReflectsEventState()
     {
         var ev = new AsyncAutoResetEvent(initialState: false);
-        Assert.That(ev.IsSet, Is.False);
-        Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.IsSet, Is.False);
+            Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        }
 
         ev.Set();
         Assert.That(ev.IsSet, Is.True);
@@ -82,18 +85,24 @@ public class AsyncAutoResetEventTests
         // Wait for continuation to complete
         await waiter.ConfigureAwait(false);
 
-        Assert.That(beforeContinuation, Is.EqualTo(0));
+        Assert.That(beforeContinuation, Is.Zero);
         if (runContinuationAsynchronously)
         {
-            // Continuation should not have run inline
-            Assert.That(afterContinuation, Is.EqualTo(1));
-            Assert.That(stage, Is.EqualTo(100));
+            using (Assert.EnterMultipleScope())
+            {
+                // Continuation should not have run inline
+                Assert.That(afterContinuation, Is.EqualTo(1));
+                Assert.That(stage, Is.EqualTo(100));
+            }
         }
         else
         {
-            // Continuation may have run inline
-            Assert.That(afterContinuation, Is.AnyOf(1, 100));
-            Assert.That(stage, Is.AnyOf(2, 100));
+            using (Assert.EnterMultipleScope())
+            {
+                // Continuation may have run inline
+                Assert.That(afterContinuation, Is.AnyOf(1, 100));
+                Assert.That(stage, Is.AnyOf(2, 100));
+            }
         }
     }
 
@@ -212,10 +221,13 @@ public class AsyncAutoResetEventTests
         var ev = new AsyncAutoResetEvent(pool: tpvts);
 
         ValueTask vt = ev.WaitAsync();
-        Assert.That(vt.IsCompleted, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(vt.IsCompleted, Is.False);
 
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -225,14 +237,20 @@ public class AsyncAutoResetEventTests
         var ev = new AsyncAutoResetEvent(pool: tpvts);
 
         ValueTask vt = ev.WaitAsync();
-        Assert.That(vt.IsCompleted, Is.False);
-        Assert.That(ev.InternalWaiterInUse, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(vt.IsCompleted, Is.False);
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+        }
 
         ValueTask vt2 = ev.WaitAsync();
-        Assert.That(vt2.IsCompleted, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(vt2.IsCompleted, Is.False);
 
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        }
     }
 
     [Test]
@@ -242,23 +260,35 @@ public class AsyncAutoResetEventTests
         var ev = new AsyncAutoResetEvent(pool: tpvts);
 
         ValueTask vt = ev.WaitAsync();
-        Assert.That(vt.IsCompleted, Is.False);
-        Assert.That(ev.InternalWaiterInUse, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(vt.IsCompleted, Is.False);
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+        }
 
         ValueTask vt2 = ev.WaitAsync();
-        Assert.That(vt2.IsCompleted, Is.False);
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(vt2.IsCompleted, Is.False);
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        }
 
         ev.Set();
         await vt.ConfigureAwait(false);
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        }
 
         ev.Set();
         await vt2.ConfigureAwait(false);
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -273,8 +303,11 @@ public class AsyncAutoResetEventTests
 
         await AsyncAssert.NeverCompletesAsync(t).ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -299,8 +332,11 @@ public class AsyncAutoResetEventTests
         ev.Set();
         await t.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -328,8 +364,11 @@ public class AsyncAutoResetEventTests
         await vt2.ConfigureAwait(false);
         await t.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test, CancelAfter(5000)]
@@ -359,8 +398,11 @@ public class AsyncAutoResetEventTests
         await vt2.ConfigureAwait(false);
         await t.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -380,8 +422,11 @@ public class AsyncAutoResetEventTests
             valueTasks[i] = ev.WaitAsync();
         }
 
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
+        }
 
         for (int i = 0; i < numberOfWaiters; i++)
         {
@@ -393,8 +438,11 @@ public class AsyncAutoResetEventTests
             tasks[i] = ev.WaitAsync().AsTask();
         }
 
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters * 2 - 1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters * 2 - 1));
+        }
 
         ev.PulseAll();
 
@@ -426,8 +474,11 @@ public class AsyncAutoResetEventTests
         await vt.ConfigureAwait(false);
         await t.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -455,8 +506,11 @@ public class AsyncAutoResetEventTests
         await vt2.ConfigureAwait(false);
         await t.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Theory]
@@ -478,8 +532,11 @@ public class AsyncAutoResetEventTests
             Assert.ThrowsAsync<TaskCanceledException>(async () => await ev.WaitAsync(cts.Token).ConfigureAwait(false));
         }
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Theory]
@@ -506,8 +563,11 @@ public class AsyncAutoResetEventTests
             Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
         }
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Theory]
@@ -529,8 +589,11 @@ public class AsyncAutoResetEventTests
             await ev.WaitAsync(cts.Token).ConfigureAwait(false);
         }
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -541,10 +604,13 @@ public class AsyncAutoResetEventTests
         Assert.That(ev.IsSet, Is.False);
 
         bool reset = ev.TryReset();
-        Assert.That(reset, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reset, Is.True);
 
-        Assert.That(ev.IsSet, Is.False);
-        Assert.That(ev.RunContinuationAsynchronously, Is.True);
+            Assert.That(ev.IsSet, Is.False);
+            Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        }
     }
 
     [Test]
@@ -557,8 +623,11 @@ public class AsyncAutoResetEventTests
 
         await ev.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test, CancelAfter(3000)]
@@ -631,8 +700,11 @@ public class AsyncAutoResetEventTests
         await waiter1.ConfigureAwait(false);
         await waiter2.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test, CancelAfter(3000)]
@@ -649,8 +721,11 @@ public class AsyncAutoResetEventTests
 
         await Task.Delay(50).ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 }
 

--- a/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
@@ -33,9 +33,12 @@ public class AsyncBarrierTests
     public void ParticipantCountIsCorrect()
     {
         var barrier = new AsyncBarrier(5);
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(5));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(5));
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(5));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(5));
+            Assert.That(barrier.CurrentPhase, Is.Zero);
+        }
     }
 
     [Test]
@@ -47,8 +50,11 @@ public class AsyncBarrierTests
         Assert.That(waiter.IsCompleted, Is.True);
         await waiter.ConfigureAwait(false);
 
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(1));
+        }
     }
 
     [Test]
@@ -71,10 +77,12 @@ public class AsyncBarrierTests
         await barrier.SignalAndWaitAsync().ConfigureAwait(false);
 
         int result = await t1.ConfigureAwait(false);
-        Assert.That(result, Is.EqualTo(2));
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(2));
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -103,9 +111,12 @@ public class AsyncBarrierTests
         var barrier = new AsyncBarrier(2);
 
         long phase = barrier.AddParticipant();
-        Assert.That(phase, Is.EqualTo(0));
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(3));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(3));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(phase, Is.Zero);
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(3));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(3));
+        }
 
         await Task.WhenAll(
             Task.Run(async () => await barrier.SignalAndWaitAsync().ConfigureAwait(false)),
@@ -113,9 +124,12 @@ public class AsyncBarrierTests
             Task.Run(async () => await barrier.SignalAndWaitAsync().ConfigureAwait(false))
         ).ConfigureAwait(false);
 
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(3));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(3));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(3));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(3));
+        }
     }
 
     [Test]
@@ -132,17 +146,22 @@ public class AsyncBarrierTests
         var barrier = new AsyncBarrier(3, pool: customPool);
 
         barrier.RemoveParticipant();
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(2));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(2));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+        }
 
         await Task.WhenAll(
             Task.Run(async () => await barrier.SignalAndWaitAsync().ConfigureAwait(false)),
             Task.Run(async () => await barrier.SignalAndWaitAsync().ConfigureAwait(false))
         ).ConfigureAwait(false);
 
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -157,11 +176,13 @@ public class AsyncBarrierTests
         barrier.RemoveParticipant();
         await waiter.ConfigureAwait(false);
 
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(1));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(1));
-
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(1));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(1));
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -190,9 +211,11 @@ public class AsyncBarrierTests
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await barrier.SignalAndWaitAsync(cts.Token).ConfigureAwait(false));
 
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
-
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -212,9 +235,11 @@ public class AsyncBarrierTests
             await waiter.ConfigureAwait(false));
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
-
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -237,13 +262,19 @@ public class AsyncBarrierTests
 
         // Add 2 more participants
         barrier.AddParticipants(2);
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(5));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(5));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(5));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(5));
+        }
 
         // Remove 1 participant
         barrier.RemoveParticipant();
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(4));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(4));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(4));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(4));
+        }
     }
 
     [Test]
@@ -302,8 +333,11 @@ public class AsyncBarrierTests
         ValueTask waiter1 = barrier.SignalAndWaitAsync();
         ValueTask waiter2 = barrier.SignalAndWaitAsync();
 
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(1));
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(1));
+            Assert.That(barrier.CurrentPhase, Is.Zero);
+        }
 
         // Remove the last remaining participant - should release waiters
         barrier.RemoveParticipant();
@@ -311,9 +345,12 @@ public class AsyncBarrierTests
         await waiter1.ConfigureAwait(false);
         await waiter2.ConfigureAwait(false);
 
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(2));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(2));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+        }
     }
 
     [Test]
@@ -327,8 +364,11 @@ public class AsyncBarrierTests
 
         // Add another participant - now need 2 more to release
         barrier.AddParticipant();
-        Assert.That(barrier.ParticipantCount, Is.EqualTo(3));
-        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(3));
+            Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+        }
 
         // Signal twice more to release all
         ValueTask waiter2 = barrier.SignalAndWaitAsync();
@@ -360,7 +400,7 @@ public class AsyncBarrierTests
     {
         var barrier = new AsyncBarrier(2);
 
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(0));
+        Assert.That(barrier.CurrentPhase, Is.Zero);
 
         await Task.WhenAll(
             barrier.SignalAndWaitAsync().AsTask(),
@@ -390,7 +430,7 @@ public class AsyncBarrierTests
         var barrier = new AsyncBarrier(1);
 
         long phase0 = barrier.AddParticipant();
-        Assert.That(phase0, Is.EqualTo(0));
+        Assert.That(phase0, Is.Zero);
 
         // Complete phase 0
         await Task.WhenAll(
@@ -453,8 +493,11 @@ public class AsyncBarrierTests
         BarrierPostPhaseException? ex = Assert.ThrowsAsync<BarrierPostPhaseException>(async () =>
             await barrier.SignalAndWaitAsync().ConfigureAwait(false));
 
-        Assert.That(ex!.InnerException, Is.TypeOf<InvalidOperationException>());
-        Assert.That(ex.InnerException!.Message, Is.EqualTo("Post-phase error"));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ex!.InnerException, Is.TypeOf<InvalidOperationException>());
+            Assert.That(ex.InnerException!.Message, Is.EqualTo("Post-phase error"));
+        }
     }
 
     [Test]
@@ -483,14 +526,18 @@ public class AsyncBarrierTests
             await waiter2.ConfigureAwait(false));
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
-        Assert.That(ex1!.InnerException!.Message, Is.EqualTo("Phase 0 error"));
-        Assert.That(ex2!.InnerException!.Message, Is.EqualTo("Phase 0 error"));
-        Assert.That(ex3!.InnerException!.Message, Is.EqualTo("Phase 0 error"));
+        using (Assert.EnterMultipleScope())
+        {
 
-        // Phase should still advance after exception
-        Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(ex1!.InnerException!.Message, Is.EqualTo("Phase 0 error"));
+            Assert.That(ex2!.InnerException!.Message, Is.EqualTo("Phase 0 error"));
+            Assert.That(ex3!.InnerException!.Message, Is.EqualTo("Phase 0 error"));
 
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+            // Phase should still advance after exception
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -527,8 +574,11 @@ public class AsyncBarrierTests
         // Remove the last remaining participant - triggers post-phase action
         BarrierPostPhaseException? ex = Assert.Throws<BarrierPostPhaseException>(barrier.RemoveParticipant);
 
-        Assert.That(ex!.InnerException, Is.TypeOf<InvalidOperationException>());
-        Assert.That(ex.InnerException!.Message, Is.EqualTo("Remove participant error"));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ex!.InnerException, Is.TypeOf<InvalidOperationException>());
+            Assert.That(ex.InnerException!.Message, Is.EqualTo("Remove participant error"));
+        }
     }
 
     [Test]
@@ -554,10 +604,12 @@ public class AsyncBarrierTests
             await waiter2.ConfigureAwait(false));
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
-        Assert.That(ex1!.InnerException!.Message, Is.EqualTo("Remove error"));
-        Assert.That(ex2!.InnerException!.Message, Is.EqualTo("Remove error"));
-
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ex1!.InnerException!.Message, Is.EqualTo("Remove error"));
+            Assert.That(ex2!.InnerException!.Message, Is.EqualTo("Remove error"));
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]

--- a/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
@@ -60,8 +60,8 @@ public class AsyncBarrierTests
     [Test]
     public async Task TwoParticipantsSynchronize()
     {
-        var customPool = new TestObjectPool<bool>();
-        var barrier = new AsyncBarrier(2, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var barrier = new AsyncBarrier(2, pool: pool);
         int reached = 0;
 
         Task<int> t1 = Task.Run(async () => {
@@ -81,7 +81,7 @@ public class AsyncBarrierTests
         {
             Assert.That(result, Is.EqualTo(2));
             Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -142,8 +142,8 @@ public class AsyncBarrierTests
     [Test]
     public async Task RemoveParticipantDecreasesRemainingAndCount()
     {
-        var customPool = new TestObjectPool<bool>();
-        var barrier = new AsyncBarrier(3, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var barrier = new AsyncBarrier(3, pool: pool);
 
         barrier.RemoveParticipant();
         using (Assert.EnterMultipleScope())
@@ -160,15 +160,15 @@ public class AsyncBarrierTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task RemoveParticipantReleasesWaitersWhenZeroRemaining()
     {
-        var customPool = new TestObjectPool<bool>();
-        var barrier = new AsyncBarrier(2, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var barrier = new AsyncBarrier(2, pool: pool);
 
         ValueTask waiter = barrier.SignalAndWaitAsync();
         Assert.That(waiter.IsCompleted, Is.False);
@@ -181,7 +181,7 @@ public class AsyncBarrierTests
             Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
             Assert.That(barrier.ParticipantCount, Is.EqualTo(1));
             Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(1));
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -202,8 +202,8 @@ public class AsyncBarrierTests
     [Test]
     public async Task CancellationBeforeWaitThrows()
     {
-        var customPool = new TestObjectPool<bool>();
-        var barrier = new AsyncBarrier(2, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var barrier = new AsyncBarrier(2, pool: pool);
         using var cts = new CancellationTokenSource();
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -214,15 +214,15 @@ public class AsyncBarrierTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task CancellationWhileWaitingThrows()
     {
-        var customPool = new TestObjectPool<bool>();
-        var barrier = new AsyncBarrier(2, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var barrier = new AsyncBarrier(2, pool: pool);
         using var cts = new CancellationTokenSource();
 
         ValueTask waiter = barrier.SignalAndWaitAsync(cts.Token);
@@ -238,7 +238,7 @@ public class AsyncBarrierTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -503,13 +503,13 @@ public class AsyncBarrierTests
     [Test]
     public async Task PostPhaseActionExceptionPropagatedToAllWaiters()
     {
-        var customPool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
         var barrier = new AsyncBarrier(3, b => {
             if (b.CurrentPhase == 0)
             {
                 throw new InvalidOperationException("Phase 0 error");
             }
-        }, pool: customPool);
+        }, pool: pool);
 
         ValueTask waiter1 = barrier.SignalAndWaitAsync();
         ValueTask waiter2 = barrier.SignalAndWaitAsync();
@@ -536,7 +536,7 @@ public class AsyncBarrierTests
             // Phase should still advance after exception
             Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
 
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -584,10 +584,10 @@ public class AsyncBarrierTests
     [Test]
     public async Task PostPhaseActionExceptionOnRemoveParticipantsPropagatedToWaiters()
     {
-        var customPool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
         var barrier = new AsyncBarrier(3, b => {
             throw new InvalidOperationException("Remove error");
-        }, pool: customPool);
+        }, pool: pool);
 
         // Two participants signal
         ValueTask waiter1 = barrier.SignalAndWaitAsync();
@@ -608,7 +608,7 @@ public class AsyncBarrierTests
         {
             Assert.That(ex1!.InnerException!.Message, Is.EqualTo("Remove error"));
             Assert.That(ex2!.InnerException!.Message, Is.EqualTo("Remove error"));
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 

--- a/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
@@ -230,10 +230,10 @@ public class AsyncBarrierTests
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await waiter.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         using (Assert.EnterMultipleScope())
         {
@@ -518,13 +518,13 @@ public class AsyncBarrierTests
         BarrierPostPhaseException? ex3 = Assert.ThrowsAsync<BarrierPostPhaseException>(async () =>
             await barrier.SignalAndWaitAsync().ConfigureAwait(false));
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
         // Previous waiters should also receive the exception
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         BarrierPostPhaseException? ex1 = Assert.ThrowsAsync<BarrierPostPhaseException>(async () =>
             await waiter1.ConfigureAwait(false));
         BarrierPostPhaseException? ex2 = Assert.ThrowsAsync<BarrierPostPhaseException>(async () =>
             await waiter2.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         using (Assert.EnterMultipleScope())
         {
@@ -596,13 +596,13 @@ public class AsyncBarrierTests
         // Remove the last remaining participant - triggers post-phase action
         Assert.Throws<BarrierPostPhaseException>(barrier.RemoveParticipant);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
         // Waiters should receive the exception
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         BarrierPostPhaseException? ex1 = Assert.ThrowsAsync<BarrierPostPhaseException>(async () =>
             await waiter1.ConfigureAwait(false));
         BarrierPostPhaseException? ex2 = Assert.ThrowsAsync<BarrierPostPhaseException>(async () =>
             await waiter2.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         using (Assert.EnterMultipleScope())
         {

--- a/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
@@ -588,4 +588,64 @@ public class AsyncBarrierTests
 
         Assert.That(phaseCounts, Is.EqualTo(new[] { 1, 1, 1 }));
     }
+
+    [Test]
+    public async Task SignalAndWaitAsyncWithTimeoutCompletesWhenAllArrive()
+    {
+        var barrier = new AsyncBarrier(2);
+
+        var task1 = barrier.SignalAndWaitAsync(TimeSpan.FromSeconds(5)).AsTask();
+        var task2 = barrier.SignalAndWaitAsync(TimeSpan.FromSeconds(5)).AsTask();
+
+        await Task.WhenAll(task1, task2).ConfigureAwait(false);
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task SignalAndWaitAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var barrier = new AsyncBarrier(2);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await barrier.SignalAndWaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SignalAndWaitAsyncWithZeroTimeoutThrowsWhenParticipantsPending()
+    {
+        var barrier = new AsyncBarrier(2);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await barrier.SignalAndWaitAsync(TimeSpan.Zero).ConfigureAwait(false));
+    }
+
+    [Test]
+    public async Task SignalAndWaitAsyncWithZeroTimeoutCompletesWhenLastParticipant()
+    {
+        var barrier = new AsyncBarrier(1);
+
+        await barrier.SignalAndWaitAsync(TimeSpan.Zero).ConfigureAwait(false);
+    }
+
+    [Test]
+    public void SignalAndWaitAsyncWithNegativeTimeoutThrows()
+    {
+        var barrier = new AsyncBarrier(2);
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => barrier.SignalAndWaitAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task SignalAndWaitAsyncWithInfiniteTimeoutBehavesLikeDefault()
+    {
+        var barrier = new AsyncBarrier(2);
+
+        var task1 = barrier.SignalAndWaitAsync(Timeout.InfiniteTimeSpan).AsTask();
+        var task2 = barrier.SignalAndWaitAsync(Timeout.InfiniteTimeSpan).AsTask();
+
+        await Task.WhenAll(task1, task2).ConfigureAwait(false);
+    }
 }

--- a/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
@@ -273,10 +273,10 @@ public class AsyncCountdownEventTests
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await waiter.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         Assert.That(pool.ActiveCount, Is.Zero);
     }

--- a/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
@@ -32,9 +32,12 @@ public class AsyncCountdownEventTests
     public void InitialCountIsCorrect()
     {
         var countdown = new AsyncCountdownEvent(5);
-        Assert.That(countdown.CurrentCount, Is.EqualTo(5));
-        Assert.That(countdown.InitialCount, Is.EqualTo(5));
-        Assert.That(countdown.IsSet, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(countdown.CurrentCount, Is.EqualTo(5));
+            Assert.That(countdown.InitialCount, Is.EqualTo(5));
+            Assert.That(countdown.IsSet, Is.False);
+        }
     }
 
     [Test]
@@ -49,8 +52,11 @@ public class AsyncCountdownEventTests
         Assert.That(countdown.CurrentCount, Is.EqualTo(1));
 
         countdown.Signal();
-        Assert.That(countdown.CurrentCount, Is.EqualTo(0));
-        Assert.That(countdown.IsSet, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(countdown.CurrentCount, Is.Zero);
+            Assert.That(countdown.IsSet, Is.True);
+        }
     }
 
     [Test]
@@ -91,7 +97,7 @@ public class AsyncCountdownEventTests
         countdown.Signal();
         await waiter.ConfigureAwait(false);
 
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        Assert.That(customPool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -115,9 +121,12 @@ public class AsyncCountdownEventTests
         var t2 = countdown.WaitAsync();
         var t3 = countdown.WaitAsync();
 
-        Assert.That(t1.IsCompleted, Is.False);
-        Assert.That(t2.IsCompleted, Is.False);
-        Assert.That(t3.IsCompleted, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(t1.IsCompleted, Is.False);
+            Assert.That(t2.IsCompleted, Is.False);
+            Assert.That(t3.IsCompleted, Is.False);
+        }
 
         countdown.Signal();
 
@@ -125,7 +134,7 @@ public class AsyncCountdownEventTests
         await t2.ConfigureAwait(false);
         await t3.ConfigureAwait(false);
 
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        Assert.That(customPool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -170,8 +179,11 @@ public class AsyncCountdownEventTests
     {
         var countdown = new AsyncCountdownEvent(2);
 
-        Assert.That(countdown.TryAddCount(), Is.True);
-        Assert.That(countdown.CurrentCount, Is.EqualTo(3));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(countdown.TryAddCount(), Is.True);
+            Assert.That(countdown.CurrentCount, Is.EqualTo(3));
+        }
     }
 
     [Test]
@@ -180,16 +192,22 @@ public class AsyncCountdownEventTests
         var countdown = new AsyncCountdownEvent(1);
         countdown.Signal();
 
-        Assert.That(countdown.TryAddCount(), Is.False);
-        Assert.That(countdown.CurrentCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(countdown.TryAddCount(), Is.False);
+            Assert.That(countdown.CurrentCount, Is.Zero);
+        }
     }
 
     [Test]
     public void TryAddCountReturnsFalseForInvalidCount()
     {
         var countdown = new AsyncCountdownEvent(2);
-        Assert.That(countdown.TryAddCount(0), Is.False);
-        Assert.That(countdown.TryAddCount(-1), Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(countdown.TryAddCount(0), Is.False);
+            Assert.That(countdown.TryAddCount(-1), Is.False);
+        }
     }
 
     [Test]
@@ -204,8 +222,11 @@ public class AsyncCountdownEventTests
 
         countdown.Reset();
 
-        Assert.That(countdown.CurrentCount, Is.EqualTo(3));
-        Assert.That(countdown.IsSet, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(countdown.CurrentCount, Is.EqualTo(3));
+            Assert.That(countdown.IsSet, Is.False);
+        }
     }
 
     [Test]
@@ -218,8 +239,11 @@ public class AsyncCountdownEventTests
 
         countdown.Reset(5);
 
-        Assert.That(countdown.CurrentCount, Is.EqualTo(5));
-        Assert.That(countdown.InitialCount, Is.EqualTo(5));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(countdown.CurrentCount, Is.EqualTo(5));
+            Assert.That(countdown.InitialCount, Is.EqualTo(5));
+        }
     }
 
     [Test]
@@ -234,7 +258,7 @@ public class AsyncCountdownEventTests
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await countdown.WaitAsync(cts.Token).ConfigureAwait(false));
 
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        Assert.That(customPool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -254,7 +278,7 @@ public class AsyncCountdownEventTests
             await waiter.ConfigureAwait(false));
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        Assert.That(customPool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -279,7 +303,7 @@ public class AsyncCountdownEventTests
 
         await countdown.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-        Assert.That(countdown.CurrentCount, Is.EqualTo(0));
+        Assert.That(countdown.CurrentCount, Is.Zero);
     }
 
     [Test, CancelAfter(3000)]

--- a/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
@@ -85,8 +85,8 @@ public class AsyncCountdownEventTests
     [Test]
     public async Task WaitAsyncCompletesWhenCountReachesZero()
     {
-        var customPool = new TestObjectPool<bool>();
-        var countdown = new AsyncCountdownEvent(2, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var countdown = new AsyncCountdownEvent(2, pool: pool);
 
         var waiter = countdown.WaitAsync();
         Assert.That(waiter.IsCompleted, Is.False);
@@ -97,7 +97,7 @@ public class AsyncCountdownEventTests
         countdown.Signal();
         await waiter.ConfigureAwait(false);
 
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -114,8 +114,8 @@ public class AsyncCountdownEventTests
     [Test]
     public async Task MultipleWaitersAreAllReleased()
     {
-        var customPool = new TestObjectPool<bool>();
-        var countdown = new AsyncCountdownEvent(1, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var countdown = new AsyncCountdownEvent(1, pool: pool);
 
         var t1 = countdown.WaitAsync();
         var t2 = countdown.WaitAsync();
@@ -134,7 +134,7 @@ public class AsyncCountdownEventTests
         await t2.ConfigureAwait(false);
         await t3.ConfigureAwait(false);
 
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
@@ -249,8 +249,8 @@ public class AsyncCountdownEventTests
     [Test]
     public async Task CancellationBeforeWaitThrows()
     {
-        var customPool = new TestObjectPool<bool>();
-        var countdown = new AsyncCountdownEvent(2, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var countdown = new AsyncCountdownEvent(2, pool: pool);
         using var cts = new CancellationTokenSource();
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -258,14 +258,14 @@ public class AsyncCountdownEventTests
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await countdown.WaitAsync(cts.Token).ConfigureAwait(false));
 
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
     public async Task CancellationWhileWaitingThrows()
     {
-        var customPool = new TestObjectPool<bool>();
-        var countdown = new AsyncCountdownEvent(2, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var countdown = new AsyncCountdownEvent(2, pool: pool);
         using var cts = new CancellationTokenSource();
 
         var waiter = countdown.WaitAsync(cts.Token);
@@ -278,7 +278,7 @@ public class AsyncCountdownEventTests
             await waiter.ConfigureAwait(false));
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]

--- a/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
@@ -269,4 +269,64 @@ public class AsyncCountdownEventTests
         countdown.RunContinuationAsynchronously = true;
         Assert.That(countdown.RunContinuationAsynchronously, Is.True);
     }
+
+    [Test]
+    public async Task WaitAsyncWithTimeoutCompletesWhenCountReachesZeroBeforeTimeout()
+    {
+        var countdown = new AsyncCountdownEvent(1);
+
+        _ = Task.Run(async () => { await Task.Delay(50).ConfigureAwait(false); countdown.Signal(); });
+
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        Assert.That(countdown.CurrentCount, Is.EqualTo(0));
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task WaitAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var countdown = new AsyncCountdownEvent(1);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await countdown.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutCompletesImmediatelyWhenAlreadyZero()
+    {
+        var countdown = new AsyncCountdownEvent(1);
+        countdown.Signal();
+
+        await countdown.WaitAsync(TimeSpan.Zero).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutThrowsWhenCountIsNonZero()
+    {
+        var countdown = new AsyncCountdownEvent(1);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await countdown.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
+    }
+
+    [Test]
+    public void WaitAsyncWithNegativeTimeoutThrows()
+    {
+        var countdown = new AsyncCountdownEvent(1);
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => countdown.WaitAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task WaitAsyncWithInfiniteTimeoutBehavesLikeWaitAsync()
+    {
+        var countdown = new AsyncCountdownEvent(1);
+        countdown.Signal();
+
+        await countdown.WaitAsync(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+    }
 }

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -19,7 +19,8 @@ public class AsyncLockTests
     [Test]
     public void AsyncLockUnlockedSynchronouslyPermitsLock()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
 
         Task<AsyncLock.Releaser> lockTask = mutex.LockAsync().AsTask();
 
@@ -34,7 +35,9 @@ public class AsyncLockTests
     [Test]
     public async Task AsyncLockLockedPreventsLockUntilUnlocked()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
+
         TaskCompletionSource<object?> task1HasLock = CreateAsyncTaskSource<object?>();
         TaskCompletionSource<object?> task1Continue = CreateAsyncTaskSource<object?>();
 
@@ -59,8 +62,8 @@ public class AsyncLockTests
     [Test]
     public async Task AsyncLockOnlyPermitsOneLockerAtATime()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         var task1HasLock = new TaskCompletionSource<bool>();
         var task1Continue = new TaskCompletionSource<bool>();
@@ -105,14 +108,16 @@ public class AsyncLockTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public void AsyncLockPreCancelledUnlockedSynchronouslyTakesLock()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
+
         var token = new CancellationToken(true);
 
         Task<AsyncLock.Releaser> task = mutex.LockAsync(token).AsTask();
@@ -130,7 +135,9 @@ public class AsyncLockTests
     [TestCase(false)]
     public async Task AsyncLockPreCancelledLockedSynchronouslyCancels(bool useAsTask)
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
+
         ValueTask<AsyncLock.Releaser> lockTask = mutex.LockAsync();
         var token = new CancellationToken(true);
 
@@ -161,7 +168,9 @@ public class AsyncLockTests
     [Test]
     public async Task AsyncLockCancelledLockLeavesLockUnlocked()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
+
         using var cts = new CancellationTokenSource();
         TaskCompletionSource<object?> taskReady = CreateAsyncTaskSource<object?>();
 
@@ -185,7 +194,9 @@ public class AsyncLockTests
     [Test]
     public async Task AsyncLockCanceledTooLateStillTakesLock()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
+
         using var cts = new CancellationTokenSource();
 
         ValueTask<AsyncLock.Releaser> cancelableLockTask;
@@ -207,8 +218,10 @@ public class AsyncLockTests
     [Test]
     public async Task AsyncLockSupportsMultipleAsynchronousLocks()
     {
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+
         await Task.Run(async () => {
-            var asyncLock = new AsyncLock();
+            var asyncLock = new AsyncLock(pool: pool);
             using var cancellationTokenSource = new CancellationTokenSource();
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
@@ -249,8 +262,8 @@ public class AsyncLockTests
     [Test]
     public async Task LockUnlockSingleAwaiter()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         ValueTask<AsyncLock.Releaser> vt = al.LockAsync();
         Assert.That(vt.IsCompleted);
@@ -268,15 +281,15 @@ public class AsyncLockTests
         {
             Assert.That(al.IsTaken, Is.False);
             Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task MultipleWaitersAreServedSequentially()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         Task t1, t2;
         using (await al.LockAsync().ConfigureAwait(false))
@@ -293,18 +306,14 @@ public class AsyncLockTests
         await Task.WhenAll(t1, t2).ConfigureAwait(false);
         await Task.Delay(50).ConfigureAwait(false);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
-        }
+        Assert.That(al.InternalWaiterInUse, Is.False);
     }
 
     [Test]
     public async Task WaitAsyncWithCancellationTokenCancelsBeforeQueuing()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         using (await al.LockAsync().ConfigureAwait(false))
         {
@@ -316,18 +325,14 @@ public class AsyncLockTests
             Assert.ThrowsAsync<TaskCanceledException>(async () => await al.LockAsync(cts.Token).ConfigureAwait(false));
         }
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
-        }
+        Assert.That(al.InternalWaiterInUse, Is.False);
     }
 
     [Test]
     public async Task WaitAsyncWithCancellationTokenCancelsWhileQueued()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         using var cts = new CancellationTokenSource();
 
@@ -342,18 +347,14 @@ public class AsyncLockTests
             Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
         }
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
-        }
+        Assert.That(al.InternalWaiterInUse, Is.False);
     }
 
     [Test]
     public async Task WaitAsyncWithCancellationTokenSucceedsIfNotCancelled()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         using var cts = new CancellationTokenSource();
 
@@ -364,18 +365,14 @@ public class AsyncLockTests
             Assert.That(al.IsTaken);
         }
 
-        using (Assert.EnterMultipleScope())
-        {
             Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
-        }
     }
 
     [Test]
     public async Task WaitAsyncWithCancellationTokenCancelAfterLock()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         using var cts = new CancellationTokenSource();
 
@@ -389,18 +386,14 @@ public class AsyncLockTests
         // Cancel after lock is released, should not throw
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-        using (Assert.EnterMultipleScope())
-        {
             Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
-        }
     }
 
     [Test, CancelAfter(1000)]
     public async Task WaitAsyncWithCancellationTokenCancelAfterTimeout()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         using var cts = new CancellationTokenSource(250);
 
@@ -412,18 +405,14 @@ public class AsyncLockTests
             Assert.ThrowsAsync<OperationCanceledException>(async () => await al.LockAsync(cts.Token).ConfigureAwait(false));
         }
 
-        using (Assert.EnterMultipleScope())
-        {
             Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
-        }
     }
 
     [Theory]
     public async Task WaitAsyncGetAwaiterWithCancellationTokenCancelAfterLock(bool useAsTask)
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var al = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var al = new AsyncLock(pool: pool);
 
         using var cts = new CancellationTokenSource();
 
@@ -447,11 +436,7 @@ public class AsyncLockTests
         // Cancel after lock is released, should not throw
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-        using (Assert.EnterMultipleScope())
-        {
             Assert.That(al.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
-        }
     }
 
     [Test]
@@ -473,8 +458,8 @@ public class AsyncLockTests
     [Test]
     public async Task LockAsyncWithTimeoutCompletesWhenLockAvailableBeforeTimeout()
     {
-        var customPool = new TestObjectPool<AsyncLock.Releaser>();
-        var mutex = new AsyncLock(pool: customPool);
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
 
         using (await mutex.LockAsync().ConfigureAwait(false)) { }
 
@@ -486,14 +471,15 @@ public class AsyncLockTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(mutex.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test, CancelAfter(3000)]
     public async Task LockAsyncWithTimeoutThrowsWhenTimeoutElapses()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
 
         using var outerReleaser = await mutex.LockAsync().ConfigureAwait(false);
 
@@ -523,7 +509,8 @@ public class AsyncLockTests
     [Test]
     public async Task LockAsyncWithZeroTimeoutThrowsWhenLocked()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
 
         using var outerReleaser = await mutex.LockAsync().ConfigureAwait(false);
 
@@ -538,7 +525,8 @@ public class AsyncLockTests
     [Test]
     public void LockAsyncWithNegativeTimeoutThrows()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
 
 #pragma warning disable VSTHRD110
 #pragma warning disable CA2012
@@ -552,7 +540,8 @@ public class AsyncLockTests
     [Test]
     public async Task LockAsyncWithInfiniteTimeoutBehavesLikeLockAsync()
     {
-        var mutex = new AsyncLock();
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
 
         using (await mutex.LockAsync(Timeout.InfiniteTimeSpan).ConfigureAwait(false))
         {

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -479,6 +479,10 @@ public class AsyncLockTests
         {
             Assert.That(mutex.IsTaken);
         }
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(mutex.InternalWaiterInUse, Is.False);
     }
 
     [Test]
@@ -489,7 +493,11 @@ public class AsyncLockTests
         using var outerReleaser = await mutex.LockAsync().ConfigureAwait(false);
 
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            await mutex.LockAsync(TimeSpan.Zero).ConfigureAwait(false));
+            _ = await mutex.LockAsync(TimeSpan.Zero).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(mutex.InternalWaiterInUse, Is.False);
     }
 
     [Test]
@@ -498,8 +506,12 @@ public class AsyncLockTests
         var mutex = new AsyncLock();
 
 #pragma warning disable VSTHRD110
+#pragma warning disable CA2012
         Assert.Throws<ArgumentOutOfRangeException>(() => mutex.LockAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore CA2012
 #pragma warning restore VSTHRD110
+
+        Assert.That(mutex.InternalWaiterInUse, Is.False);
     }
 
     [Test]
@@ -511,6 +523,8 @@ public class AsyncLockTests
         {
             Assert.That(mutex.IsTaken);
         }
+
+        Assert.That(mutex.InternalWaiterInUse, Is.False);
     }
 
     private static TaskCompletionSource<TResult> CreateAsyncTaskSource<TResult>()

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -365,7 +365,7 @@ public class AsyncLockTests
             Assert.That(al.IsTaken);
         }
 
-            Assert.That(al.InternalWaiterInUse, Is.False);
+        Assert.That(al.InternalWaiterInUse, Is.False);
     }
 
     [Test]
@@ -386,7 +386,7 @@ public class AsyncLockTests
         // Cancel after lock is released, should not throw
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-            Assert.That(al.InternalWaiterInUse, Is.False);
+        Assert.That(al.InternalWaiterInUse, Is.False);
     }
 
     [Test, CancelAfter(1000)]
@@ -405,7 +405,7 @@ public class AsyncLockTests
             Assert.ThrowsAsync<OperationCanceledException>(async () => await al.LockAsync(cts.Token).ConfigureAwait(false));
         }
 
-            Assert.That(al.InternalWaiterInUse, Is.False);
+        Assert.That(al.InternalWaiterInUse, Is.False);
     }
 
     [Theory]
@@ -436,7 +436,7 @@ public class AsyncLockTests
         // Cancel after lock is released, should not throw
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-            Assert.That(al.InternalWaiterInUse, Is.False);
+        Assert.That(al.InternalWaiterInUse, Is.False);
     }
 
     [Test]

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -344,7 +344,9 @@ public class AsyncLockTests
             // Cancel after queuing
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
             Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         }
 
         Assert.That(al.InternalWaiterInUse, Is.False);

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -430,6 +430,81 @@ public class AsyncLockTests
         Assert.That(ev.IsTaken, Is.False);
     }
 
+    [Test]
+    public async Task LockAsyncWithTimeoutCompletesWhenLockAvailableBeforeTimeout()
+    {
+        var customPool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: customPool);
+
+        using (await mutex.LockAsync().ConfigureAwait(false)) { }
+
+        using (await mutex.LockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
+        {
+            Assert.That(mutex.IsTaken);
+        }
+
+        Assert.That(mutex.InternalWaiterInUse, Is.False);
+        Assert.That(customPool.ActiveCount, Is.Zero);
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task LockAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var mutex = new AsyncLock();
+
+        using var outerReleaser = await mutex.LockAsync().ConfigureAwait(false);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await mutex.LockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(mutex.InternalWaiterInUse, Is.False);
+    }
+
+    [Test]
+    public async Task LockAsyncWithZeroTimeoutCompletesImmediatelyWhenUnlocked()
+    {
+        var mutex = new AsyncLock();
+
+        using (await mutex.LockAsync(TimeSpan.Zero).ConfigureAwait(false))
+        {
+            Assert.That(mutex.IsTaken);
+        }
+    }
+
+    [Test]
+    public async Task LockAsyncWithZeroTimeoutThrowsWhenLocked()
+    {
+        var mutex = new AsyncLock();
+
+        using var outerReleaser = await mutex.LockAsync().ConfigureAwait(false);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await mutex.LockAsync(TimeSpan.Zero).ConfigureAwait(false));
+    }
+
+    [Test]
+    public void LockAsyncWithNegativeTimeoutThrows()
+    {
+        var mutex = new AsyncLock();
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => mutex.LockAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task LockAsyncWithInfiniteTimeoutBehavesLikeLockAsync()
+    {
+        var mutex = new AsyncLock();
+
+        using (await mutex.LockAsync(Timeout.InfiniteTimeSpan).ConfigureAwait(false))
+        {
+            Assert.That(mutex.IsTaken);
+        }
+    }
+
     private static TaskCompletionSource<TResult> CreateAsyncTaskSource<TResult>()
     {
         return new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -23,9 +23,12 @@ public class AsyncLockTests
 
         Task<AsyncLock.Releaser> lockTask = mutex.LockAsync().AsTask();
 
-        Assert.That(lockTask.IsCompleted, Is.True);
-        Assert.That(lockTask.IsFaulted, Is.False);
-        Assert.That(lockTask.IsCanceled, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(lockTask.IsCompleted, Is.True);
+            Assert.That(lockTask.IsFaulted, Is.False);
+            Assert.That(lockTask.IsCanceled, Is.False);
+        }
     }
 
     [Test]
@@ -99,8 +102,11 @@ public class AsyncLockTests
         await task2.ConfigureAwait(false);
         await task3.ConfigureAwait(false);
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -111,9 +117,12 @@ public class AsyncLockTests
 
         Task<AsyncLock.Releaser> task = mutex.LockAsync(token).AsTask();
 
-        Assert.That(task.IsCompleted, Is.True);
-        Assert.That(task.IsCanceled, Is.False);
-        Assert.That(task.IsFaulted, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(task.IsCompleted, Is.True);
+            Assert.That(task.IsCanceled, Is.False);
+            Assert.That(task.IsFaulted, Is.False);
+        }
     }
 
     [Test]
@@ -128,16 +137,22 @@ public class AsyncLockTests
         if (useAsTask)
         {
             Task<AsyncLock.Releaser> task = mutex.LockAsync(token).AsTask();
-            Assert.That(task.IsCompleted, Is.True);
-            Assert.That(task.IsCanceled, Is.True);
-            Assert.That(task.IsFaulted, Is.False);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(task.IsCompleted, Is.True);
+                Assert.That(task.IsCanceled, Is.True);
+                Assert.That(task.IsFaulted, Is.False);
+            }
         }
         else
         {
             ValueTask<AsyncLock.Releaser> valueTask = mutex.LockAsync(token);
-            Assert.That(valueTask.IsCompleted, Is.True);
-            Assert.That(valueTask.IsCanceled, Is.True);
-            Assert.That(valueTask.IsFaulted, Is.False);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(valueTask.IsCompleted, Is.True);
+                Assert.That(valueTask.IsCanceled, Is.True);
+                Assert.That(valueTask.IsFaulted, Is.False);
+            }
         }
 
         await lockTask.ConfigureAwait(false);
@@ -249,10 +264,12 @@ public class AsyncLockTests
             }
         }
 
-        Assert.That(al.IsTaken, Is.False);
-
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.IsTaken, Is.False);
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -276,8 +293,11 @@ public class AsyncLockTests
         await Task.WhenAll(t1, t2).ConfigureAwait(false);
         await Task.Delay(50).ConfigureAwait(false);
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -296,8 +316,11 @@ public class AsyncLockTests
             Assert.ThrowsAsync<TaskCanceledException>(async () => await al.LockAsync(cts.Token).ConfigureAwait(false));
         }
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -341,8 +364,11 @@ public class AsyncLockTests
             Assert.That(al.IsTaken);
         }
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -363,8 +389,11 @@ public class AsyncLockTests
         // Cancel after lock is released, should not throw
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test, CancelAfter(1000)]
@@ -383,8 +412,11 @@ public class AsyncLockTests
             Assert.ThrowsAsync<OperationCanceledException>(async () => await al.LockAsync(cts.Token).ConfigureAwait(false));
         }
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Theory]
@@ -451,8 +483,11 @@ public class AsyncLockTests
             Assert.That(mutex.IsTaken);
         }
 
-        Assert.That(mutex.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mutex.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test, CancelAfter(3000)]

--- a/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
@@ -10,7 +10,6 @@ using CryptoHives.Foundation.Threading.Async.Pooled;
 using NUnit.Framework;
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Threading.Tests.Pools;
@@ -55,17 +54,17 @@ public class AsyncManualResetEventTests
     [Test]
     public void ConstructorWithCustomPool()
     {
-        var customPool = new TestObjectPool<bool>();
-        _ = new AsyncManualResetEvent(pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        _ = new AsyncManualResetEvent(pool: pool);
 
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
     public async Task WaitAsyncUnsetNeverCompletes()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(pool: pool);
 
         Task task = mre.WaitAsync().AsTask();
 
@@ -74,15 +73,15 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(mre.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Theory]
     public void WaitAsyncAfterSetCompletesSynchronously(bool useAsTask)
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(pool: pool);
 
         mre.Set();
 
@@ -97,29 +96,29 @@ public class AsyncManualResetEventTests
             Assert.That(task.IsCompleted, Is.True);
         }
 
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
     public void WaitAsyncWithInitialStateSetCompletesSynchronously()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(set: true, pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(set: true, pool: pool);
 
         ValueTask task = mre.WaitAsync();
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(task.IsCompleted, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task MultipleWaitersCompleteAfterSet()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(pool: pool);
 
         Task t1 = mre.WaitAsync().AsTask();
         Task t2 = mre.WaitAsync().AsTask();
@@ -127,7 +126,7 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(mre.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(1));
         }
 
         mre.Set();
@@ -143,7 +142,7 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(mre.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -153,15 +152,15 @@ public class AsyncManualResetEventTests
     [TestCase(10)]
     public async Task MultipleWaitersAllComplete(int numberOfWaiters)
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(pool: pool);
 
         Task[] taskWaiters = Enumerable.Range(0, numberOfWaiters).Select(_ => mre.WaitAsync().AsTask()).ToArray();
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(mre.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
         }
 
         foreach (Task t in taskWaiters)
@@ -182,15 +181,15 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(mre.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task ResetUnsetsEvent()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(set: true, pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(set: true, pool: pool);
 
         Assert.That(mre.IsSet, Is.True);
 
@@ -201,36 +200,28 @@ public class AsyncManualResetEventTests
         Task wait = mre.WaitAsync().AsTask();
         await AsyncAssert.NeverCompletesAsync(wait).ConfigureAwait(false);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(mre.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
-        }
+        Assert.That(mre.InternalWaiterInUse, Is.True);
     }
 
     [Test]
     public async Task ResetWhenAlreadyResetDoesNothing()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(set: false, pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(set: false, pool: pool);
 
         mre.Reset();
 
         Task wait = mre.WaitAsync().AsTask();
         await AsyncAssert.NeverCompletesAsync(wait).ConfigureAwait(false);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(mre.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
-        }
+        Assert.That(mre.InternalWaiterInUse, Is.True);
     }
 
     [Test]
     public async Task SetAfterResetReleasesNewWaiters()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(set: true, pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(set: true, pool: pool);
 
         await mre.WaitAsync().ConfigureAwait(false);
 
@@ -246,15 +237,15 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(mre.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task MultipleSetCallsOnlySignalOnce()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var mre = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var mre = new AsyncManualResetEvent(pool: pool);
 
         mre.Set();
         mre.Set();
@@ -264,18 +255,14 @@ public class AsyncManualResetEventTests
 
         await mre.WaitAsync().ConfigureAwait(false);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(mre.IsSet, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
-        }
+        Assert.That(mre.IsSet, Is.True);
     }
 
     [Test]
     public async Task WaitAsyncWithCancellationTokenCancelsBeforeQueuing()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
         using var cts = new CancellationTokenSource();
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -287,15 +274,16 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task WaitAsyncWithCancellationTokenCancelsWhileQueued()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncManualResetEvent(set: false, pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(set: false, pool: pool);
+
         using var cts = new CancellationTokenSource();
 
         ValueTask vt = ev.WaitAsync(cts.Token);
@@ -307,15 +295,16 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task WaitAsyncWithCancellationTokenSucceedsIfNotCancelled()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
+
         using var cts = new CancellationTokenSource();
 
         ValueTask vt = ev.WaitAsync(cts.Token);
@@ -327,15 +316,15 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task CancellationOfMiddleWaiterInQueue()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
 
         var waiter1 = ev.WaitAsync();
         using var cts = new CancellationTokenSource();
@@ -345,7 +334,7 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(2));
+            Assert.That(pool.ActiveCount, Is.EqualTo(2));
         }
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -355,7 +344,7 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.True);
-            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+            Assert.That(pool.ActiveCount, Is.EqualTo(1));
         }
 
         ev.Set();
@@ -366,15 +355,15 @@ public class AsyncManualResetEventTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task CancellationAfterSetButBeforeAwaitDoesNotThrow()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
         using var cts = new CancellationTokenSource();
 
         var waiter = ev.WaitAsync(cts.Token);
@@ -384,13 +373,14 @@ public class AsyncManualResetEventTests
 
         await waiter.ConfigureAwait(false);
 
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
     public void TryReset_SucceedsWhenNotInUse()
     {
-        var ev = new AsyncManualResetEvent(set: true);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(set: true, pool: pool);
 
         Assert.That(ev.IsSet, Is.True);
 
@@ -406,24 +396,21 @@ public class AsyncManualResetEventTests
     [Test]
     public async Task WaitAsyncWithTimeoutCompletesWhenSetBeforeTimeout()
     {
-        var tpvts = new TestObjectPool<bool>();
-        var ev = new AsyncManualResetEvent(pool: tpvts);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
 
         _ = Task.Run(async () => { await Task.Delay(50).ConfigureAwait(false); ev.Set(); });
 
         await ev.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(ev.InternalWaiterInUse, Is.False);
-            Assert.That(tpvts.ActiveCount, Is.Zero);
-        }
+        Assert.That(ev.InternalWaiterInUse, Is.False);
     }
 
     [Test, CancelAfter(3000)]
     public async Task WaitAsyncWithTimeoutThrowsWhenTimeoutElapses()
     {
-        var ev = new AsyncManualResetEvent();
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
 
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await ev.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
@@ -436,7 +423,8 @@ public class AsyncManualResetEventTests
     [Test]
     public async Task WaitAsyncWithZeroTimeoutThrowsImmediatelyWhenNotSet()
     {
-        var ev = new AsyncManualResetEvent();
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
 
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
@@ -445,7 +433,8 @@ public class AsyncManualResetEventTests
     [Test]
     public async Task WaitAsyncWithZeroTimeoutCompletesImmediatelyWhenSet()
     {
-        var ev = new AsyncManualResetEvent(set: true);
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(set: true, pool: pool);
 
         await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false);
 
@@ -455,7 +444,8 @@ public class AsyncManualResetEventTests
     [Test]
     public void WaitAsyncWithNegativeTimeoutThrows()
     {
-        var ev = new AsyncManualResetEvent();
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
 
 #pragma warning disable VSTHRD110
         Assert.Throws<ArgumentOutOfRangeException>(() => ev.WaitAsync(TimeSpan.FromMilliseconds(-2)));
@@ -465,7 +455,8 @@ public class AsyncManualResetEventTests
     [Test]
     public async Task WaitAsyncWithInfiniteTimeoutBehavesLikeWaitAsync()
     {
-        var ev = new AsyncManualResetEvent();
+        using var pool = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: pool);
 
         ev.Set();
 

--- a/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
@@ -350,4 +350,72 @@ public class AsyncManualResetEventTests
         Assert.That(ev.IsSet, Is.False);
         Assert.That(ev.RunContinuationAsynchronously, Is.True);
     }
+
+    [Test]
+    public async Task WaitAsyncWithTimeoutCompletesWhenSetBeforeTimeout()
+    {
+        var tpvts = new TestObjectPool<bool>();
+        var ev = new AsyncManualResetEvent(pool: tpvts);
+
+        _ = Task.Run(async () => { await Task.Delay(50).ConfigureAwait(false); ev.Set(); });
+
+        await ev.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        Assert.That(ev.InternalWaiterInUse, Is.False);
+        Assert.That(tpvts.ActiveCount, Is.Zero);
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task WaitAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var ev = new AsyncManualResetEvent();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await ev.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(ev.InternalWaiterInUse, Is.False);
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutThrowsImmediatelyWhenNotSet()
+    {
+        var ev = new AsyncManualResetEvent();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutCompletesImmediatelyWhenSet()
+    {
+        var ev = new AsyncManualResetEvent(set: true);
+
+        await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false);
+
+        Assert.That(ev.IsSet, Is.True);
+    }
+
+    [Test]
+    public void WaitAsyncWithNegativeTimeoutThrows()
+    {
+        var ev = new AsyncManualResetEvent();
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => ev.WaitAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task WaitAsyncWithInfiniteTimeoutBehavesLikeWaitAsync()
+    {
+        var ev = new AsyncManualResetEvent();
+
+        ev.Set();
+
+        await ev.WaitAsync(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+
+        Assert.That(ev.IsSet, Is.True);
+    }
 }

--- a/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
@@ -23,8 +23,11 @@ public class AsyncManualResetEventTests
     public void IsSetReflectsEventState()
     {
         var mre = new AsyncManualResetEvent(set: false);
-        Assert.That(mre.IsSet, Is.False);
-        Assert.That(mre.RunContinuationAsynchronously, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.IsSet, Is.False);
+            Assert.That(mre.RunContinuationAsynchronously, Is.True);
+        }
 
         mre.Set();
         Assert.That(mre.IsSet, Is.True);
@@ -68,8 +71,11 @@ public class AsyncManualResetEventTests
 
         await AsyncAssert.NeverCompletesAsync(task).ConfigureAwait(false);
 
-        Assert.That(mre.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Theory]
@@ -102,8 +108,11 @@ public class AsyncManualResetEventTests
 
         ValueTask task = mre.WaitAsync();
 
-        Assert.That(task.IsCompleted, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(task.IsCompleted, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -115,8 +124,11 @@ public class AsyncManualResetEventTests
         Task t1 = mre.WaitAsync().AsTask();
         Task t2 = mre.WaitAsync().AsTask();
 
-        Assert.That(mre.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        }
 
         mre.Set();
 
@@ -128,8 +140,11 @@ public class AsyncManualResetEventTests
             Assert.That(mre.IsSet, Is.True);
         }
 
-        Assert.That(mre.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -143,8 +158,11 @@ public class AsyncManualResetEventTests
 
         Task[] taskWaiters = Enumerable.Range(0, numberOfWaiters).Select(_ => mre.WaitAsync().AsTask()).ToArray();
 
-        Assert.That(mre.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(numberOfWaiters - 1));
+        }
 
         foreach (Task t in taskWaiters)
         {
@@ -161,8 +179,11 @@ public class AsyncManualResetEventTests
             Assert.That(mre.IsSet, Is.True);
         }
 
-        Assert.That(mre.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -180,8 +201,11 @@ public class AsyncManualResetEventTests
         Task wait = mre.WaitAsync().AsTask();
         await AsyncAssert.NeverCompletesAsync(wait).ConfigureAwait(false);
 
-        Assert.That(mre.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -195,8 +219,11 @@ public class AsyncManualResetEventTests
         Task wait = mre.WaitAsync().AsTask();
         await AsyncAssert.NeverCompletesAsync(wait).ConfigureAwait(false);
 
-        Assert.That(mre.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -216,8 +243,11 @@ public class AsyncManualResetEventTests
 
         await waiter.ConfigureAwait(false);
 
-        Assert.That(mre.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -234,9 +264,11 @@ public class AsyncManualResetEventTests
 
         await mre.WaitAsync().ConfigureAwait(false);
 
-        Assert.That(mre.IsSet, Is.True);
-
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mre.IsSet, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -252,8 +284,11 @@ public class AsyncManualResetEventTests
 
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -269,8 +304,11 @@ public class AsyncManualResetEventTests
 
         Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -286,8 +324,11 @@ public class AsyncManualResetEventTests
 
         await vt.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -301,23 +342,32 @@ public class AsyncManualResetEventTests
         var waiter2 = ev.WaitAsync(cts.Token);
         var waiter3 = ev.WaitAsync();
 
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(2));
+        }
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter2.ConfigureAwait(false));
 
-        Assert.That(ev.InternalWaiterInUse, Is.True);
-        Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.True);
+            Assert.That(tpvts.ActiveCount, Is.EqualTo(1));
+        }
 
         ev.Set();
 
         await waiter1.ConfigureAwait(false);
         await waiter3.ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -345,10 +395,12 @@ public class AsyncManualResetEventTests
         Assert.That(ev.IsSet, Is.True);
 
         bool reset = ev.TryReset();
-        Assert.That(reset, Is.True);
-
-        Assert.That(ev.IsSet, Is.False);
-        Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reset, Is.True);
+            Assert.That(ev.IsSet, Is.False);
+            Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        }
     }
 
     [Test]
@@ -361,8 +413,11 @@ public class AsyncManualResetEventTests
 
         await ev.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-        Assert.That(ev.InternalWaiterInUse, Is.False);
-        Assert.That(tpvts.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.InternalWaiterInUse, Is.False);
+            Assert.That(tpvts.ActiveCount, Is.Zero);
+        }
     }
 
     [Test, CancelAfter(3000)]

--- a/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
@@ -269,7 +269,9 @@ public class AsyncManualResetEventTests
 
         ValueTask vt = ev.WaitAsync(cts.Token);
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         using (Assert.EnterMultipleScope())
         {
@@ -290,7 +292,9 @@ public class AsyncManualResetEventTests
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         using (Assert.EnterMultipleScope())
         {
@@ -339,7 +343,9 @@ public class AsyncManualResetEventTests
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter2.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         using (Assert.EnterMultipleScope())
         {

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -24,6 +24,8 @@ using Threading.Tests.Pools;
    value = UpgradeableReader + (readerCount - 1). To get readerCount when >= UpgradeableReader: readerCount = status - UpgradeableReader + 1.
  - Writer (-1): exclusive writer holds the lock.
  - UpgradedWriter (-2): the upgradeable reader has upgraded to an exclusive writer.
+ - UpgradedWriterWithoutReader (-3): an upgraded writer is waiting for remaining readers to release
+  (occurs when the upgradeable reader is released before the upgrade completes).
 
  Events and transitions (high level):
  - Uncontested + ReaderLock -> Reader (1)
@@ -40,11 +42,16 @@ using Threading.Tests.Pools;
  - UpgradeableReader.EnterUpgradedWriter:
      * If it is the only holder (no other readers) -> UpgradedWriter (-2)
      * Otherwise enqueued in _waitingUpgradedWriters and will transition to UpgradedWriter when outstanding readers drop to zero (and writers have priority)
- - UpgradedWriter release ->
-     * Set status back to UpgradeableReader (or wake readers if no writers waiting) and possibly wake reader chain
+ - UpgradedWriter release:
+    * If no other readers but waiting writers exist -> Demote to Writer with next writer
+    * If no other readers and no writers but waiting upgradeable readers exist -> Demote to UpgradeableReader
+    * If no waiting tasks exist -> Uncontested
+    * If upgraded writer was entered with remaining readers (not from UpgradeableReader but after dispose):
+      - Status becomes UpgradedWriterWithoutReader
+      - Waiting writers are prioritized over other waiters
 
- Cancellation semantics:
- - If a waiter is cancelled while queued, it is removed from its WaiterQueue and a TaskCanceledException is set on the waiter.
+ Cancellation and timeout semantics:
+ - If a waiter is cancelled while queued, it is removed from its WaiterQueue and a OperationCanceledException is set on the waiter.
  - Cancellations do not modify _status unless the waiter had already been granted the lock (in which case disposal/release logic applies).
 
  Priority rules:
@@ -73,16 +80,37 @@ public class AsyncReaderWriterLockTests
         new object[] { "RunContAsync" }
     ];
 
+    /// <summary>
+    /// Default timeout TimeSpans to test.
+    /// </summary>
+    public static readonly TimeSpan[] TimeoutTestArgs =
+    [
+        Timeout.InfiniteTimeSpan,
+        TimeSpan.FromSeconds(10),
+    ];
+
+    /// <summary>
+    /// Default timeout TimeSpans to test.
+    /// </summary>
+    public static readonly TimeSpan[] TimeoutTestArgsWithZero =
+    [
+        TimeSpan.Zero,
+        Timeout.InfiniteTimeSpan,
+        TimeSpan.FromSeconds(10),
+    ];
+
     public AsyncReaderWriterLockTests(string runContinuationAsync)
     {
         RunContinuationAsynchronously = runContinuationAsync == "RunContAsync";
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task SingleReaderAcquiresImmediately(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgsWithZero)), CancelAfter(CancelAfterMS)]
+    public async Task SingleReaderAcquiresImmediately(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         var lockTask = rwLock.ReaderLockAsync(ct);
         Assert.That(lockTask.IsCompleted, Is.True);
@@ -104,13 +132,15 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task SingleWriterAcquiresImmediately(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgsWithZero)), CancelAfter(CancelAfterMS)]
+    public async Task SingleWriterAcquiresImmediately(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
-        var lockTask = rwLock.WriterLockAsync(ct);
+        var lockTask = rwLock.WriterLockAsync(timeout, ct);
         Assert.That(lockTask.IsCompleted, Is.True);
 
         using (await lockTask.ConfigureAwait(false))
@@ -125,13 +155,15 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.IsWriteLockHeld, Is.False);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task SingleUpgradeableReaderAcquiresImmediately(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgsWithZero)), CancelAfter(CancelAfterMS)]
+    public async Task SingleUpgradeableReaderAcquiresImmediately(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
-        var lockTask = rwLock.UpgradeableReaderLockAsync(ct);
+        var lockTask = rwLock.UpgradeableReaderLockAsync(timeout, ct);
         Assert.That(lockTask.IsCompleted, Is.True);
 
         using (await lockTask.ConfigureAwait(false))
@@ -147,15 +179,17 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.IsWriteLockHeld, Is.False);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task MultipleReadersCanAcquireConcurrently(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task MultipleReadersCanAcquireConcurrently(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
-        using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
-        using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
-        using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
+        using (await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
+        using (await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
             using (Assert.EnterMultipleScope())
             {
@@ -167,15 +201,17 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.CurrentReaderCount, Is.Zero);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task MultipleReadersCanDisposeOutOfOrder(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task MultipleReadersCanDisposeOutOfOrder(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
-        var lockTask1 = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
-        var lockTask2 = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
-        var lockTask3 = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
+        var lockTask1 = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false);
+        var lockTask2 = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false);
+        var lockTask3 = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false);
 
         using (Assert.EnterMultipleScope())
         {
@@ -268,17 +304,18 @@ public class AsyncReaderWriterLockTests
         Assert.That(pool.ActiveCount, Is.Zero);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task WriterBlocksReaders(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task WriterBlocksReaders(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> readerTask;
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            readerTask = rwLock.ReaderLockAsync(ct);
+            readerTask = rwLock.ReaderLockAsync(timeout, ct);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(readerTask.IsCompleted, Is.False);
@@ -298,17 +335,18 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task WriterBlocksUpgradeableReaders(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task WriterBlocksUpgradeableReaders(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> upgradeableReaderTask;
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            upgradeableReaderTask = rwLock.UpgradeableReaderLockAsync(ct);
+            upgradeableReaderTask = rwLock.UpgradeableReaderLockAsync(timeout, ct);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(upgradeableReaderTask.IsCompleted, Is.False);
@@ -328,17 +366,18 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task UpgradeableReaderBlocksUpgradeableReaders(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task UpgradeableReaderBlocksUpgradeableReaders(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> upgradeableReaderTask;
-        using (await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            upgradeableReaderTask = rwLock.UpgradeableReaderLockAsync(ct);
+            upgradeableReaderTask = rwLock.UpgradeableReaderLockAsync(timeout, ct);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(upgradeableReaderTask.IsCompleted, Is.False);
@@ -358,17 +397,18 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task ReadersBlockWriter(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task ReadersBlockWriter(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> writerTask;
-        using (var readerReleaser = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+        using (var readerReleaser = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            writerTask = rwLock.WriterLockAsync(ct);
+            writerTask = rwLock.WriterLockAsync(timeout, ct);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(writerTask.IsCompleted, Is.False);
@@ -388,18 +428,20 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task WriterPriorityOverNewReaders(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task WriterPriorityOverNewReaders(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         var order = new ConcurrentQueue<string>();
 
-        using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
             var writerTask = Task.Run(async () => {
-                using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+                using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
                 {
                     order.Enqueue("writer");
                 }
@@ -408,7 +450,7 @@ public class AsyncReaderWriterLockTests
             await Task.Delay(50, ct).ConfigureAwait(false);
 
             var readerTask = Task.Run(async () => {
-                using (await rwLock.ReaderLockAsync().ConfigureAwait(false))
+                using (await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
                 {
                     order.Enqueue("reader");
                 }
@@ -431,20 +473,21 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task WriterReleasesAllPendingReaders(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task WriterReleasesAllPendingReaders(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> r1, r2, r3;
 
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            r1 = rwLock.ReaderLockAsync(ct);
-            r2 = rwLock.ReaderLockAsync(ct);
-            r3 = rwLock.ReaderLockAsync(ct);
+            r1 = rwLock.ReaderLockAsync(timeout, ct);
+            r2 = rwLock.ReaderLockAsync(timeout, ct);
+            r3 = rwLock.ReaderLockAsync(timeout, ct);
 
             using (Assert.EnterMultipleScope())
             {
@@ -464,24 +507,25 @@ public class AsyncReaderWriterLockTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(rwLock.CurrentReaderCount, Is.Zero);
-
             Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
             Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
             Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task ReaderReleaseCancellationThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task ReaderReleaseCancellationThrows(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using var cts = new CancellationTokenSource();
 
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            var readerTask = rwLock.ReaderLockAsync(cts.Token);
+            var readerTask = rwLock.ReaderLockAsync(timeout, cts.Token);
             Assert.That(readerTask.IsCompleted, Is.False);
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -500,17 +544,19 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task UpgradedReaderReleaseCancellationThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task UpgradedReaderReleaseCancellationThrows(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using var cts = new CancellationTokenSource();
 
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            var readerTask = rwLock.UpgradeableReaderLockAsync(cts.Token);
+            var readerTask = rwLock.UpgradeableReaderLockAsync(timeout, cts.Token);
             Assert.That(readerTask.IsCompleted, Is.False);
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -529,17 +575,19 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task WriterReleaseCancellationThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task WriterReleaseCancellationThrows(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using var cts = new CancellationTokenSource();
 
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            var writerTask = rwLock.WriterLockAsync(cts.Token);
+            var writerTask = rwLock.WriterLockAsync(timeout, cts.Token);
             Assert.That(writerTask.IsCompleted, Is.False);
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -558,18 +606,20 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task UpgradedWriterReleaseCancellationThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task UpgradedWriterReleaseCancellationThrows(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using var cts = new CancellationTokenSource();
 
-        using (var upgradeableReleaser = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
-        using (await upgradeableReleaser.UpgradeToWriterLockAsync(ct).ConfigureAwait(false))
+        using (var upgradeableReleaser = await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false))
+        using (await upgradeableReleaser.UpgradeToWriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            var writerTask = rwLock.WriterLockAsync(cts.Token);
+            var writerTask = rwLock.WriterLockAsync(timeout, cts.Token);
             Assert.That(writerTask.IsCompleted, Is.False);
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -588,18 +638,21 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task PreCancelledReaderThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task PreCancelledReaderThrows(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using var cts = new CancellationTokenSource();
 
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-            var readerTask = rwLock.ReaderLockAsync(cts.Token);
+            var readerTask = rwLock.ReaderLockAsync(timeout, cts.Token);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(readerTask.IsCompleted, Is.True);
@@ -608,18 +661,21 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task PreCancelledUpgradeableReaderThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task PreCancelledUpgradeableReaderThrows(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using var cts = new CancellationTokenSource();
 
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-            var readerTask = rwLock.UpgradeableReaderLockAsync(cts.Token);
+            var readerTask = rwLock.UpgradeableReaderLockAsync(timeout, cts.Token);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(readerTask.IsCompleted, Is.True);
@@ -628,18 +684,20 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task PreCancelledWriterThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task PreCancelledWriterThrows(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
         using var cts = new CancellationTokenSource();
 
         using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
         {
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-            var writerTask = rwLock.WriterLockAsync(cts.Token);
+            var writerTask = rwLock.WriterLockAsync(timeout, cts.Token);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(writerTask.IsCompleted, Is.True);
@@ -665,7 +723,11 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public void ReleaserEquality(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         var releaser1 = rwLock.ReaderLockAsync(ct).AsTask().GetAwaiter().GetResult();
         var releaser2 = rwLock.ReaderLockAsync(ct).AsTask().GetAwaiter().GetResult();
 
@@ -683,21 +745,22 @@ public class AsyncReaderWriterLockTests
         releaser2.Dispose();
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task UpgradeableStateTransitions(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task UpgradeableStateTransitions(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire an upgradeable reader and another regular reader
-        using (var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
+        using (var upgr = await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
             ValueTask<AsyncReaderWriterLock.Releaser> upgradeTask;
-            using (var regular = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+            using (var regular = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
             {
                 // Upgrade should wait while the other reader is present
-                upgradeTask = upgr.UpgradeToWriterLockAsync(ct);
+                upgradeTask = upgr.UpgradeToWriterLockAsync(timeout, ct);
                 using (Assert.EnterMultipleScope())
                 {
                     Assert.That(upgradeTask.IsCompleted, Is.False);
@@ -730,21 +793,22 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.CurrentReaderCount, Is.Zero);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task MultipleUpgradedWritersAreSerialized(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task MultipleUpgradedWritersAreSerialized(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> t1;
         ValueTask<AsyncReaderWriterLock.Releaser> t2;
 
         // Hold writer to force upgradeable readers to queue, dispose immediately after enqueuing
-        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            t1 = rwLock.UpgradeableReaderLockAsync(ct);
-            t2 = rwLock.UpgradeableReaderLockAsync(ct);
+            t1 = rwLock.UpgradeableReaderLockAsync(timeout, ct);
+            t2 = rwLock.UpgradeableReaderLockAsync(timeout, ct);
 
             Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.EqualTo(2));
 
@@ -778,35 +842,38 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.False);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task EnterUpgradedWriter_OnNonUpgradeable_Throws(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task EnterUpgradedWriter_OnNonUpgradeable_Throws(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Reader releaser should not allow upgrading
-        using (var reader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+        using (var reader = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.UpgradeToWriterLockAsync().ConfigureAwait(false));
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.UpgradeToWriterLockAsync(timeout).ConfigureAwait(false));
         }
 
         // Default (uninitialized) releaser should also throw
         var none = default(AsyncReaderWriterLock.Releaser);
-        Assert.ThrowsAsync<InvalidOperationException>(async () => await none.UpgradeToWriterLockAsync().ConfigureAwait(false));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await none.UpgradeToWriterLockAsync(timeout).ConfigureAwait(false));
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task WaitingCountsAndInternalFlagsAfterUpgradeAndCancellation(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task WaitingCountsAndInternalFlagsAfterUpgradeAndCancellation(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
-        using var writer = await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
+        using var writer = await rwLock.WriterLockAsync(timeout, ct).ConfigureAwait(false);
 
         // queue an upgradeable reader with cancellation
         using var cts = new CancellationTokenSource();
-        var waiting = rwLock.UpgradeableReaderLockAsync(cts.Token);
+        var waiting = rwLock.UpgradeableReaderLockAsync(timeout, cts.Token);
         Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.EqualTo(1));
 
         // cancel and ensure waiter cleaned up
@@ -817,19 +884,20 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.InternalUpgradeableReaderWaiterInUse, Is.False);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task EnterUpgradedWriterCancellation_WhenWaiting(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task EnterUpgradedWriterCancellation_WhenWaiting(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and another regular reader to block upgrade
-        using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
-        var otherReader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false);
+        var otherReader = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false);
 
         using var cts = new CancellationTokenSource();
-        var upgradeAttempt = upgr.UpgradeToWriterLockAsync(cts.Token);
+        ValueTask<AsyncReaderWriterLock.Releaser> upgradeAttempt = upgr.UpgradeToWriterLockAsync(timeout, cts.Token);
         Assert.That(upgradeAttempt.IsCompleted, Is.False);
 
         // cancel the upgrade attempt and ensure it is removed from waiter queue
@@ -849,15 +917,17 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task EnterUpgradedWriter_OnUpgradedReleaser_Throws(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task EnterUpgradedWriter_OnUpgradedReleaser_Throws(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and upgrade to writer
-        using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
-        using (var upgWriter = await upgr.UpgradeToWriterLockAsync(ct).ConfigureAwait(false))
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false);
+        using (var upgWriter = await upgr.UpgradeToWriterLockAsync(timeout, ct).ConfigureAwait(false))
         {
             // The returned releaser is an UpgradedWriter and must not be allowed to call EnterUpgradedWriterLockAsync()
             Assert.ThrowsAsync<InvalidOperationException>(async () => await upgWriter.UpgradeToWriterLockAsync().ConfigureAwait(false));
@@ -867,18 +937,21 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task PreCancelledEnterUpgradedWriterThrows(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task PreCancelledEnterUpgradedWriterThrows(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
         AsyncReaderWriterLock.Releaser releaser;
-        using (var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
+        using (var upgr = await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            var writer = upgr.UpgradeToWriterLockAsync(cts.Token);
+            var writer = upgr.UpgradeToWriterLockAsync(timeout, cts.Token);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(writer.IsCompleted, Is.True);
@@ -889,16 +962,17 @@ public class AsyncReaderWriterLockTests
         releaser.Dispose();
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task CancelWaitingUpgradedWriter_CleansUp(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task CancelWaitingUpgradedWriter_CleansUp(TimeSpan timeout, CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and another regular reader to block upgrade
-        using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
-        var otherReader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false);
+        var otherReader = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false);
 
         using var cts = new CancellationTokenSource();
         var upgradeAttempt = upgr.UpgradeToWriterLockAsync(cts.Token);
@@ -926,11 +1000,13 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task ReaderWhileUpgradeableWaiting_BlockedWhenWriterWaiting(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task ReaderWhileUpgradeableWaiting_BlockedWhenWriterWaiting(TimeSpan timeout, CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Hold a writer briefly to force the upgradeable request to queue behind it
         ValueTask<AsyncReaderWriterLock.Releaser> upgradeableTask1;
@@ -938,18 +1014,18 @@ public class AsyncReaderWriterLockTests
         ValueTask<AsyncReaderWriterLock.Releaser> r1Task;
         ValueTask<AsyncReaderWriterLock.Releaser> r2Task;
 
-        using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false))
         {
-            upgradeableTask1 = rwLock.UpgradeableReaderLockAsync(ct);
+            upgradeableTask1 = rwLock.UpgradeableReaderLockAsync(timeout, ct);
             Assert.That(upgradeableTask1.IsCompleted, Is.True);
 
-            upgradeableTask2 = rwLock.UpgradeableReaderLockAsync(ct);
+            upgradeableTask2 = rwLock.UpgradeableReaderLockAsync(timeout, ct);
             Assert.That(upgradeableTask2.IsCompleted, Is.False);
 
-            r1Task = rwLock.ReaderLockAsync(ct);
+            r1Task = rwLock.ReaderLockAsync(timeout, ct);
             Assert.That(r1Task.IsCompleted, Is.True);
 
-            r2Task = rwLock.ReaderLockAsync(ct);
+            r2Task = rwLock.ReaderLockAsync(timeout, ct);
             Assert.That(r2Task.IsCompleted, Is.True);
         }
 
@@ -964,7 +1040,10 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task NewReadersBlockedDuringUpgradedWriterQueue(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
         var otherReader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
@@ -989,7 +1068,9 @@ public class AsyncReaderWriterLockTests
     public async Task CancelWaitingUpgradeDoesNotLoseWake(CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using var cts = new CancellationTokenSource();
         ValueTask<AsyncReaderWriterLock.Releaser> t1;
@@ -1008,11 +1089,9 @@ public class AsyncReaderWriterLockTests
 
 #pragma warning disable CHT001 // ValueTask awaited multiple times
         Assert.ThrowsAsync<OperationCanceledException>(async () => await t2.ConfigureAwait(false));
+#pragma warning restore CHT001 // ValueTask awaited multiple times
         using (Assert.EnterMultipleScope())
         {
-#pragma warning restore CHT001 // ValueTask awaited multiple times
-
-
             Assert.That(rwLock.InternalUpgradeableReaderWaiterInUse, Is.False);
             Assert.That(pool.ActiveCount, Is.Zero);
         }
@@ -1022,7 +1101,10 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task DisposeUpgradeableReaderWhileUpgradedWriterRuns(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and upgrade to writer immediately (no other readers)
         var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
@@ -1047,7 +1129,10 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task SerializedUpgradedWriterHandoffsDisposeBetweenRuns(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and enqueue two upgrades
         var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
@@ -1081,7 +1166,10 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task SerializedUpgradedWriterBlockingReaderHandoffsDisposeBetweenRuns(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and enqueue two upgrades
         var reader1 = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
@@ -1121,8 +1209,12 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task Releaser_EqualsAndHashCode(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        using var r = await rw.ReaderLockAsync(ct).ConfigureAwait(false);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var r = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
         object boxed = r;
         Assert.That(r, Is.EqualTo(boxed));
         var copy = r;
@@ -1133,52 +1225,61 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task PreCancelledUpgradeToWriter_IsCanceled(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task PreCancelledUpgradeToWriter_IsCanceled(TimeSpan timeout, CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        using var upgr = await rw.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
-        using var other = await rw.ReaderLockAsync(ct).ConfigureAwait(false);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(timeout, ct).ConfigureAwait(false);
+        using var other = await rwLock.ReaderLockAsync(timeout, ct).ConfigureAwait(false);
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var vt = upgr.UpgradeToWriterLockAsync(cts.Token);
+        var vt = upgr.UpgradeToWriterLockAsync(timeout, cts.Token);
         Assert.That(vt.IsCompleted, Is.True);
 #pragma warning disable CHT001
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
 #pragma warning restore CHT001
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task PreCancelledWriter_IsCanceled(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task PreCancelledWriter_IsCanceled(TimeSpan timeout, CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        using var r = await rw.ReaderLockAsync(ct).ConfigureAwait(false);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var r = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var vt = rw.WriterLockAsync(cts.Token);
+        var vt = rwLock.WriterLockAsync(timeout, cts.Token);
         Assert.That(vt.IsCompleted, Is.True);
 #pragma warning disable CHT001
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
 #pragma warning restore CHT001
     }
 
-    [Test]
-    [CancelAfter(CancelAfterMS)]
-    public async Task PreCancelledUpgradeableReader_IsCanceled(CancellationToken ct)
+    [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
+    public async Task PreCancelledUpgradeableReader_IsCanceled(TimeSpan timeout, CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        using var writer = await rw.WriterLockAsync(ct).ConfigureAwait(false);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var writer = await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var vt = rw.UpgradeableReaderLockAsync(cts.Token);
+        var vt = rwLock.UpgradeableReaderLockAsync(timeout, cts.Token);
         Assert.That(vt.IsCompleted, Is.True);
 #pragma warning disable CHT001
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
@@ -1189,15 +1290,19 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task WaitingUpgradedWriterCount_IncrementsWhenQueued(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        using var upgr = await rw.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
-        var other = await rw.ReaderLockAsync(ct).ConfigureAwait(false);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
+        var other = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
 
         var attempt = upgr.UpgradeToWriterLockAsync(ct);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(attempt.IsCompleted, Is.False);
-            Assert.That(rw.WaitingUpgradedWriterCount, Is.EqualTo(1));
+            Assert.That(rwLock.WaitingUpgradedWriterCount, Is.EqualTo(1));
         }
 
         other.Dispose();
@@ -1208,16 +1313,20 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReleaseUpgradedWriter_WakesUpgradeableWhenWithoutReader(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        var upgr = await rw.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
         var upgWriter = await upgr.UpgradeToWriterLockAsync(ct).ConfigureAwait(false);
 
         // queue a waiting upgradeable reader while upgraded writer holds
-        var tWaiting = rw.UpgradeableReaderLockAsync(ct);
+        var tWaiting = rwLock.UpgradeableReaderLockAsync(ct);
 
         // dispose upgradeable releaser to move to UpgradedWriterWithoutReader
         upgr.Dispose();
-        Assert.That(rw.IsUpgradeableReadLockHeld, Is.False);
+        Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
 
         // release upgraded writer which should wake the waiting upgradeable reader
         upgWriter.Dispose();
@@ -1228,12 +1337,16 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReleaseUpgradedWriter_WakesWriterWhenWaitingAndWithoutReader(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        var upgr = await rw.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
         var upgWriter = await upgr.UpgradeToWriterLockAsync(ct).ConfigureAwait(false);
 
         // queue a regular writer while upgraded writer holds
-        var writerWaiting = rw.WriterLockAsync(ct);
+        var writerWaiting = rwLock.WriterLockAsync(ct);
 
         // dispose upgradeable to set UpgradedWriterWithoutReader
         upgr.Dispose();
@@ -1246,8 +1359,12 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task WriterLock_FastPathCompletes(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
-        var vt = rw.WriterLockAsync(ct);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        var vt = rwLock.WriterLockAsync(ct);
         Assert.That(vt.IsCompleted, Is.True);
         using (await vt.ConfigureAwait(false)) { }
     }
@@ -1256,13 +1373,18 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReleaseReader_WakesQueuedReaders(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Hold writer so readers queue
-        using (await rw.WriterLockAsync(ct).ConfigureAwait(false))
+        ValueTask<AsyncReaderWriterLock.Releaser> r1;
+        ValueTask<AsyncReaderWriterLock.Releaser> r2;
+        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
         {
-            var r1 = rw.ReaderLockAsync(TimeSpan.FromSeconds(1), ct);
-            var r2 = rw.ReaderLockAsync(ct);
+            r1 = rwLock.ReaderLockAsync(TimeSpan.FromSeconds(1), ct);
+            r2 = rwLock.ReaderLockAsync(ct);
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(r1.IsCompleted, Is.False);
@@ -1273,20 +1395,25 @@ public class AsyncReaderWriterLockTests
             await Task.Delay(1, ct).ConfigureAwait(false);
         }
 
-        using (await rw.ReaderLockAsync(ct).ConfigureAwait(false)) { }
+        using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false)) { }
+        (await r1.ConfigureAwait(false)).Dispose();
+        (await r2.AsTask().ConfigureAwait(false)).Dispose();
     }
 
     [Test]
     [CancelAfter(CancelAfterMS)]
     public async Task NonCancelableWaiter_RegistersDefault(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Hold a writer so the next writer request will queue with a non-cancelable token
         ValueTask<AsyncReaderWriterLock.Releaser> vt;
-        using (await rw.WriterLockAsync(ct).ConfigureAwait(false))
+        using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
         {
-            vt = rw.WriterLockAsync(CancellationToken.None);
+            vt = rwLock.WriterLockAsync(CancellationToken.None);
             Assert.That(vt.IsCompleted, Is.False);
         }
 
@@ -1298,18 +1425,21 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReleaseReader_CompareExchangeFallthroughScenario(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Scenario: have upgradeable reader + extra reader so that ReleaseReader tries to promote upgraded writer
-        using var upgr = await rw.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
-        var r = await rw.ReaderLockAsync(ct).ConfigureAwait(false);
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
+        var r = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
 
         // queue an upgraded writer which will wait due to additional reader
         var upgradeAttempt = upgr.UpgradeToWriterLockAsync(ct);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(upgradeAttempt.IsCompleted, Is.False);
-            Assert.That(rw.WaitingUpgradedWriterCount, Is.EqualTo(1));
+            Assert.That(rwLock.WaitingUpgradedWriterCount, Is.EqualTo(1));
         }
 
         // Now dispose the extra reader to allow the upgrade to proceed and exercise the CompareExchange path
@@ -1321,14 +1451,17 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReleaseUpgradedWriter_WriterWakeWhenWithoutReaderScenario(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and upgrade to writer
-        var upgr = await rw.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
+        var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
         var upgWriter = await upgr.UpgradeToWriterLockAsync(ct).ConfigureAwait(false);
 
         // While upgraded writer holds, queue a regular writer and dispose the upgradeable to enter WithoutReader state
-        var writerWaiting = rw.WriterLockAsync(ct);
+        var writerWaiting = rwLock.WriterLockAsync(ct);
         upgr.Dispose();
 
         // Now release upgraded writer and ensure a waiting writer is granted
@@ -1340,11 +1473,14 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReleaseUpgradeableReader_CompareExchangeFallback(CancellationToken ct)
     {
-        var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire upgradeable reader and queue an upgraded writer, then a waiting upgradeable reader behind it
         ValueTask<AsyncReaderWriterLock.Releaser> waitingUpgr;
-        using (var upgr = await rw.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
+        using (var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
         {
             var upgAttempt = upgr.UpgradeToWriterLockAsync(ct);
             Assert.That(upgAttempt.IsCompleted, Is.True);
@@ -1352,7 +1488,7 @@ public class AsyncReaderWriterLockTests
             using (await upgAttempt.ConfigureAwait(false)) { }
 
             // Queue another upgradeable reader which should wait
-            waitingUpgr = rw.UpgradeableReaderLockAsync(ct);
+            waitingUpgr = rwLock.UpgradeableReaderLockAsync(ct);
             Assert.That(waitingUpgr.IsCompleted, Is.False);
 
             // Dispose the original upgradeable reader to exercise fallback in ReleaseUpgradeableReader
@@ -1366,7 +1502,11 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public void DoubleDisposeReleaser_IsNoop(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         var releaser = rwLock.ReaderLockAsync(ct).AsTask().GetAwaiter().GetResult();
         releaser.Dispose();
         // second dispose throws object disposed
@@ -1474,6 +1614,32 @@ public class AsyncReaderWriterLockTests
         {
             Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.False);
             Assert.That(rwLock.IsWriteLockHeld, Is.False);
+        }
+    }
+
+    [CancelAfter(CancelAfterMS)]
+    public async Task UpgradeableReaderToWriterSuccess(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using (var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
+        {
+            Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
+            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+
+            using var writer = await upgr.UpgradeToWriterLockAsync(ct).ConfigureAwait(false);
+            Assert.That(rwLock.IsWriteLockHeld, Is.True);
+            Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+            Assert.That(rwLock.IsWriteLockHeld, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -1589,7 +1755,7 @@ public class AsyncReaderWriterLockTests
     }
 
     [Test, CancelAfter(CancelAfterMS)]
-    [Repeat(50)]
+    [Repeat(5)]
     public async Task LastReaderNextReaderRaceDoesNotAdmitWriterEarlyAsync(
         CancellationToken ct)
     {

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -1263,5 +1263,107 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.False);
         Assert.That(rwLock.IsWriteLockHeld, Is.False);
     }
+
+    [Test]
+    public async Task ReaderLockAsyncWithTimeoutCompletesWhenLockAvailable()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        using (await rwLock.ReaderLockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
+        {
+            Assert.That(rwLock.IsReadLockHeld);
+        }
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task ReaderLockAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        using var outerWriter = await rwLock.WriterLockAsync().ConfigureAwait(false);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await rwLock.ReaderLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+    }
+
+    [Test]
+    public void ReaderLockAsyncWithNegativeTimeoutThrows()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.ReaderLockAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task WriterLockAsyncWithTimeoutCompletesWhenLockAvailable()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        using (await rwLock.WriterLockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
+        {
+            Assert.That(rwLock.IsWriteLockHeld);
+        }
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task WriterLockAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        using var outerReader = await rwLock.ReaderLockAsync().ConfigureAwait(false);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+    }
+
+    [Test]
+    public void WriterLockAsyncWithNegativeTimeoutThrows()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task UpgradeableReaderLockAsyncWithTimeoutCompletesWhenLockAvailable()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        using (await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
+        {
+            Assert.That(rwLock.IsUpgradeableReadLockHeld);
+        }
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task UpgradeableReaderLockAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+        using var outerUpgr = await rwLock.UpgradeableReaderLockAsync().ConfigureAwait(false);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+    }
+
+    [Test]
+    public void UpgradeableReaderLockAsyncWithNegativeTimeoutThrows()
+    {
+        var rwLock = new AsyncReaderWriterLock();
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
 }
 

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -10,7 +10,6 @@ using CryptoHives.Foundation.Threading.Async.Pooled;
 using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Threading.Tests.Pools;
@@ -1513,19 +1512,6 @@ public class AsyncReaderWriterLockTests
     }
 
     [Test]
-    public void ReaderLockAsyncWithNegativeTimeoutThrows()
-    {
-        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(
-            runContinuationAsynchronously: RunContinuationAsynchronously,
-            pool: pool);
-
-#pragma warning disable VSTHRD110
-        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.ReaderLockAsync(TimeSpan.FromMilliseconds(-2)));
-#pragma warning restore VSTHRD110
-    }
-
-    [Test]
     public async Task WriterLockAsyncWithTimeoutCompletesWhenLockAvailable()
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
@@ -1555,57 +1541,205 @@ public class AsyncReaderWriterLockTests
         await Task.Delay(50).ConfigureAwait(false);
     }
 
-    [Test]
-    public void WriterLockAsyncWithNegativeTimeoutThrows()
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task UpgradeableReaderLockAsyncWithTimeoutCompletesWhenLockAvailable(CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(
             runContinuationAsynchronously: RunContinuationAsynchronously,
             pool: pool);
 
-#pragma warning disable VSTHRD110
-        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(-2)));
-#pragma warning restore VSTHRD110
-    }
-
-    [Test]
-    public async Task UpgradeableReaderLockAsyncWithTimeoutCompletesWhenLockAvailable()
-    {
-        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
-        var rwLock = new AsyncReaderWriterLock(
-            runContinuationAsynchronously: RunContinuationAsynchronously,
-            pool: pool);
-
-        using (await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
+        using (await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false))
         {
             Assert.That(rwLock.IsUpgradeableReadLockHeld);
         }
     }
 
     [Test, CancelAfter(CancelAfterMS)]
-    public async Task UpgradeableReaderLockAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    public async Task UpgradeableReaderLockAsyncWithTimeoutThrowsWhenTimeoutElapses(CancellationToken ct)
     {
         using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(
             runContinuationAsynchronously: RunContinuationAsynchronously,
             pool: pool);
 
-        using var outerUpgr = await rwLock.UpgradeableReaderLockAsync().ConfigureAwait(false);
+        using var outerUpgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
 
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+            await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(100), ct).ConfigureAwait(false));
 
-        await Task.Delay(50).ConfigureAwait(false);
+        await Task.Delay(50, ct).ConfigureAwait(false);
     }
 
-    [Test]
-    public void UpgradeableReaderLockAsyncWithNegativeTimeoutThrows()
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task LocksWithNegativeTimeoutThrows(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
 #pragma warning disable VSTHRD110
-        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(-2)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(-2), ct));
+        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.ReaderLockAsync(TimeSpan.FromMilliseconds(-2), ct));
+        Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(-2), ct));
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(100), ct).ConfigureAwait(false);
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await upgr.UpgradeToWriterLockAsync(TimeSpan.FromMilliseconds(-2), ct).ConfigureAwait(false));
+        using var writerlock = await upgr.UpgradeToWriterLockAsync(TimeSpan.FromMilliseconds(100), ct).ConfigureAwait(false);
 #pragma warning restore VSTHRD110
+    }
+
+    [Test, CancelAfter(CancelAfterMS)]
+    [Repeat(50)]
+    public async Task LastReaderNextReaderRaceDoesNotAdmitWriterEarlyAsync(
+        CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+        int activeReaders = 0;
+        int maxObservedReadersInsideWriter = 0;
+
+        // Start concurrent readers.
+        using var churnCts = CancellationTokenSource
+            .CreateLinkedTokenSource(ct);
+        var concurrency = new Task[Environment.ProcessorCount];
+        for (int i = 0; i < concurrency.Length; i++)
+        {
+            concurrency[i] = Task.Run(async () => {
+                while (!churnCts.IsCancellationRequested)
+                {
+                    using AsyncReaderWriterLock.Releaser r =
+                        await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
+                    Interlocked.Increment(ref activeReaders);
+                    await Task.Yield();
+                    Interlocked.Decrement(ref activeReaders);
+                }
+            }, churnCts.Token);
+        }
+
+        // Force writer acquisitions and check race conditions.
+        for (int round = 0; round < 2000; round++)
+        {
+            using AsyncReaderWriterLock.Releaser w = await rwLock
+                .WriterLockAsync(ct).ConfigureAwait(false);
+            int observed = Volatile.Read(ref activeReaders);
+            if (observed > maxObservedReadersInsideWriter)
+            {
+                maxObservedReadersInsideWriter = observed;
+            }
+            Assert.That(observed, Is.Zero,
+                $"Writer #{round} observed {observed} active readers");
+            await Task.Yield();
+        }
+
+        await AsyncAssert.CancelAsync(churnCts).ConfigureAwait(false);
+        try
+        {
+            await Task.WhenAll(concurrency).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on shutdown
+        }
+
+        Assert.That(maxObservedReadersInsideWriter, Is.Zero);
+    }
+
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task WriterCancellationDoesNotLeakAsTask(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using (AsyncReaderWriterLock.Releaser reader =
+            await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+        {
+            using var writerCts = new CancellationTokenSource();
+            Task<AsyncReaderWriterLock.Releaser> writer =
+                rwLock.WriterLockAsync(writerCts.Token).AsTask();
+
+            // Ensure the writer has reached the drain wait.
+            await Task.Delay(50, ct).ConfigureAwait(false);
+            Assert.That(writer.IsCompleted, Is.False);
+
+            // Cancel the writer while draining.
+            await AsyncAssert.CancelAsync(writerCts).ConfigureAwait(false);
+            Assert.That(async () => await writer.ConfigureAwait(false),
+                Throws.InstanceOf<OperationCanceledException>());
+        }
+
+        using var nextWriter =
+            await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
+    }
+
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task WriterCancellationDoesNotLeakPreserved(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using (AsyncReaderWriterLock.Releaser reader =
+            await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+        {
+            using var writerCts = new CancellationTokenSource();
+            ValueTask<AsyncReaderWriterLock.Releaser> writer =
+                rwLock.WriterLockAsync(writerCts.Token).Preserve();
+
+            // Ensure the writer has reached the drain wait.
+            await Task.Delay(50, ct).ConfigureAwait(false);
+            Assert.That(writer.IsCompleted, Is.False);
+
+            // Cancel the writer while draining.
+            await AsyncAssert.CancelAsync(writerCts).ConfigureAwait(false);
+            Assert.That(async () => await writer.ConfigureAwait(false),
+                Throws.InstanceOf<OperationCanceledException>());
+        }
+
+        using var nextWriter =
+            await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
+    }
+
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task ReaderWriterTimeOutWhenBlocked(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using AsyncReaderWriterLock.Releaser outer =
+            await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
+
+        using var innerCts = CancellationTokenSource
+            .CreateLinkedTokenSource(ct);
+        innerCts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await rwLock
+                .WriterLockAsync(innerCts.Token)
+                .ConfigureAwait(false));
+
+        Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await rwLock
+                .WriterLockAsync(TimeSpan.FromMilliseconds(100), ct)
+                .ConfigureAwait(false));
+
+        Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await rwLock
+                .ReaderLockAsync(TimeSpan.FromMilliseconds(100), ct)
+                .ConfigureAwait(false));
+
+        Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await rwLock
+                .UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(100), ct)
+                .ConfigureAwait(false));
     }
 }
 

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -209,11 +209,73 @@ public class AsyncReaderWriterLockTests
         }
     }
 
+    [TestCase(32)]
+    [TestCase(256)]
+    [CancelAfter(CancelAfterMS)]
+    public async Task ParallelReadersWithUpgradeableReaderAdmitted(int contention, CancellationToken ct)
+    {
+        // Spin up readers in parallel
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+        var startGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        int holdingCount = 0;
+        int peakHolding = 0;
+        var readers = new Task[contention];
+        for (int i = 0; i < contention; i++)
+        {
+            int loopCount = i;
+            readers[i] = Task.Run(async () => {
+                using AsyncReaderWriterLock.Releaser r =
+                    loopCount == 0 ?
+                    await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false) :
+                    await rwLock.ReaderLockAsync(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);
+
+                int now = Interlocked.Increment(ref holdingCount);
+                int peak;
+                do
+                {
+                    peak = Volatile.Read(ref peakHolding);
+                    if (now <= peak)
+                    {
+                        break;
+                    }
+                } while (Interlocked.CompareExchange(ref peakHolding, now, peak) != peak);
+
+                await releaseGate.Task.ConfigureAwait(false);
+
+                Interlocked.Decrement(ref holdingCount);
+            }, ct);
+        }
+
+        // Give all readers time to acquire.
+        await Task.Delay(200, ct).ConfigureAwait(false);
+        releaseGate.SetResult(true);
+        await Task.WhenAll(readers).ConfigureAwait(false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalUpgradeableReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        }
+
+        Assert.That(peakHolding, Is.EqualTo(contention),
+            $"All {contention} readers should have held the lock simultaneously.");
+
+        Assert.That(pool.ActiveCount, Is.Zero);
+    }
+
     [Test]
     [CancelAfter(CancelAfterMS)]
     public async Task WriterBlocksReaders(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> readerTask;
@@ -243,7 +305,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task WriterBlocksUpgradeableReaders(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> upgradeableReaderTask;
@@ -273,7 +335,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task UpgradeableReaderBlocksUpgradeableReaders(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> upgradeableReaderTask;
@@ -303,7 +365,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReadersBlockWriter(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> writerTask;
@@ -333,7 +395,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task WriterPriorityOverNewReaders(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
         var order = new ConcurrentQueue<string>();
 
@@ -376,7 +438,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task WriterReleasesAllPendingReaders(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> r1, r2, r3;
@@ -416,7 +478,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task ReaderReleaseCancellationThrows(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
         using var cts = new CancellationTokenSource();
 
@@ -445,7 +507,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task UpgradedReaderReleaseCancellationThrows(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
         using var cts = new CancellationTokenSource();
 
@@ -474,7 +536,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task WriterReleaseCancellationThrows(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
         using var cts = new CancellationTokenSource();
 
@@ -503,7 +565,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task UpgradedWriterReleaseCancellationThrows(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
         using var cts = new CancellationTokenSource();
 
@@ -628,7 +690,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task UpgradeableStateTransitions(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         // Acquire an upgradeable reader and another regular reader
@@ -675,7 +737,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task MultipleUpgradedWritersAreSerialized(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         ValueTask<AsyncReaderWriterLock.Releaser> t1;
@@ -740,7 +802,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task WaitingCountsAndInternalFlagsAfterUpgradeAndCancellation(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         using var writer = await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
@@ -762,7 +824,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task EnterUpgradedWriterCancellation_WhenWaiting(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         // Acquire upgradeable reader and another regular reader to block upgrade
@@ -834,7 +896,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task CancelWaitingUpgradedWriter_CleansUp(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         // Acquire upgradeable reader and another regular reader to block upgrade
@@ -929,7 +991,7 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task CancelWaitingUpgradeDoesNotLoseWake(CancellationToken ct)
     {
-        var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously, pool: pool);
 
         using var cts = new CancellationTokenSource();
@@ -1202,7 +1264,7 @@ public class AsyncReaderWriterLockTests
         // Hold writer so readers queue
         using (await rw.WriterLockAsync(ct).ConfigureAwait(false))
         {
-            var r1 = rw.ReaderLockAsync(ct);
+            var r1 = rw.ReaderLockAsync(TimeSpan.FromSeconds(1), ct);
             var r2 = rw.ReaderLockAsync(ct);
             using (Assert.EnterMultipleScope())
             {
@@ -1303,44 +1365,46 @@ public class AsyncReaderWriterLockTests
         using var w = await waitingUpgr.ConfigureAwait(false);
     }
 
-#if TODO
-    [Test][ CancelAfter(CancelAfterMS)]
+    [Test]
+    [CancelAfter(CancelAfterMS)]
     public void DoubleDisposeReleaser_IsNoop(CancellationToken ct)
     {
         var rwLock = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
         var releaser = rwLock.ReaderLockAsync(ct).AsTask().GetAwaiter().GetResult();
         releaser.Dispose();
-        // second dispose should be okay and not throw
-        releaser.Dispose();
+        // second dispose throws object disposed
+        Assert.Throws<ObjectDisposedException>(() => releaser.Dispose());
     }
-#endif
 
     [Test]
     public void TryReset_SucceedsWhenNotInUse()
     {
-        var ev = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(ev.CurrentReaderCount, Is.Zero);
-            Assert.That(ev.WaitingReaderCount, Is.Zero);
-            Assert.That(ev.WaitingWriterCount, Is.Zero);
-            Assert.That(ev.WaitingUpgradeableReaderCount, Is.Zero);
-            Assert.That(ev.WaitingUpgradedWriterCount, Is.Zero);
-            Assert.That(ev.RunContinuationAsynchronously, Is.True);
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+            Assert.That(rwLock.WaitingReaderCount, Is.Zero);
+            Assert.That(rwLock.WaitingWriterCount, Is.Zero);
+            Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.Zero);
+            Assert.That(rwLock.WaitingUpgradedWriterCount, Is.Zero);
+            Assert.That(rwLock.RunContinuationAsynchronously, Is.EqualTo(RunContinuationAsynchronously));
         }
 
-        bool reset = ev.TryReset();
+        bool reset = rwLock.TryReset();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(reset, Is.True);
 
-            Assert.That(ev.CurrentReaderCount, Is.Zero);
-            Assert.That(ev.WaitingReaderCount, Is.Zero);
-            Assert.That(ev.WaitingWriterCount, Is.Zero);
-            Assert.That(ev.WaitingUpgradeableReaderCount, Is.Zero);
-            Assert.That(ev.WaitingUpgradedWriterCount, Is.Zero);
-            Assert.That(ev.RunContinuationAsynchronously, Is.True);
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+            Assert.That(rwLock.WaitingReaderCount, Is.Zero);
+            Assert.That(rwLock.WaitingWriterCount, Is.Zero);
+            Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.Zero);
+            Assert.That(rwLock.WaitingUpgradedWriterCount, Is.Zero);
+            Assert.That(rwLock.RunContinuationAsynchronously, Is.True);
         }
     }
 
@@ -1348,7 +1412,11 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task TryReset_FailsWhenReaderLockHeld(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
         {
             Assert.That(rwLock.TryReset(), Is.False);
@@ -1360,7 +1428,11 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task TryReset_FailsWhenWriterLockHeld(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
         using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
         {
             Assert.That(rwLock.TryReset(), Is.False);
@@ -1372,7 +1444,10 @@ public class AsyncReaderWriterLockTests
     [CancelAfter(CancelAfterMS)]
     public async Task IsUpgradedWriterLockHeld_TrueWhenUpgradeableReaderReleasedFirst(CancellationToken ct)
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         // Acquire both an upgradeable reader and an extra regular reader so that
         // the upgrade must wait until the regular reader is released.
@@ -1408,7 +1483,10 @@ public class AsyncReaderWriterLockTests
     [Test]
     public async Task ReaderLockAsyncWithTimeoutCompletesWhenLockAvailable()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using (await rwLock.ReaderLockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
         {
@@ -1416,10 +1494,13 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test, CancelAfter(3000)]
+    [Test, CancelAfter(CancelAfterMS)]
     public async Task ReaderLockAsyncWithTimeoutThrowsWhenTimeoutElapses()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using var outerWriter = await rwLock.WriterLockAsync().ConfigureAwait(false);
 
@@ -1427,12 +1508,17 @@ public class AsyncReaderWriterLockTests
             await rwLock.ReaderLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(pool.ActiveCount, Is.Zero);
     }
 
     [Test]
     public void ReaderLockAsyncWithNegativeTimeoutThrows()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
 #pragma warning disable VSTHRD110
         Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.ReaderLockAsync(TimeSpan.FromMilliseconds(-2)));
@@ -1442,7 +1528,10 @@ public class AsyncReaderWriterLockTests
     [Test]
     public async Task WriterLockAsyncWithTimeoutCompletesWhenLockAvailable()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using (await rwLock.WriterLockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
         {
@@ -1450,10 +1539,13 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test, CancelAfter(3000)]
+    [Test, CancelAfter(CancelAfterMS)]
     public async Task WriterLockAsyncWithTimeoutThrowsWhenTimeoutElapses()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using var outerReader = await rwLock.ReaderLockAsync().ConfigureAwait(false);
 
@@ -1466,7 +1558,10 @@ public class AsyncReaderWriterLockTests
     [Test]
     public void WriterLockAsyncWithNegativeTimeoutThrows()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
 #pragma warning disable VSTHRD110
         Assert.Throws<ArgumentOutOfRangeException>(() => rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(-2)));
@@ -1476,7 +1571,10 @@ public class AsyncReaderWriterLockTests
     [Test]
     public async Task UpgradeableReaderLockAsyncWithTimeoutCompletesWhenLockAvailable()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using (await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
         {
@@ -1484,10 +1582,13 @@ public class AsyncReaderWriterLockTests
         }
     }
 
-    [Test, CancelAfter(3000)]
+    [Test, CancelAfter(CancelAfterMS)]
     public async Task UpgradeableReaderLockAsyncWithTimeoutThrowsWhenTimeoutElapses()
     {
-        var rwLock = new AsyncReaderWriterLock();
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
 
         using var outerUpgr = await rwLock.UpgradeableReaderLockAsync().ConfigureAwait(false);
 

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -530,10 +530,10 @@ public class AsyncReaderWriterLockTests
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
             Assert.ThrowsAsync<OperationCanceledException>(async () =>
                 await readerTask.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         }
 
         using (Assert.EnterMultipleScope())
@@ -561,10 +561,10 @@ public class AsyncReaderWriterLockTests
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
             Assert.ThrowsAsync<OperationCanceledException>(async () =>
                 await readerTask.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         }
 
         using (Assert.EnterMultipleScope())
@@ -592,10 +592,10 @@ public class AsyncReaderWriterLockTests
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
             Assert.ThrowsAsync<OperationCanceledException>(async () =>
                 await writerTask.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         }
 
         using (Assert.EnterMultipleScope())
@@ -624,10 +624,10 @@ public class AsyncReaderWriterLockTests
 
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
             Assert.ThrowsAsync<OperationCanceledException>(async () =>
                 await writerTask.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         }
 
         using (Assert.EnterMultipleScope())
@@ -878,9 +878,9 @@ public class AsyncReaderWriterLockTests
 
         // cancel and ensure waiter cleaned up
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await waiting.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         Assert.That(rwLock.InternalUpgradeableReaderWaiterInUse, Is.False);
     }
 
@@ -902,9 +902,9 @@ public class AsyncReaderWriterLockTests
 
         // cancel the upgrade attempt and ensure it is removed from waiter queue
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await upgradeAttempt.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         Assert.That(rwLock.InternalUpgradedWriterWaiterInUse, Is.False);
 
@@ -980,9 +980,9 @@ public class AsyncReaderWriterLockTests
 
         // cancel the upgrade attempt and ensure it is removed from waiter queue
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await upgradeAttempt.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         using (Assert.EnterMultipleScope())
         {
@@ -1087,9 +1087,9 @@ public class AsyncReaderWriterLockTests
         // t1 should be granted and t2 should be canceled; ensure internal waiters cleared and pool drained
         using var upgr1 = await t1.ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await t2.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         using (Assert.EnterMultipleScope())
         {
             Assert.That(rwLock.InternalUpgradeableReaderWaiterInUse, Is.False);
@@ -1241,9 +1241,9 @@ public class AsyncReaderWriterLockTests
 
         var vt = upgr.UpgradeToWriterLockAsync(timeout, cts.Token);
         Assert.That(vt.IsCompleted, Is.True);
-#pragma warning disable CHT001
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
-#pragma warning restore CHT001
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
     }
 
     [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
@@ -1261,9 +1261,9 @@ public class AsyncReaderWriterLockTests
 
         var vt = rwLock.WriterLockAsync(timeout, cts.Token);
         Assert.That(vt.IsCompleted, Is.True);
-#pragma warning disable CHT001
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
-#pragma warning restore CHT001
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
     }
 
     [TestCaseSource(nameof(TimeoutTestArgs)), CancelAfter(CancelAfterMS)]
@@ -1281,9 +1281,9 @@ public class AsyncReaderWriterLockTests
 
         var vt = rwLock.UpgradeableReaderLockAsync(timeout, cts.Token);
         Assert.That(vt.IsCompleted, Is.True);
-#pragma warning disable CHT001
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<TaskCanceledException>(async () => await vt.ConfigureAwait(false));
-#pragma warning restore CHT001
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
     }
 
     [Test]

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -219,8 +219,6 @@ public class AsyncReaderWriterLockTests
         var rwLock = new AsyncReaderWriterLock(
             runContinuationAsynchronously: RunContinuationAsynchronously,
             pool: pool);
-        var startGate = new TaskCompletionSource<bool>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseGate = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -90,13 +90,19 @@ public class AsyncReaderWriterLockTests
 
         using (await lockTask.ConfigureAwait(false))
         {
-            Assert.That(rwLock.IsReadLockHeld, Is.True);
-            Assert.That(rwLock.IsWriteLockHeld, Is.False);
-            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rwLock.IsReadLockHeld, Is.True);
+                Assert.That(rwLock.IsWriteLockHeld, Is.False);
+                Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+            }
         }
 
-        Assert.That(rwLock.IsReadLockHeld, Is.False);
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsReadLockHeld, Is.False);
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -110,8 +116,11 @@ public class AsyncReaderWriterLockTests
 
         using (await lockTask.ConfigureAwait(false))
         {
-            Assert.That(rwLock.IsWriteLockHeld, Is.True);
-            Assert.That(rwLock.IsReadLockHeld, Is.False);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rwLock.IsWriteLockHeld, Is.True);
+                Assert.That(rwLock.IsReadLockHeld, Is.False);
+            }
         }
 
         Assert.That(rwLock.IsWriteLockHeld, Is.False);
@@ -128,9 +137,12 @@ public class AsyncReaderWriterLockTests
 
         using (await lockTask.ConfigureAwait(false))
         {
-            Assert.That(rwLock.IsWriteLockHeld, Is.False);
-            Assert.That(rwLock.IsReadLockHeld, Is.True);
-            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rwLock.IsWriteLockHeld, Is.False);
+                Assert.That(rwLock.IsReadLockHeld, Is.True);
+                Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+            }
         }
 
         Assert.That(rwLock.IsWriteLockHeld, Is.False);
@@ -146,11 +158,14 @@ public class AsyncReaderWriterLockTests
         using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
         using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
         {
-            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(3));
-            Assert.That(rwLock.IsReadLockHeld, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(3));
+                Assert.That(rwLock.IsReadLockHeld, Is.True);
+            }
         }
 
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
+        Assert.That(rwLock.CurrentReaderCount, Is.Zero);
     }
 
     [Test]
@@ -163,23 +178,35 @@ public class AsyncReaderWriterLockTests
         var lockTask2 = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
         var lockTask3 = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
 
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(3));
-        Assert.That(rwLock.IsReadLockHeld, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(3));
+            Assert.That(rwLock.IsReadLockHeld, Is.True);
+        }
 
         lockTask1.Dispose();
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(2));
-        Assert.That(rwLock.IsReadLockHeld, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(2));
+            Assert.That(rwLock.IsReadLockHeld, Is.True);
+        }
 
         lockTask2.Dispose();
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
-        Assert.That(rwLock.IsReadLockHeld, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+            Assert.That(rwLock.IsReadLockHeld, Is.True);
+        }
 
         lockTask3.Dispose();
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
-        Assert.That(rwLock.IsReadLockHeld, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+            Assert.That(rwLock.IsReadLockHeld, Is.False);
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        }
     }
 
     [Test]
@@ -193,8 +220,11 @@ public class AsyncReaderWriterLockTests
         using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
         {
             readerTask = rwLock.ReaderLockAsync(ct);
-            Assert.That(readerTask.IsCompleted, Is.False);
-            Assert.That(rwLock.WaitingReaderCount, Is.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(readerTask.IsCompleted, Is.False);
+                Assert.That(rwLock.WaitingReaderCount, Is.EqualTo(1));
+            }
         }
 
         using (await readerTask.ConfigureAwait(false))
@@ -202,8 +232,11 @@ public class AsyncReaderWriterLockTests
             Assert.That(rwLock.IsReadLockHeld, Is.True);
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        }
     }
 
     [Test]
@@ -217,8 +250,11 @@ public class AsyncReaderWriterLockTests
         using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
         {
             upgradeableReaderTask = rwLock.UpgradeableReaderLockAsync(ct);
-            Assert.That(upgradeableReaderTask.IsCompleted, Is.False);
-            Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(upgradeableReaderTask.IsCompleted, Is.False);
+                Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.EqualTo(1));
+            }
         }
 
         using (await upgradeableReaderTask.ConfigureAwait(false))
@@ -226,8 +262,11 @@ public class AsyncReaderWriterLockTests
             Assert.That(rwLock.IsReadLockHeld, Is.True);
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        }
     }
 
     [Test]
@@ -241,8 +280,11 @@ public class AsyncReaderWriterLockTests
         using (await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
         {
             upgradeableReaderTask = rwLock.UpgradeableReaderLockAsync(ct);
-            Assert.That(upgradeableReaderTask.IsCompleted, Is.False);
-            Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(upgradeableReaderTask.IsCompleted, Is.False);
+                Assert.That(rwLock.WaitingUpgradeableReaderCount, Is.EqualTo(1));
+            }
         }
 
         using (await upgradeableReaderTask.ConfigureAwait(false))
@@ -250,8 +292,11 @@ public class AsyncReaderWriterLockTests
             Assert.That(rwLock.IsReadLockHeld, Is.True);
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        }
     }
 
     [Test]
@@ -265,8 +310,11 @@ public class AsyncReaderWriterLockTests
         using (var readerReleaser = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
         {
             writerTask = rwLock.WriterLockAsync(ct);
-            Assert.That(writerTask.IsCompleted, Is.False);
-            Assert.That(rwLock.WaitingWriterCount, Is.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(writerTask.IsCompleted, Is.False);
+                Assert.That(rwLock.WaitingWriterCount, Is.EqualTo(1));
+            }
         }
 
         using (await writerTask.ConfigureAwait(false))
@@ -274,8 +322,11 @@ public class AsyncReaderWriterLockTests
             Assert.That(rwLock.IsWriteLockHeld, Is.True);
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+        }
     }
 
     [Test]
@@ -310,12 +361,15 @@ public class AsyncReaderWriterLockTests
         await Task.Delay(100, ct).ConfigureAwait(false);
 
         var items = order.ToArray();
-        Assert.That(items[0], Is.EqualTo("writer"));
-        Assert.That(items[1], Is.EqualTo("reader"));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(items[0], Is.EqualTo("writer"));
+            Assert.That(items[1], Is.EqualTo("reader"));
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -333,9 +387,12 @@ public class AsyncReaderWriterLockTests
             r2 = rwLock.ReaderLockAsync(ct);
             r3 = rwLock.ReaderLockAsync(ct);
 
-            Assert.That(r1.IsCompleted, Is.False);
-            Assert.That(r2.IsCompleted, Is.False);
-            Assert.That(r3.IsCompleted, Is.False);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(r1.IsCompleted, Is.False);
+                Assert.That(r2.IsCompleted, Is.False);
+                Assert.That(r3.IsCompleted, Is.False);
+            }
         }
 
         using (await r3.ConfigureAwait(false))
@@ -345,11 +402,14 @@ public class AsyncReaderWriterLockTests
             Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(3));
         }
 
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -373,9 +433,12 @@ public class AsyncReaderWriterLockTests
 #pragma warning restore CHT001 // ValueTask awaited multiple times
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -399,9 +462,12 @@ public class AsyncReaderWriterLockTests
 #pragma warning restore CHT001 // ValueTask awaited multiple times
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -425,9 +491,12 @@ public class AsyncReaderWriterLockTests
 #pragma warning restore CHT001 // ValueTask awaited multiple times
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -452,9 +521,12 @@ public class AsyncReaderWriterLockTests
 #pragma warning restore CHT001 // ValueTask awaited multiple times
         }
 
-        Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
-        Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalReaderWaiterInUse, Is.False);
+            Assert.That(rwLock.InternalWriterWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -469,8 +541,11 @@ public class AsyncReaderWriterLockTests
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
             var readerTask = rwLock.ReaderLockAsync(cts.Token);
-            Assert.That(readerTask.IsCompleted, Is.True);
-            Assert.That(readerTask.IsCanceled, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(readerTask.IsCompleted, Is.True);
+                Assert.That(readerTask.IsCanceled, Is.True);
+            }
         }
     }
 
@@ -486,8 +561,11 @@ public class AsyncReaderWriterLockTests
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
             var readerTask = rwLock.UpgradeableReaderLockAsync(cts.Token);
-            Assert.That(readerTask.IsCompleted, Is.True);
-            Assert.That(readerTask.IsCanceled, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(readerTask.IsCompleted, Is.True);
+                Assert.That(readerTask.IsCanceled, Is.True);
+            }
         }
     }
 
@@ -503,8 +581,11 @@ public class AsyncReaderWriterLockTests
             await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
             var writerTask = rwLock.WriterLockAsync(cts.Token);
-            Assert.That(writerTask.IsCompleted, Is.True);
-            Assert.That(writerTask.IsCanceled, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(writerTask.IsCompleted, Is.True);
+                Assert.That(writerTask.IsCanceled, Is.True);
+            }
         }
     }
 
@@ -529,10 +610,15 @@ public class AsyncReaderWriterLockTests
         var releaser1 = rwLock.ReaderLockAsync(ct).AsTask().GetAwaiter().GetResult();
         var releaser2 = rwLock.ReaderLockAsync(ct).AsTask().GetAwaiter().GetResult();
 
-        Assert.That(releaser1.Equals(releaser1), Is.True);
-        Assert.That(releaser1 == releaser2, Is.True);
-        Assert.That(releaser1 != releaser2, Is.False);
-        Assert.That(releaser1.GetHashCode(), Is.EqualTo(releaser2.GetHashCode()));
+        using (Assert.EnterMultipleScope())
+        {
+#pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
+            Assert.That(releaser1.Equals(releaser1), Is.True);
+            Assert.That(releaser1 == releaser2, Is.True);
+            Assert.That(releaser1 != releaser2, Is.False);
+            Assert.That(releaser1.GetHashCode(), Is.EqualTo(releaser2.GetHashCode()));
+#pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
+        }
 
         releaser1.Dispose();
         releaser2.Dispose();
@@ -553,19 +639,25 @@ public class AsyncReaderWriterLockTests
             {
                 // Upgrade should wait while the other reader is present
                 upgradeTask = upgr.UpgradeToWriterLockAsync(ct);
-                Assert.That(upgradeTask.IsCompleted, Is.False);
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(upgradeTask.IsCompleted, Is.False);
 
-                // Current state: upgradeable present + one regular reader => count == 2
-                Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
-                Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(2));
+                    // Current state: upgradeable present + one regular reader => count == 2
+                    Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
+                    Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(2));
+                }
 
                 // Release the regular reader and complete the upgrade
             }
 
             using (await upgradeTask.ConfigureAwait(false))
             {
-                Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.True);
-                Assert.That(rwLock.IsWriteLockHeld, Is.True);
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.True);
+                    Assert.That(rwLock.IsWriteLockHeld, Is.True);
+                }
             }
 
             using (Assert.EnterMultipleScope())
@@ -576,7 +668,7 @@ public class AsyncReaderWriterLockTests
             }
         }
 
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
+        Assert.That(rwLock.CurrentReaderCount, Is.Zero);
     }
 
     [Test]
@@ -691,8 +783,11 @@ public class AsyncReaderWriterLockTests
 
         // clean up other reader and ensure state is consistent: only upgradeable reader remains
         otherReader.Dispose();
-        Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
+            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+        }
     }
 
     [Test]
@@ -725,8 +820,11 @@ public class AsyncReaderWriterLockTests
         using (var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
         {
             var writer = upgr.UpgradeToWriterLockAsync(cts.Token);
-            Assert.That(writer.IsCompleted, Is.True);
-            Assert.That(writer.IsCanceled, Is.False);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(writer.IsCompleted, Is.True);
+                Assert.That(writer.IsCanceled, Is.False);
+            }
             releaser = await writer.ConfigureAwait(false);
         }
         releaser.Dispose();
@@ -753,13 +851,20 @@ public class AsyncReaderWriterLockTests
         Assert.ThrowsAsync<OperationCanceledException>(async () => await upgradeAttempt.ConfigureAwait(false));
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
-        Assert.That(rwLock.InternalUpgradedWriterWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.InternalUpgradedWriterWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
 
         // clean up other reader and ensure state is consistent: only upgradeable reader remains
         otherReader.Dispose();
-        Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.True);
+            Assert.That(rwLock.WaitingReaderCount, Is.Zero);
+            Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(1));
+        }
     }
 
     [Test]
@@ -844,11 +949,14 @@ public class AsyncReaderWriterLockTests
 
 #pragma warning disable CHT001 // ValueTask awaited multiple times
         Assert.ThrowsAsync<OperationCanceledException>(async () => await t2.ConfigureAwait(false));
+        using (Assert.EnterMultipleScope())
+        {
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
 
-        Assert.That(rwLock.InternalUpgradeableReaderWaiterInUse, Is.False);
-        Assert.That(pool.ActiveCount, Is.EqualTo(0));
+            Assert.That(rwLock.InternalUpgradeableReaderWaiterInUse, Is.False);
+            Assert.That(pool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -869,8 +977,11 @@ public class AsyncReaderWriterLockTests
 
         // Release upgraded writer and ensure final state has no upgradeable reader and no readers
         upgWriter.Dispose();
-        Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -900,8 +1011,11 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
 
         upg2.Dispose();
-        Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -937,8 +1051,11 @@ public class AsyncReaderWriterLockTests
         Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
 
         upg2.Dispose();
-        Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
-        Assert.That(rwLock.CurrentReaderCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsUpgradeableReadLockHeld, Is.False);
+            Assert.That(rwLock.CurrentReaderCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -948,10 +1065,13 @@ public class AsyncReaderWriterLockTests
         var rw = new AsyncReaderWriterLock(runContinuationAsynchronously: RunContinuationAsynchronously);
         using var r = await rw.ReaderLockAsync(ct).ConfigureAwait(false);
         object boxed = r;
-        Assert.That(r.Equals(boxed), Is.True);
+        Assert.That(r, Is.EqualTo(boxed));
         var copy = r;
-        Assert.That(copy.Equals(r), Is.True);
-        Assert.That(r.GetHashCode(), Is.EqualTo(copy.GetHashCode()));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(copy, Is.EqualTo(r));
+            Assert.That(r.GetHashCode(), Is.EqualTo(copy.GetHashCode()));
+        }
     }
 
     [Test]
@@ -1015,8 +1135,11 @@ public class AsyncReaderWriterLockTests
         var other = await rw.ReaderLockAsync(ct).ConfigureAwait(false);
 
         var attempt = upgr.UpgradeToWriterLockAsync(ct);
-        Assert.That(attempt.IsCompleted, Is.False);
-        Assert.That(rw.WaitingUpgradedWriterCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(attempt.IsCompleted, Is.False);
+            Assert.That(rw.WaitingUpgradedWriterCount, Is.EqualTo(1));
+        }
 
         other.Dispose();
         using (await attempt.ConfigureAwait(false)) { }
@@ -1081,8 +1204,11 @@ public class AsyncReaderWriterLockTests
         {
             var r1 = rw.ReaderLockAsync(ct);
             var r2 = rw.ReaderLockAsync(ct);
-            Assert.That(r1.IsCompleted, Is.False);
-            Assert.That(r2.IsCompleted, Is.False);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(r1.IsCompleted, Is.False);
+                Assert.That(r2.IsCompleted, Is.False);
+            }
 
             // release writer at end of using - readers should be granted
             await Task.Delay(1, ct).ConfigureAwait(false);
@@ -1121,8 +1247,11 @@ public class AsyncReaderWriterLockTests
 
         // queue an upgraded writer which will wait due to additional reader
         var upgradeAttempt = upgr.UpgradeToWriterLockAsync(ct);
-        Assert.That(upgradeAttempt.IsCompleted, Is.False);
-        Assert.That(rw.WaitingUpgradedWriterCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(upgradeAttempt.IsCompleted, Is.False);
+            Assert.That(rw.WaitingUpgradedWriterCount, Is.EqualTo(1));
+        }
 
         // Now dispose the extra reader to allow the upgrade to proceed and exercise the CompareExchange path
         r.Dispose();
@@ -1191,22 +1320,28 @@ public class AsyncReaderWriterLockTests
     {
         var ev = new AsyncReaderWriterLock();
 
-        Assert.That(ev.CurrentReaderCount, Is.Zero);
-        Assert.That(ev.WaitingReaderCount, Is.Zero);
-        Assert.That(ev.WaitingWriterCount, Is.Zero);
-        Assert.That(ev.WaitingUpgradeableReaderCount, Is.Zero);
-        Assert.That(ev.WaitingUpgradedWriterCount, Is.Zero);
-        Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ev.CurrentReaderCount, Is.Zero);
+            Assert.That(ev.WaitingReaderCount, Is.Zero);
+            Assert.That(ev.WaitingWriterCount, Is.Zero);
+            Assert.That(ev.WaitingUpgradeableReaderCount, Is.Zero);
+            Assert.That(ev.WaitingUpgradedWriterCount, Is.Zero);
+            Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        }
 
         bool reset = ev.TryReset();
-        Assert.That(reset, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reset, Is.True);
 
-        Assert.That(ev.CurrentReaderCount, Is.Zero);
-        Assert.That(ev.WaitingReaderCount, Is.Zero);
-        Assert.That(ev.WaitingWriterCount, Is.Zero);
-        Assert.That(ev.WaitingUpgradeableReaderCount, Is.Zero);
-        Assert.That(ev.WaitingUpgradedWriterCount, Is.Zero);
-        Assert.That(ev.RunContinuationAsynchronously, Is.True);
+            Assert.That(ev.CurrentReaderCount, Is.Zero);
+            Assert.That(ev.WaitingReaderCount, Is.Zero);
+            Assert.That(ev.WaitingWriterCount, Is.Zero);
+            Assert.That(ev.WaitingUpgradeableReaderCount, Is.Zero);
+            Assert.That(ev.WaitingUpgradedWriterCount, Is.Zero);
+            Assert.That(ev.RunContinuationAsynchronously, Is.True);
+        }
     }
 
     [Test]
@@ -1255,13 +1390,19 @@ public class AsyncReaderWriterLockTests
         // This transitions status to UpgradedWriterWithoutReader.
         upgr.Dispose();
 
-        Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.True);
-        Assert.That(rwLock.IsWriteLockHeld, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.True);
+            Assert.That(rwLock.IsWriteLockHeld, Is.True);
+        }
 
         upgWriter.Dispose();
 
-        Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.False);
-        Assert.That(rwLock.IsWriteLockHeld, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rwLock.IsUpgradedWriterLockHeld, Is.False);
+            Assert.That(rwLock.IsWriteLockHeld, Is.False);
+        }
     }
 
     [Test]

--- a/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
@@ -217,4 +217,70 @@ public class AsyncSemaphoreTests
         semaphore.RunContinuationAsynchronously = true;
         Assert.That(semaphore.RunContinuationAsynchronously, Is.True);
     }
+
+    [Test]
+    public async Task WaitAsyncWithTimeoutCompletesWhenPermitAvailableBeforeTimeout()
+    {
+        var customPool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: customPool);
+
+        _ = Task.Run(async () => { await Task.Delay(50).ConfigureAwait(false); semaphore.Release(); });
+
+        await semaphore.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        Assert.That(semaphore.InternalWaiterInUse, Is.False);
+        Assert.That(customPool.ActiveCount, Is.Zero);
+    }
+
+    [Test, CancelAfter(3000)]
+    public async Task WaitAsyncWithTimeoutThrowsWhenTimeoutElapses()
+    {
+        var semaphore = new AsyncSemaphore(0);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await semaphore.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Assert.That(semaphore.InternalWaiterInUse, Is.False);
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutCompletesImmediatelyWhenPermitAvailable()
+    {
+        var semaphore = new AsyncSemaphore(1);
+
+        await semaphore.WaitAsync(TimeSpan.Zero).ConfigureAwait(false);
+
+        Assert.That(semaphore.CurrentCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task WaitAsyncWithZeroTimeoutThrowsWhenNoPermit()
+    {
+        var semaphore = new AsyncSemaphore(0);
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await semaphore.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
+    }
+
+    [Test]
+    public void WaitAsyncWithNegativeTimeoutThrows()
+    {
+        var semaphore = new AsyncSemaphore(1);
+
+#pragma warning disable VSTHRD110
+        Assert.Throws<ArgumentOutOfRangeException>(() => semaphore.WaitAsync(TimeSpan.FromMilliseconds(-2)));
+#pragma warning restore VSTHRD110
+    }
+
+    [Test]
+    public async Task WaitAsyncWithInfiniteTimeoutBehavesLikeWaitAsync()
+    {
+        var semaphore = new AsyncSemaphore(1);
+
+        await semaphore.WaitAsync(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+
+        Assert.That(semaphore.CurrentCount, Is.EqualTo(0));
+    }
 }

--- a/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
@@ -67,8 +67,8 @@ public class AsyncSemaphoreTests
     [Test]
     public async Task WaitAsyncBlocksWhenCountIsZero()
     {
-        var customPool = new TestObjectPool<bool>();
-        var semaphore = new AsyncSemaphore(0, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: pool);
 
         var waiter = semaphore.WaitAsync();
         Assert.That(waiter.IsCompleted, Is.False);
@@ -79,15 +79,15 @@ public class AsyncSemaphoreTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(semaphore.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task MultipleWaitersAreReleasedInOrder()
     {
-        var customPool = new TestObjectPool<bool>();
-        var semaphore = new AsyncSemaphore(0, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: pool);
         var completed = new System.Collections.Concurrent.ConcurrentBag<int>();
 
         var t1 = semaphore.WaitAsync();
@@ -117,15 +117,15 @@ public class AsyncSemaphoreTests
             Assert.That(completed, Has.Count.EqualTo(3));
 
             Assert.That(semaphore.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task ReleaseManyReleasesMultipleWaiters()
     {
-        var customPool = new TestObjectPool<bool>();
-        var semaphore = new AsyncSemaphore(0, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: pool);
 
         var t1 = semaphore.WaitAsync();
         var t2 = semaphore.WaitAsync();
@@ -151,15 +151,15 @@ public class AsyncSemaphoreTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(semaphore.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task CancellationBeforeWaitThrows()
     {
-        var customPool = new TestObjectPool<bool>();
-        var semaphore = new AsyncSemaphore(0, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: pool);
         using var cts = new CancellationTokenSource();
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
@@ -170,15 +170,15 @@ public class AsyncSemaphoreTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(semaphore.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task CancellationWhileWaitingThrows()
     {
-        var customPool = new TestObjectPool<bool>();
-        var semaphore = new AsyncSemaphore(0, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: pool);
         using var cts = new CancellationTokenSource();
 
         var waiter = semaphore.WaitAsync(cts.Token);
@@ -194,15 +194,15 @@ public class AsyncSemaphoreTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(semaphore.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
     [Test]
     public async Task CancelledMiddleWaiterDoesNotAffectOthers()
     {
-        var customPool = new TestObjectPool<bool>();
-        var semaphore = new AsyncSemaphore(0, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: pool);
         using var cts = new CancellationTokenSource();
 
         var t1 = semaphore.WaitAsync();
@@ -225,7 +225,7 @@ public class AsyncSemaphoreTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(semaphore.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 
@@ -245,8 +245,8 @@ public class AsyncSemaphoreTests
     [Test]
     public async Task WaitAsyncWithTimeoutCompletesWhenPermitAvailableBeforeTimeout()
     {
-        var customPool = new TestObjectPool<bool>();
-        var semaphore = new AsyncSemaphore(0, pool: customPool);
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(0, pool: pool);
 
         _ = Task.Run(async () => { await Task.Delay(50).ConfigureAwait(false); semaphore.Release(); });
 
@@ -255,7 +255,7 @@ public class AsyncSemaphoreTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(semaphore.InternalWaiterInUse, Is.False);
-            Assert.That(customPool.ActiveCount, Is.Zero);
+            Assert.That(pool.ActiveCount, Is.Zero);
         }
     }
 

--- a/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
@@ -26,7 +26,7 @@ public class AsyncSemaphoreTests
     public void ConstructorWithZeroCountIsValid()
     {
         var semaphore = new AsyncSemaphore(0);
-        Assert.That(semaphore.CurrentCount, Is.EqualTo(0));
+        Assert.That(semaphore.CurrentCount, Is.Zero);
     }
 
     [Test]
@@ -42,7 +42,7 @@ public class AsyncSemaphoreTests
         Assert.That(semaphore.CurrentCount, Is.EqualTo(1));
 
         await semaphore.WaitAsync().ConfigureAwait(false);
-        Assert.That(semaphore.CurrentCount, Is.EqualTo(0));
+        Assert.That(semaphore.CurrentCount, Is.Zero);
     }
 
     [Test]
@@ -51,7 +51,7 @@ public class AsyncSemaphoreTests
         var semaphore = new AsyncSemaphore(1);
 
         await semaphore.WaitAsync().ConfigureAwait(false);
-        Assert.That(semaphore.CurrentCount, Is.EqualTo(0));
+        Assert.That(semaphore.CurrentCount, Is.Zero);
 
         semaphore.Release();
         Assert.That(semaphore.CurrentCount, Is.EqualTo(1));
@@ -76,8 +76,11 @@ public class AsyncSemaphoreTests
         semaphore.Release();
         await waiter.ConfigureAwait(false);
 
-        Assert.That(semaphore.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(semaphore.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -93,9 +96,12 @@ public class AsyncSemaphoreTests
         await Task.Delay(50).ConfigureAwait(false);
         var t3 = semaphore.WaitAsync();
 
-        Assert.That(t1.IsCompleted, Is.False);
-        Assert.That(t2.IsCompleted, Is.False);
-        Assert.That(t3.IsCompleted, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(t1.IsCompleted, Is.False);
+            Assert.That(t2.IsCompleted, Is.False);
+            Assert.That(t3.IsCompleted, Is.False);
+        }
 
         semaphore.Release(3);
 
@@ -106,10 +112,13 @@ public class AsyncSemaphoreTests
         await t3.ConfigureAwait(false);
         completed.Add(3);
 
-        Assert.That(completed.Count, Is.EqualTo(3));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(completed, Has.Count.EqualTo(3));
 
-        Assert.That(semaphore.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+            Assert.That(semaphore.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -122,9 +131,12 @@ public class AsyncSemaphoreTests
         var t2 = semaphore.WaitAsync();
         var t3 = semaphore.WaitAsync();
 
-        Assert.That(t1.IsCompleted, Is.False);
-        Assert.That(t2.IsCompleted, Is.False);
-        Assert.That(t3.IsCompleted, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(t1.IsCompleted, Is.False);
+            Assert.That(t2.IsCompleted, Is.False);
+            Assert.That(t3.IsCompleted, Is.False);
+        }
 
         semaphore.Release(2);
 
@@ -136,8 +148,11 @@ public class AsyncSemaphoreTests
         semaphore.Release();
         await t3.ConfigureAwait(false);
 
-        Assert.That(semaphore.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(semaphore.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -152,8 +167,11 @@ public class AsyncSemaphoreTests
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await semaphore.WaitAsync(cts.Token).ConfigureAwait(false));
 
-        Assert.That(semaphore.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(semaphore.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -173,8 +191,11 @@ public class AsyncSemaphoreTests
             await waiter.ConfigureAwait(false));
 #pragma warning restore CHT001 // ValueTask awaited multiple times
 
-        Assert.That(semaphore.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(semaphore.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -201,8 +222,11 @@ public class AsyncSemaphoreTests
         await t1.ConfigureAwait(false);
         await t3.ConfigureAwait(false);
 
-        Assert.That(semaphore.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.EqualTo(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(semaphore.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -228,8 +252,11 @@ public class AsyncSemaphoreTests
 
         await semaphore.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-        Assert.That(semaphore.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(semaphore.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test, CancelAfter(3000)]
@@ -252,7 +279,7 @@ public class AsyncSemaphoreTests
 
         await semaphore.WaitAsync(TimeSpan.Zero).ConfigureAwait(false);
 
-        Assert.That(semaphore.CurrentCount, Is.EqualTo(0));
+        Assert.That(semaphore.CurrentCount, Is.Zero);
     }
 
     [Test]
@@ -281,6 +308,6 @@ public class AsyncSemaphoreTests
 
         await semaphore.WaitAsync(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
 
-        Assert.That(semaphore.CurrentCount, Is.EqualTo(0));
+        Assert.That(semaphore.CurrentCount, Is.Zero);
     }
 }

--- a/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
@@ -186,10 +186,10 @@ public class AsyncSemaphoreTests
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda/closure
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await waiter.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda/closure
 
         using (Assert.EnterMultipleScope())
         {
@@ -213,9 +213,9 @@ public class AsyncSemaphoreTests
 
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times
+#pragma warning disable CHT010 // ValueTask captured in lambda/closure
         Assert.ThrowsAsync<OperationCanceledException>(async () => await t2.ConfigureAwait(false));
-#pragma warning restore CHT001 // ValueTask awaited multiple times
+#pragma warning restore CHT010 // ValueTask captured in lambda/closure
 
         semaphore.Release(2);
 

--- a/tests/Threading/Internal/SpinLockTests.cs
+++ b/tests/Threading/Internal/SpinLockTests.cs
@@ -152,8 +152,11 @@ public class SpinLockTests
             }
         });
 
-        Assert.That(violations, Is.EqualTo(0), "Inconsistent pair observed: release reordered before stores");
-        Assert.That(sharedA, Is.EqualTo(sharedB));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(violations, Is.Zero, "Inconsistent pair observed: release reordered before stores");
+            Assert.That(sharedA, Is.EqualTo(sharedB));
+        }
         Assert.That(sharedA, Is.EqualTo((long)ThreadCount * IterationsPerThread));
     }
 
@@ -197,8 +200,11 @@ public class SpinLockTests
             }
         });
 
-        Assert.That(violations, Is.EqualTo(0), "Acquirer observed partially-written state from previous holder");
-        Assert.That(word0, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(violations, Is.Zero, "Acquirer observed partially-written state from previous holder");
+            Assert.That(word0, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+        }
     }
 
     /// <summary>
@@ -237,8 +243,11 @@ public class SpinLockTests
             }
         });
 
-        Assert.That(violations, Is.EqualTo(0), "Payload/sequence mismatch: release did not fence stores");
-        Assert.That(sequence, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(violations, Is.Zero, "Payload/sequence mismatch: release did not fence stores");
+            Assert.That(sequence, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+        }
     }
 
     /// <summary>
@@ -275,8 +284,11 @@ public class SpinLockTests
             }
         });
 
-        Assert.That(concurrencyViolations, Is.EqualTo(0), "Multiple threads entered the critical section simultaneously");
-        Assert.That(totalIterations, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(concurrencyViolations, Is.Zero, "Multiple threads entered the critical section simultaneously");
+            Assert.That(totalIterations, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+        }
     }
 
     /// <summary>

--- a/tests/Threading/Pools/PooledManualResetValueTaskSourceTests.cs
+++ b/tests/Threading/Pools/PooledManualResetValueTaskSourceTests.cs
@@ -3,7 +3,8 @@
 
 namespace Threading.Tests.Pools;
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times - intentionally testing misuse behavior
+// intentionally testing misuse behavior
+#pragma warning disable CHT001 // ValueTask awaited multiple times
 
 using CryptoHives.Foundation.Threading.Pools;
 using NUnit.Framework;
@@ -47,7 +48,9 @@ public class PooledManualResetValueTaskSourceTests
         }
 
         // calling with old version throws
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         _ = Assert.ThrowsAsync<InvalidOperationException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         _ = Assert.ThrowsAsync<InvalidOperationException>(vt.AsTask);
 
         Assert.That(tpvts.ActiveCount, Is.Zero, "Instance count should be 0 after reuse.");
@@ -87,7 +90,9 @@ public class PooledManualResetValueTaskSourceTests
         }
 
         // calling with old version throws
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         _ = Assert.ThrowsAsync<InvalidOperationException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         _ = Assert.ThrowsAsync<InvalidOperationException>(vt.AsTask);
 
         Assert.That(tpvts.ActiveCount, Is.Zero, "Instance count should be 0 after reuse.");

--- a/tests/Threading/Pools/TestObjectPool{T}.cs
+++ b/tests/Threading/Pools/TestObjectPool{T}.cs
@@ -7,6 +7,7 @@ namespace Threading.Tests.Pools;
 
 using CryptoHives.Foundation.Threading.Pools;
 using Microsoft.Extensions.ObjectPool;
+using NUnit.Framework;
 using System;
 using System.Threading;
 
@@ -15,7 +16,10 @@ using System.Threading;
 /// A counter tracks get object instances. Allows to check active objects in use.
 /// </summary>
 
-internal class TestObjectPool<T> : ObjectPool<PooledManualResetValueTaskSource<T>>, IGetPooledManualResetValueTaskSource<T> where T : notnull
+internal class TestObjectPool<T> :
+    ObjectPool<PooledManualResetValueTaskSource<T>>,
+    IDisposable,
+    IGetPooledManualResetValueTaskSource<T> where T : notnull
 {
     private readonly ObjectPool<PooledManualResetValueTaskSource<T>> _valueTaskSourcePool;
     private readonly TestPooledValueTaskSourceObjectPolicy<T> _valueTaskSourcePoolPolicy;
@@ -31,6 +35,12 @@ internal class TestObjectPool<T> : ObjectPool<PooledManualResetValueTaskSource<T
     /// Gets the active number of objects of the class that are in use.
     /// </summary>
     public int ActiveCount => _getCount - _valueTaskSourcePoolPolicy.ReturnedCount;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Assert.That(ActiveCount, Is.Zero);
+    }
 
     /// <inheritdoc/>
     /// <remarks>

--- a/tests/Threading/Pools/ValueTaskPreserveTests.cs
+++ b/tests/Threading/Pools/ValueTaskPreserveTests.cs
@@ -113,7 +113,7 @@ public class ValueTaskPreserveTests
     [Test, CancelAfter(1000)]
     public async Task PreservePooledSourceCompletedCanBeAwaitedMultipleTimes()
     {
-        var pool = new TestObjectPool<int>();
+        using var pool = new TestObjectPool<int>();
         PooledManualResetValueTaskSource<int> source = pool.GetPooledWaiter(null);
         source.SetResult(42);
 
@@ -138,7 +138,7 @@ public class ValueTaskPreserveTests
     [Test, CancelAfter(1000)]
     public async Task PreservePooledSourcePendingCanBeAwaitedMultipleTimes()
     {
-        var pool = new TestObjectPool<int>();
+        using var pool = new TestObjectPool<int>();
         PooledManualResetValueTaskSource<int> source = pool.GetPooledWaiter(null);
 
         var vt = new ValueTask<int>(source, source.Version);
@@ -167,7 +167,7 @@ public class ValueTaskPreserveTests
     [Test, CancelAfter(1000)]
     public async Task PreservePooledSourceDoesNotThrowAfterPoolReturn()
     {
-        var pool = new TestObjectPool<string>();
+        using var pool = new TestObjectPool<string>();
         PooledManualResetValueTaskSource<string> source = pool.GetPooledWaiter(null);
 
         var vt = new ValueTask<string>(source, source.Version);
@@ -199,7 +199,7 @@ public class ValueTaskPreserveTests
     [Test, CancelAfter(1000)]
     public async Task PreservePooledSourceWithExceptionCanBeAwaitedMultipleTimes()
     {
-        var pool = new TestObjectPool<int>();
+        using var pool = new TestObjectPool<int>();
         PooledManualResetValueTaskSource<int> source = pool.GetPooledWaiter(null);
 
         var vt = new ValueTask<int>(source, source.Version);
@@ -229,7 +229,7 @@ public class ValueTaskPreserveTests
     [Test, CancelAfter(1000)]
     public async Task OriginalPooledSourceThrowsOnMultipleAwaitWithoutPreserve()
     {
-        var pool = new TestObjectPool<int>();
+        using var pool = new TestObjectPool<int>();
         PooledManualResetValueTaskSource<int> source = pool.GetPooledWaiter(null);
         source.SetResult(42);
 
@@ -248,7 +248,7 @@ public class ValueTaskPreserveTests
     [Test, CancelAfter(1000)]
     public async Task PreservePooledNonGenericSourceCanBeAwaitedMultipleTimes()
     {
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
         PooledManualResetValueTaskSource<bool> source = pool.GetPooledWaiter(null);
 
         // Create non-generic ValueTask from generic source

--- a/tests/Threading/Pools/ValueTaskPreserveTests.cs
+++ b/tests/Threading/Pools/ValueTaskPreserveTests.cs
@@ -183,7 +183,9 @@ public class ValueTaskPreserveTests
         string r2 = await preserved.ConfigureAwait(false);
         string r3 = await preserved.ConfigureAwait(false);
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<InvalidOperationException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<InvalidOperationException>(vt.AsTask);
 
         using (Assert.EnterMultipleScope())
@@ -208,7 +210,9 @@ public class ValueTaskPreserveTests
         // Set exception
         source.SetException(new InvalidOperationException("Test exception"));
 
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<InvalidOperationException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
         Assert.ThrowsAsync<InvalidOperationException>(vt.AsTask);
 
         // should throw the same exception each time
@@ -240,7 +244,9 @@ public class ValueTaskPreserveTests
         Assert.That(result, Is.EqualTo(42));
 
         // second await throws because the source was consumed and returned to pool
+#pragma warning disable CHT010 // ValueTask captured in lambda or closure
         _ = Assert.ThrowsAsync<InvalidOperationException>(async () => await vt.ConfigureAwait(false));
+#pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         Assert.That(pool.ActiveCount, Is.Zero);
     }

--- a/tests/Threading/Pools/WaiterQueueTests.cs
+++ b/tests/Threading/Pools/WaiterQueueTests.cs
@@ -21,7 +21,7 @@ public class WaiterQueueTests
     public void EnqueueIncreasesCount()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         queue.Enqueue(pool.GetPooledWaiter(null));
         Assert.That(queue.Count, Is.EqualTo(1));
@@ -31,13 +31,17 @@ public class WaiterQueueTests
 
         queue.Enqueue(pool.GetPooledWaiter(null));
         Assert.That(queue.Count, Is.EqualTo(3));
+
+        pool.Return((queue.Dequeue() as PooledManualResetValueTaskSource<bool>)!);
+        pool.Return((queue.Dequeue() as PooledManualResetValueTaskSource<bool>)!);
+        pool.Return((queue.Dequeue() as PooledManualResetValueTaskSource<bool>)!);
     }
 
     [Test]
     public void DequeueReturnsInFifoOrder()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         var second = pool.GetPooledWaiter(null);
@@ -54,30 +58,37 @@ public class WaiterQueueTests
             Assert.That(queue.Dequeue(), Is.SameAs(third));
             Assert.That(queue.Count, Is.Zero);
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
     }
 
     [Test]
     public void DequeueClearsNodeLinks()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var node = pool.GetPooledWaiter(null);
         queue.Enqueue(node);
-        queue.Dequeue();
+        var queuedWaiter = queue.Dequeue() as PooledManualResetValueTaskSource<bool>;
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(queuedWaiter, Is.Not.Null);
             Assert.That(node.Next, Is.Null);
             Assert.That(node.Prev, Is.Null);
         }
+
+        pool.Return(queuedWaiter);
     }
 
     [Test]
     public void RemoveOnlyElement()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var node = pool.GetPooledWaiter(null);
         queue.Enqueue(node);
@@ -91,13 +102,15 @@ public class WaiterQueueTests
             Assert.That(node.Next, Is.Null);
             Assert.That(node.Prev, Is.Null);
         }
+
+        pool.Return(node);
     }
 
     [Test]
     public void RemoveHead()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         var second = pool.GetPooledWaiter(null);
@@ -116,13 +129,21 @@ public class WaiterQueueTests
             Assert.That(queue.Dequeue(), Is.SameAs(second));
             Assert.That(queue.Dequeue(), Is.SameAs(third));
         }
+
+        pool.Return(first);
+
+        queue.Remove(second);
+        pool.Return(second);
+
+        queue.Remove(third);
+        pool.Return(third);
     }
 
     [Test]
     public void RemoveTail()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         var second = pool.GetPooledWaiter(null);
@@ -141,13 +162,17 @@ public class WaiterQueueTests
             Assert.That(queue.Dequeue(), Is.SameAs(first));
             Assert.That(queue.Dequeue(), Is.SameAs(second));
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
     }
 
     [Test]
     public void RemoveMiddle()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         var second = pool.GetPooledWaiter(null);
@@ -166,13 +191,17 @@ public class WaiterQueueTests
             Assert.That(queue.Dequeue(), Is.SameAs(first));
             Assert.That(queue.Dequeue(), Is.SameAs(third));
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
     }
 
     [Test]
     public void RemoveNodeNotInQueueReturnsFalse()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var inQueue = pool.GetPooledWaiter(null);
         var notInQueue = pool.GetPooledWaiter(null);
@@ -186,24 +215,29 @@ public class WaiterQueueTests
             Assert.That(removed, Is.False);
             Assert.That(queue.Count, Is.EqualTo(1));
         }
+
+        pool.Return(inQueue);
+        pool.Return(notInQueue);
     }
 
     [Test]
     public void RemoveFromEmptyQueueReturnsFalse()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
         var node = pool.GetPooledWaiter(null);
 
         bool removed = queue.Remove(node);
         Assert.That(removed, Is.False);
+
+        pool.Return(node);
     }
 
     [Test]
     public void DoubleRemoveReturnsFalseOnSecondCall()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var node = pool.GetPooledWaiter(null);
         queue.Enqueue(node);
@@ -217,13 +251,15 @@ public class WaiterQueueTests
             Assert.That(second, Is.False);
             Assert.That(queue.Count, Is.Zero);
         }
+
+        pool.Return(node);
     }
 
     [Test]
     public void DetachAllReturnsChainAndClearsQueue()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         var second = pool.GetPooledWaiter(null);
@@ -244,13 +280,17 @@ public class WaiterQueueTests
             Assert.That(head.Next!.Next, Is.SameAs(third));
             Assert.That(head.Next.Next!.Next, Is.Null);
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
     }
 
     [Test]
     public void DetachAllClearsPrevLinks()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         var second = pool.GetPooledWaiter(null);
@@ -265,6 +305,9 @@ public class WaiterQueueTests
             Assert.That(first.Prev, Is.Null);
             Assert.That(second.Prev, Is.Null);
         }
+
+        pool.Return(first);
+        pool.Return(second);
     }
 
     [Test]
@@ -285,7 +328,7 @@ public class WaiterQueueTests
     public void EnqueueAfterDetachAllWorksCorrectly()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         queue.Enqueue(first);
@@ -301,67 +344,78 @@ public class WaiterQueueTests
             Assert.That(queue.Count, Is.EqualTo(1));
             Assert.That(queue.Dequeue(), Is.SameAs(second));
         }
+
+        pool.Return(first);
+        pool.Return(second);
     }
 
     [Test]
     public void DetachFirstReturnsSubset()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
-        var a = pool.GetPooledWaiter(null);
-        var b = pool.GetPooledWaiter(null);
-        var c = pool.GetPooledWaiter(null);
-        var d = pool.GetPooledWaiter(null);
+        var first = pool.GetPooledWaiter(null);
+        var second = pool.GetPooledWaiter(null);
+        var third = pool.GetPooledWaiter(null);
+        var fourth = pool.GetPooledWaiter(null);
 
-        queue.Enqueue(a);
-        queue.Enqueue(b);
-        queue.Enqueue(c);
-        queue.Enqueue(d);
+        queue.Enqueue(first);
+        queue.Enqueue(second);
+        queue.Enqueue(third);
+        queue.Enqueue(fourth);
 
         var head = queue.DetachUpTo(2, out int count);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(count, Is.EqualTo(2));
-            Assert.That(head, Is.SameAs(a));
-            Assert.That(head!.Next, Is.SameAs(b));
+            Assert.That(head, Is.SameAs(first));
+            Assert.That(head!.Next, Is.SameAs(second));
             Assert.That(head.Next!.Next, Is.Null);
             Assert.That(queue.Count, Is.EqualTo(2));
-            Assert.That(queue.Dequeue(), Is.SameAs(c));
-            Assert.That(queue.Dequeue(), Is.SameAs(d));
+            Assert.That(queue.Dequeue(), Is.SameAs(third));
+            Assert.That(queue.Dequeue(), Is.SameAs(fourth));
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
+        pool.Return(fourth);
     }
 
     [Test]
     public void DetachFirstMoreThanAvailableDetachesAll()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
-        var a = pool.GetPooledWaiter(null);
-        var b = pool.GetPooledWaiter(null);
+        var first = pool.GetPooledWaiter(null);
+        var second = pool.GetPooledWaiter(null);
 
-        queue.Enqueue(a);
-        queue.Enqueue(b);
+        queue.Enqueue(first);
+        queue.Enqueue(second);
 
         var head = queue.DetachUpTo(5, out int count);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(count, Is.EqualTo(2));
-            Assert.That(head, Is.SameAs(a));
-            Assert.That(head!.Next, Is.SameAs(b));
+            Assert.That(head, Is.SameAs(first));
+            Assert.That(head!.Next, Is.SameAs(second));
             Assert.That(head.Next!.Next, Is.Null);
             Assert.That(queue.Count, Is.Zero);
         }
+
+        pool.Return(first);
+        pool.Return(second);
     }
 
     [Test]
     public void EnqueueAfterRemoveAllWorksCorrectly()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
         var first = pool.GetPooledWaiter(null);
         queue.Enqueue(first);
@@ -375,94 +429,110 @@ public class WaiterQueueTests
             Assert.That(queue.Count, Is.EqualTo(1));
             Assert.That(queue.Dequeue(), Is.SameAs(second));
         }
+
+        pool.Return(first);
+        pool.Return(second);
     }
 
     [Test]
     public void InterleavedEnqueueDequeueRemove()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
-        var a = pool.GetPooledWaiter(null);
-        var b = pool.GetPooledWaiter(null);
-        var c = pool.GetPooledWaiter(null);
-        var d = pool.GetPooledWaiter(null);
+        var first = pool.GetPooledWaiter(null);
+        var second = pool.GetPooledWaiter(null);
+        var third = pool.GetPooledWaiter(null);
+        var fourth = pool.GetPooledWaiter(null);
 
-        queue.Enqueue(a);
-        queue.Enqueue(b);
-        queue.Enqueue(c);
+        queue.Enqueue(first);
+        queue.Enqueue(second);
+        queue.Enqueue(third);
 
         // Remove middle
-        queue.Remove(b);
+        queue.Remove(second);
         Assert.That(queue.Count, Is.EqualTo(2));
 
         // Dequeue head
         var dequeued = queue.Dequeue();
-        Assert.That(dequeued, Is.SameAs(a));
+        Assert.That(dequeued, Is.SameAs(first));
 
         // Enqueue new
-        queue.Enqueue(d);
+        queue.Enqueue(fourth);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(queue.Count, Is.EqualTo(2));
-            Assert.That(queue.Dequeue(), Is.SameAs(c));
-            Assert.That(queue.Dequeue(), Is.SameAs(d));
+            Assert.That(queue.Dequeue(), Is.SameAs(third));
+            Assert.That(queue.Dequeue(), Is.SameAs(fourth));
             Assert.That(queue.Count, Is.Zero);
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
+        pool.Return(fourth);
     }
 
     [Test]
     public void RemoveAllNodesOneByOneInForwardOrder()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
-        var a = pool.GetPooledWaiter(null);
-        var b = pool.GetPooledWaiter(null);
-        var c = pool.GetPooledWaiter(null);
+        var first = pool.GetPooledWaiter(null);
+        var second = pool.GetPooledWaiter(null);
+        var third = pool.GetPooledWaiter(null);
 
-        queue.Enqueue(a);
-        queue.Enqueue(b);
-        queue.Enqueue(c);
+        queue.Enqueue(first);
+        queue.Enqueue(second);
+        queue.Enqueue(third);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(queue.Remove(a), Is.True);
+            Assert.That(queue.Remove(first), Is.True);
             Assert.That(queue.Count, Is.EqualTo(2));
 
-            Assert.That(queue.Remove(b), Is.True);
+            Assert.That(queue.Remove(second), Is.True);
             Assert.That(queue.Count, Is.EqualTo(1));
 
-            Assert.That(queue.Remove(c), Is.True);
+            Assert.That(queue.Remove(third), Is.True);
             Assert.That(queue.Count, Is.Zero);
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
     }
 
     [Test]
     public void RemoveAllNodesOneByOneInReverseOrder()
     {
         var queue = new WaiterQueue<bool>();
-        var pool = new TestObjectPool<bool>();
+        using var pool = new TestObjectPool<bool>();
 
-        var a = pool.GetPooledWaiter(null);
-        var b = pool.GetPooledWaiter(null);
-        var c = pool.GetPooledWaiter(null);
+        var first = pool.GetPooledWaiter(null);
+        var second = pool.GetPooledWaiter(null);
+        var third = pool.GetPooledWaiter(null);
 
-        queue.Enqueue(a);
-        queue.Enqueue(b);
-        queue.Enqueue(c);
+        queue.Enqueue(first);
+        queue.Enqueue(second);
+        queue.Enqueue(third);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(queue.Remove(c), Is.True);
+            Assert.That(queue.Remove(third), Is.True);
             Assert.That(queue.Count, Is.EqualTo(2));
 
-            Assert.That(queue.Remove(b), Is.True);
+            Assert.That(queue.Remove(second), Is.True);
             Assert.That(queue.Count, Is.EqualTo(1));
 
-            Assert.That(queue.Remove(a), Is.True);
+            Assert.That(queue.Remove(first), Is.True);
             Assert.That(queue.Count, Is.Zero);
         }
+
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
     }
 }

--- a/tests/Threading/Threading.Tests.csproj
+++ b/tests/Threading/Threading.Tests.csproj
@@ -13,7 +13,7 @@
       VSTHRD003: Avoid awaiting foreign Tasks; 
       VSTHRD002: Avoid problematic synchronous waits 
       -->
-    <NoWarn>$(NoWarn);NUnit1028;AD0001;VSTHRD200;VSTHRD103;VSTHRD003;VSTHRD002</NoWarn>
+    <NoWarn>$(NoWarn);NUnit1028;AD0001;VSTHRD200;VSTHRD103;VSTHRD003;VSTHRD002;IDE1006</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SignAssembly)' == 'true'">


### PR DESCRIPTION
Add a TimeSpan based timeout option to WaitAsync signatures. 
All new API signatures support optional and concurrent use of CancellationToken and TimeSpan timeout.
Allocation free if there is no contention, otherwise allocates a system TimeProvider for the timeout timer.
Cancellation Tokens remain allocation free on newer .NET versions.

Adds the TimeProvider Bcl package on unsupported platforms.

The threading analyzer gets a new CHT010 code to track ValueTask access in a lambda/closure separately.