### PR TITLE
Add AsyncLock migration of SemaphoreSlim, bug fixes to threading analyzer

### DIFF
--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
 
       - name: Install Microsoft.DotNet.ApiCompat.Tool
         run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
@@ -44,13 +44,13 @@ jobs:
         working-directory: main
         run: |
           dotnet restore "CryptoHives .NET Foundation.sln"
-          dotnet build "CryptoHives .NET Foundation.sln" --configuration Release --no-restore -p:TargetFramework=net8.0
+          dotnet build "CryptoHives .NET Foundation.sln" --configuration Release --no-restore
 
       - name: Build PR branch
         working-directory: pr
         run: |
           dotnet restore "CryptoHives .NET Foundation.sln"
-          dotnet build "CryptoHives .NET Foundation.sln" --configuration Release --no-restore -p:TargetFramework=net8.0
+          dotnet build "CryptoHives .NET Foundation.sln" --configuration Release --no-restore
 
       - name: Check API compatibility - Threading
         continue-on-error: true
@@ -58,8 +58,8 @@ jobs:
         run: |
           echo "## Threading API Compatibility" >> $GITHUB_STEP_SUMMARY
           if microsoft.dotnet.apicompat.tool \
-            --left-assembly main/src/Threading/bin/Release/net8.0/CryptoHives.Foundation.Threading.dll \
-            --right-assembly pr/src/Threading/bin/Release/net8.0/CryptoHives.Foundation.Threading.dll \
+            --left-assembly main/src/Threading/bin/Release/net10.0/CryptoHives.Foundation.Threading.dll \
+            --right-assembly pr/src/Threading/bin/Release/net10.0/CryptoHives.Foundation.Threading.dll \
             --enable-rule-cannot-change-parameter-name false; then
             echo "? No breaking changes detected" >> $GITHUB_STEP_SUMMARY
           else
@@ -72,8 +72,8 @@ jobs:
         run: |
           echo "## Memory API Compatibility" >> $GITHUB_STEP_SUMMARY
           if microsoft.dotnet.apicompat.tool \
-            --left-assembly main/src/Memory/bin/Release/net8.0/CryptoHives.Foundation.Memory.dll \
-            --right-assembly pr/src/Memory/bin/Release/net8.0/CryptoHives.Foundation.Memory.dll \
+            --left-assembly main/src/Memory/bin/Release/net10.0/CryptoHives.Foundation.Memory.dll \
+            --right-assembly pr/src/Memory/bin/Release/net10.0/CryptoHives.Foundation.Memory.dll \
             --enable-rule-cannot-change-parameter-name false; then
             echo "? No breaking changes detected" >> $GITHUB_STEP_SUMMARY
           else

--- a/docfx/packages/threading.analyzers/CHT009.md
+++ b/docfx/packages/threading.analyzers/CHT009.md
@@ -1,0 +1,150 @@
+# CHT009: SemaphoreSlim(1, 1) used as async lock
+
+## Cause
+
+A `new SemaphoreSlim(1, 1)` expression is used to create an async-compatible exclusive lock.
+
+## Rule Description
+
+`SemaphoreSlim(1, 1)` is a common pattern for async-safe mutual exclusion — a semaphore capped at one
+permit effectively acts as a mutex that can be acquired with `await semaphore.WaitAsync()`. It works,
+but it is a general-purpose primitive that allocates a `Task` for every contended wait.
+
+`CryptoHives.Foundation.Threading.Async.Pooled.AsyncLock` is purpose-built for the same pattern:
+
+- Uses pooled `IValueTaskSource` objects so contended waits produce **zero heap allocations**.
+- Returns a deterministic `Releaser` struct compatible with `using` declarations and `await using`.
+- Exposes first-class timeout overloads (`LockAsync(TimeSpan)`) without `AsTask()` overhead.
+- Integrates naturally with `IResettable` object pools.
+
+The diagnostic is **Info** severity — the `SemaphoreSlim(1, 1)` code is not incorrect — but
+switching to `AsyncLock` is recommended for hot paths.
+
+## How to Fix
+
+### Option 1: Apply the code fix
+
+Use the IDE lightbulb or `dotnet-suggest` to apply the **"Replace with AsyncLock"** code fix.
+It will:
+
+1. Replace the `new SemaphoreSlim(1, 1)` creation expression with `new AsyncLock()`.
+2. Update the declared type from `SemaphoreSlim` to `AsyncLock` (when the type is explicit).
+3. Add `using CryptoHives.Foundation.Threading.Async.Pooled;` if not already present.
+
+### Option 2: Migrate manually
+
+```csharp
+// Before — SemaphoreSlim(1, 1) pattern
+using System.Threading;
+
+public class MyService
+{
+    private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+
+    public async Task DoWorkAsync()
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            // critical section
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+}
+```
+
+```csharp
+// After — AsyncLock pattern
+using CryptoHives.Foundation.Threading.Async.Pooled;
+
+public class MyService
+{
+    private readonly AsyncLock _lock = new AsyncLock();
+
+    public async Task DoWorkAsync()
+    {
+        using (await _lock.LockAsync())
+        {
+            // critical section — lock released automatically on dispose
+        }
+    }
+}
+```
+
+Or with a `using` declaration (C# 8+):
+
+```csharp
+public async Task DoWorkAsync()
+{
+    using var releaser = await _lock.LockAsync();
+    // critical section
+} // lock released here
+```
+
+## When to Suppress
+
+Suppress if you intentionally need `SemaphoreSlim`'s extra features, such as:
+
+- Non-async `Wait()` / `Release()` calls from synchronous code paths.
+- The `CurrentCount` / `AvailableWaitHandle` properties.
+- A permit count greater than 1 (i.e., not being used as a mutex).
+
+```csharp
+#pragma warning disable CHT009
+private readonly SemaphoreSlim _sem = new SemaphoreSlim(1, 1); // needs synchronous Wait()
+#pragma warning restore CHT009
+```
+
+## Example
+
+### Violating Code
+
+```csharp
+using System.Threading;
+
+public class Cache
+{
+    private readonly SemaphoreSlim _gate = new SemaphoreSlim(1, 1); // CHT009
+
+    public async Task<string> GetAsync(string key)
+    {
+        await _gate.WaitAsync();
+        try
+        {
+            return Compute(key);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}
+```
+
+### Fixed Code
+
+```csharp
+using CryptoHives.Foundation.Threading.Async.Pooled;
+
+public class Cache
+{
+    private readonly AsyncLock _gate = new AsyncLock();
+
+    public async Task<string> GetAsync(string key)
+    {
+        using (await _gate.LockAsync())
+        {
+            return Compute(key);
+        }
+    }
+}
+```
+
+## See Also
+
+- [AsyncLock documentation](../threading/asynclock.md)
+- [CHT007 — AsTask() stored before signaling](CHT007.md)
+- [AsyncLock API reference](https://cryptohives.github.io/Foundation/api/CryptoHives.Foundation.Threading.Async.Pooled.AsyncLock.html)

--- a/docfx/packages/threading.analyzers/index.md
+++ b/docfx/packages/threading.analyzers/index.md
@@ -28,6 +28,7 @@ Or add to your project file:
 | [CHT006](CHT006.md) | Warning | ValueTask passed to potentially unsafe method |
 | [CHT007](CHT007.md) | Info | AsTask() stored before signaling (performance) |
 | [CHT008](CHT008.md) | Warning | ValueTask not awaited or consumed |
+| [CHT009](CHT009.md) | Info | `SemaphoreSlim(1, 1)` used as async lock; replace with `AsyncLock` |
 
 ## Quick Reference
 
@@ -65,6 +66,9 @@ await t;
 
 // CHT008: Not consumed (Warning)
 GetValueTask(); // Warning: result not awaited
+
+// CHT009: SemaphoreSlim(1,1) as async lock (Info)
+private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1); // Info: consider AsyncLock
 ```
 
 ### ✅ Correct Patterns
@@ -111,6 +115,7 @@ The analyzer package includes automatic code fixes for most diagnostics:
 | CHT005 | Convert to await, Use AsTask().Result |
 | CHT007 | Await ValueTask directly |
 | CHT008 | Add await, Explicitly discard with _ = |
+| CHT009 | Replace with AsyncLock |
 
 ## The Preserve() Method
 

--- a/docfx/packages/threading.analyzers/toc.yml
+++ b/docfx/packages/threading.analyzers/toc.yml
@@ -18,3 +18,5 @@
       href: CHT007.md
     - name: CHT008 - Not Consumed
       href: CHT008.md
+    - name: CHT009 - SemaphoreSlim as AsyncLock
+      href: CHT009.md

--- a/src/Threading.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Threading.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,1 +1,8 @@
-; No unshipped rules yet
+## Release
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+CHT009 | Usage | Info | SemaphoreSlim(1, 1) used as async lock; replace with AsyncLock
+

--- a/src/Threading.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Threading.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,5 +1,3 @@
-## Release
-
 ### New Rules
 
 Rule ID | Category | Severity | Notes

--- a/src/Threading.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Threading.Analyzers/DiagnosticDescriptors.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis;
 public static class DiagnosticDescriptors
 {
     private const string Category = "Usage";
-    private const string HelpLinkBase = "https://github.com/CryptoHives/Foundation/blob/main/docs/analyzers/";
+    private const string HelpLinkBase = "https://cryptohives.github.io/Foundation/packages/threading.analyzers/";
 
     /// <summary>
     /// CHT001: ValueTask awaited multiple times.
@@ -24,8 +24,8 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "A ValueTask should only be awaited once. Awaiting it multiple times can cause undefined behavior or InvalidOperationException. Consider using .AsTask() if you need to await multiple times, or use .Preserve() to safely consume the ValueTask.",
-        helpLinkUri: HelpLinkBase + "CHT001.md",
-        customTags: WellKnownDiagnosticTags.Telemetry);
+        helpLinkUri: HelpLinkBase + "CHT001.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 
     /// <summary>
     /// CHT002: ValueTask.GetAwaiter().GetResult() used (blocking).
@@ -38,8 +38,8 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Calling GetAwaiter().GetResult() on a ValueTask is undefined behavior when backed by IValueTaskSource. Use await instead, or convert to Task first with .AsTask().GetAwaiter().GetResult() if blocking is absolutely necessary.",
-        helpLinkUri: HelpLinkBase + "CHT002.md",
-        customTags: WellKnownDiagnosticTags.NotConfigurable);
+        helpLinkUri: HelpLinkBase + "CHT002.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 
     /// <summary>
     /// CHT003: ValueTask stored in field.
@@ -52,8 +52,8 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Storing a ValueTask in a field increases the risk of consuming it multiple times, which causes undefined behavior. Consider storing the result of .AsTask() or .Preserve() instead.",
-        helpLinkUri: HelpLinkBase + "CHT003.md",
-        customTags: WellKnownDiagnosticTags.NotConfigurable);
+        helpLinkUri: HelpLinkBase + "CHT003.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 
     /// <summary>
     /// CHT004: ValueTask.AsTask() called multiple times.
@@ -66,8 +66,8 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Calling AsTask() multiple times on the same ValueTask is undefined behavior and may throw InvalidOperationException. Store the result of AsTask() if you need to use it multiple times.",
-        helpLinkUri: HelpLinkBase + "CHT004.md",
-        customTags: WellKnownDiagnosticTags.Telemetry);
+        helpLinkUri: HelpLinkBase + "CHT004.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 
     /// <summary>
     /// CHT005: ValueTask.Result accessed directly.
@@ -80,8 +80,8 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Accessing .Result directly on a ValueTask is undefined behavior when the ValueTask is backed by IValueTaskSource. Use await or convert to Task first.",
-        helpLinkUri: HelpLinkBase + "CHT005.md",
-        customTags: WellKnownDiagnosticTags.NotConfigurable);
+        helpLinkUri: HelpLinkBase + "CHT005.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 
     /// <summary>
     /// CHT006: ValueTask passed to method that may consume it multiple times.
@@ -94,8 +94,8 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Passing a ValueTask to certain methods like WhenAll, WhenAny, or custom methods may result in multiple consumption attempts. Consider using .AsTask() or .Preserve() before passing.",
-        helpLinkUri: HelpLinkBase + "CHT006.md",
-        customTags: WellKnownDiagnosticTags.NotConfigurable);
+        helpLinkUri: HelpLinkBase + "CHT006.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 
     /// <summary>
     /// CHT007: ValueTask.AsTask() stored before signaling.
@@ -108,8 +108,8 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true,
         description: "When RunContinuationsAsynchronously is true (default), storing the result of AsTask() before the underlying operation signals completion forces asynchronous scheduling, causing severe performance degradation. Await the ValueTask directly for optimal performance.",
-        helpLinkUri: HelpLinkBase + "CHT007.md",
-        customTags: WellKnownDiagnosticTags.NotConfigurable);
+        helpLinkUri: HelpLinkBase + "CHT007.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 
     /// <summary>
     /// CHT008: ValueTask not consumed.
@@ -122,6 +122,20 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "A ValueTask should always be awaited or converted to Task. When backed by pooled IValueTaskSource, not consuming it may leak pooled objects.",
-        helpLinkUri: HelpLinkBase + "CHT008.md",
-        customTags: WellKnownDiagnosticTags.NotConfigurable);
+        helpLinkUri: HelpLinkBase + "CHT008.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
+
+    /// <summary>
+    /// CHT009: SemaphoreSlim(1, 1) used as an async lock.
+    /// </summary>
+    public static readonly DiagnosticDescriptor SemaphoreSlimAsAsyncLock = new(
+        id: DiagnosticIds.SemaphoreSlimAsAsyncLock,
+        title: "SemaphoreSlim(1, 1) used as async lock",
+        messageFormat: "'{0}' is a SemaphoreSlim(1, 1) used as a mutex; consider replacing with AsyncLock for lower allocations and ValueTask-based async acquisition",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "SemaphoreSlim(1, 1) is commonly used as an async-compatible exclusive lock, but CryptoHives.Foundation.Threading.Async.Pooled.AsyncLock is purpose-built for this pattern: it uses pooled ValueTask sources to eliminate per-wait allocations and provides a deterministic Releaser struct that works with using declarations.",
+        helpLinkUri: HelpLinkBase + "CHT009.html",
+        customTags: WellKnownDiagnosticTags.CustomSeverityConfigurable);
 }

--- a/src/Threading.Analyzers/DiagnosticIds.cs
+++ b/src/Threading.Analyzers/DiagnosticIds.cs
@@ -47,4 +47,9 @@ public static class DiagnosticIds
     /// ValueTask not awaited or converted to Task.
     /// </summary>
     public const string NotConsumed = "CHT008";
+
+    /// <summary>
+    /// <c>SemaphoreSlim(1, 1)</c> used as an async lock; replace with <c>AsyncLock</c>.
+    /// </summary>
+    public const string SemaphoreSlimAsAsyncLock = "CHT009";
 }

--- a/src/Threading.Analyzers/README.md
+++ b/src/Threading.Analyzers/README.md
@@ -43,6 +43,7 @@ Or as a development-only dependency (no runtime reference):
 | [CHT006](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT006.html) | Warning | `ValueTask` passed to potentially unsafe method |
 | [CHT007](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT007.html) | Info | `AsTask()` stored before signaling (performance degradation) |
 | [CHT008](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT008.html) | Warning | `ValueTask` not awaited or consumed |
+| [CHT009](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT009.html) | Info | `SemaphoreSlim(1, 1)` used as async lock; replace with `AsyncLock` |
 
 ---
 
@@ -80,6 +81,9 @@ await t; // Info: storing AsTask() before signal causes 10–100x slowdown
 
 // CHT008: Unconsumed — Warning
 GetValueTask(); // Warning: result not awaited or discarded
+
+// CHT009: SemaphoreSlim(1, 1) as async lock — Info
+private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1); // Info: consider AsyncLock
 ```
 
 ## ✅ Correct Patterns
@@ -126,6 +130,7 @@ The analyzer package includes code fixes for most diagnostics:
 | CHT005 | Convert to `await`; use `AsTask().Result` |
 | CHT007 | Await `ValueTask` directly |
 | CHT008 | Add `await`; explicitly discard with `_ =` |
+| CHT009 | Replace with `AsyncLock` |
 
 ---
 

--- a/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockAnalyzer.cs
+++ b/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockAnalyzer.cs
@@ -1,0 +1,136 @@
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Threading.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+/// <summary>
+/// Analyzer that detects <c>new SemaphoreSlim(1, 1)</c> used as an async-compatible exclusive lock
+/// and suggests replacing it with <c>AsyncLock</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SemaphoreSlimAsAsyncLockAnalyzer : DiagnosticAnalyzer
+{
+    private const string SemaphoreSlimFullName = "System.Threading.SemaphoreSlim";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        if (context is null)
+        {
+            throw new System.ArgumentNullException(nameof(context));
+        }
+
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(
+            AnalyzeObjectCreation,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.ImplicitObjectCreationExpression);
+    }
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        // Resolve the two integer arguments from either `new SemaphoreSlim(1, 1)`
+        // or `new(1, 1)` (target-typed new).
+        ArgumentListSyntax? argumentList;
+        Location diagnosticLocation;
+        string symbolName;
+
+        if (context.Node is ObjectCreationExpressionSyntax objectCreation)
+        {
+            // Skip if the type name is not SemaphoreSlim — fast syntactic pre-filter.
+            if (!IsSemaphoreSlimTypeName(objectCreation.Type))
+            {
+                return;
+            }
+
+            argumentList = objectCreation.ArgumentList;
+            diagnosticLocation = objectCreation.GetLocation();
+            symbolName = GetDeclarationName(context.Node) ?? "semaphore";
+        }
+        else if (context.Node is ImplicitObjectCreationExpressionSyntax implicitCreation)
+        {
+            argumentList = implicitCreation.ArgumentList;
+            diagnosticLocation = implicitCreation.GetLocation();
+            symbolName = GetDeclarationName(context.Node) ?? "semaphore";
+        }
+        else
+        {
+            return;
+        }
+
+        if (argumentList is null || argumentList.Arguments.Count != 2)
+        {
+            return;
+        }
+
+        // Semantic check: ensure the constructed type is System.Threading.SemaphoreSlim.
+        var typeInfo = context.SemanticModel.GetTypeInfo(context.Node, context.CancellationToken);
+        if (typeInfo.Type is not INamedTypeSymbol typeSymbol ||
+            typeSymbol.ToDisplayString() != SemaphoreSlimFullName)
+        {
+            return;
+        }
+
+        // Verify both arguments are compile-time constant 1.
+        if (!IsConstantOne(context.SemanticModel, argumentList.Arguments[0].Expression, context.CancellationToken) ||
+            !IsConstantOne(context.SemanticModel, argumentList.Arguments[1].Expression, context.CancellationToken))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.SemaphoreSlimAsAsyncLock,
+            diagnosticLocation,
+            symbolName));
+    }
+
+    private static bool IsSemaphoreSlimTypeName(TypeSyntax type)
+    {
+        return type switch {
+            IdentifierNameSyntax id => id.Identifier.Text == "SemaphoreSlim",
+            QualifiedNameSyntax q => q.Right.Identifier.Text == "SemaphoreSlim",
+            AliasQualifiedNameSyntax a => a.Name.Identifier.Text == "SemaphoreSlim",
+            _ => false
+        };
+    }
+
+    private static bool IsConstantOne(SemanticModel model, ExpressionSyntax expression, System.Threading.CancellationToken ct)
+    {
+        var constant = model.GetConstantValue(expression, ct);
+        return constant.HasValue && constant.Value is int value && value == 1;
+    }
+
+    /// <summary>
+    /// Walks up the syntax tree to find the variable or field name that holds the
+    /// <c>SemaphoreSlim</c> instance, for use in the diagnostic message.
+    /// </summary>
+    private static string? GetDeclarationName(SyntaxNode node)
+    {
+        // variable declarator:  SemaphoreSlim _sem = new SemaphoreSlim(1, 1);
+        if (node.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator })
+        {
+            return declarator.Identifier.Text;
+        }
+
+        // assignment expression:  _sem = new SemaphoreSlim(1, 1);
+        if (node.Parent is AssignmentExpressionSyntax assignment &&
+            assignment.Right == node)
+        {
+            return assignment.Left.ToString();
+        }
+
+        return null;
+    }
+}

--- a/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockCodeFixProvider.cs
+++ b/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockCodeFixProvider.cs
@@ -148,7 +148,6 @@ public sealed class SemaphoreSlimAsAsyncLockCodeFixProvider : CodeFixProvider
         // Insert after the last existing using directive, or at the top of the file.
         if (compilationUnit.Usings.Count > 0)
         {
-            var lastUsing = compilationUnit.Usings.Last();
             var newUsings = compilationUnit.Usings.Add(newUsing);
             return compilationUnit.WithUsings(newUsings);
         }

--- a/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockCodeFixProvider.cs
+++ b/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockCodeFixProvider.cs
@@ -1,0 +1,158 @@
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Threading.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Provides a code fix for <see cref="DiagnosticIds.SemaphoreSlimAsAsyncLock"/> (CHT009)
+/// that replaces <c>new SemaphoreSlim(1, 1)</c> with <c>new AsyncLock()</c> and adds the
+/// required <c>using</c> directive.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SemaphoreSlimAsAsyncLockCodeFixProvider))]
+[Shared]
+public sealed class SemaphoreSlimAsAsyncLockCodeFixProvider : CodeFixProvider
+{
+    private const string AsyncLockNamespace = "CryptoHives.Foundation.Threading.Async.Pooled";
+    private const string AsyncLockTypeName = "AsyncLock";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticIds.SemaphoreSlimAsAsyncLock);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics.First();
+        var node = root.FindNode(diagnostic.Location.SourceSpan);
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: "Replace with AsyncLock",
+                createChangedDocument: ct => ReplaceWithAsyncLockAsync(context.Document, node, ct),
+                equivalenceKey: "ReplaceWithAsyncLock"),
+            diagnostic);
+    }
+
+    private static async Task<Document> ReplaceWithAsyncLockAsync(
+        Document document,
+        SyntaxNode node,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return document;
+        }
+
+        // Build `new AsyncLock()` with matching trivia.
+        var asyncLockCreation = SyntaxFactory.ObjectCreationExpression(
+                SyntaxFactory.IdentifierName(AsyncLockTypeName))
+            .WithArgumentList(SyntaxFactory.ArgumentList())
+            .WithLeadingTrivia(node.GetLeadingTrivia())
+            .WithTrailingTrivia(node.GetTrailingTrivia());
+
+        SyntaxNode newRoot;
+
+        // When the creation sits inside a variable declaration, also update the declared type
+        // (unless it is `var`).
+        var variableDeclaration = node
+            .AncestorsAndSelf()
+            .OfType<VariableDeclarationSyntax>()
+            .FirstOrDefault();
+
+        if (variableDeclaration is not null && !variableDeclaration.Type.IsVar)
+        {
+            var newType = SyntaxFactory.IdentifierName(AsyncLockTypeName)
+                .WithLeadingTrivia(variableDeclaration.Type.GetLeadingTrivia())
+                .WithTrailingTrivia(variableDeclaration.Type.GetTrailingTrivia());
+
+            // Replace creation expression and type in one pass.
+            newRoot = root
+                .ReplaceNodes(
+                    new SyntaxNode[] { (SyntaxNode)variableDeclaration.Type, node },
+                    (original, _) => original == variableDeclaration.Type
+                        ? (SyntaxNode)newType
+                        : asyncLockCreation);
+        }
+        else
+        {
+            newRoot = root.ReplaceNode(node, asyncLockCreation);
+        }
+
+        // Add `using CryptoHives.Foundation.Threading.Async.Pooled;` if not present.
+        newRoot = EnsureUsingDirective(newRoot, AsyncLockNamespace);
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    /// <summary>
+    /// Adds a <c>using</c> directive for <paramref name="namespaceName"/> to the compilation unit
+    /// when no equivalent directive already exists.
+    /// </summary>
+    private static SyntaxNode EnsureUsingDirective(SyntaxNode root, string namespaceName)
+    {
+        if (root is not CompilationUnitSyntax compilationUnit)
+        {
+            return root;
+        }
+
+        // Check top-level usings first.
+        bool alreadyPresent = compilationUnit.Usings
+            .Any(u => u.Name?.ToString() == namespaceName);
+
+        if (!alreadyPresent)
+        {
+            // Also check file-scoped namespace usings.
+            alreadyPresent = compilationUnit.Members
+                .OfType<FileScopedNamespaceDeclarationSyntax>()
+                .Any(ns => ns.Usings.Any(u => u.Name?.ToString() == namespaceName));
+        }
+
+        if (!alreadyPresent)
+        {
+            // Also check block-scoped namespace usings.
+            alreadyPresent = compilationUnit.Members
+                .OfType<NamespaceDeclarationSyntax>()
+                .Any(ns => ns.Usings.Any(u => u.Name?.ToString() == namespaceName));
+        }
+
+        if (alreadyPresent)
+        {
+            return root;
+        }
+
+        var newUsing = SyntaxFactory.UsingDirective(
+                SyntaxFactory.ParseName(" " + namespaceName))
+            .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
+
+        // Insert after the last existing using directive, or at the top of the file.
+        if (compilationUnit.Usings.Count > 0)
+        {
+            var lastUsing = compilationUnit.Usings.Last();
+            var newUsings = compilationUnit.Usings.Add(newUsing);
+            return compilationUnit.WithUsings(newUsings);
+        }
+
+        return compilationUnit.AddUsings(newUsing);
+    }
+}

--- a/tests/Threading.Analyzers/SemaphoreSlimAsAsyncLockAnalyzerTests.cs
+++ b/tests/Threading.Analyzers/SemaphoreSlimAsAsyncLockAnalyzerTests.cs
@@ -1,0 +1,223 @@
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Threading.Analyzers.Tests;
+
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Tests for <see cref="SemaphoreSlimAsAsyncLockAnalyzer"/> (CHT009).
+/// </summary>
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class SemaphoreSlimAsAsyncLockAnalyzerTests : AnalyzerTestBase<SemaphoreSlimAsAsyncLockAnalyzer>
+{
+    // ── Positive cases (diagnostic expected) ──────────────────────────────────
+
+    [Test]
+    public async Task FieldDeclarationWithExplicitTypeReportsDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private readonly SemaphoreSlim {|#0:_sem|} = {|#1:new SemaphoreSlim(1, 1)|};
+}";
+        DiagnosticResult expected = Diagnostic(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock)
+            .WithLocation(1)
+            .WithArguments("_sem");
+
+        await VerifyAnalyzerAsync(code, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task LocalVariableWithExplicitTypeReportsDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    public void TestMethod()
+    {
+        SemaphoreSlim sem = {|#0:new SemaphoreSlim(1, 1)|};
+    }
+}";
+        DiagnosticResult expected = Diagnostic(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock)
+            .WithLocation(0)
+            .WithArguments("sem");
+
+        await VerifyAnalyzerAsync(code, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task LocalVariableWithVarTypeReportsDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    public void TestMethod()
+    {
+        var sem = {|#0:new SemaphoreSlim(1, 1)|};
+    }
+}";
+        DiagnosticResult expected = Diagnostic(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock)
+            .WithLocation(0)
+            .WithArguments("sem");
+
+        await VerifyAnalyzerAsync(code, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task FullyQualifiedTypeNameReportsDiagnostic()
+    {
+        string code = @"
+public class TestClass
+{
+    public void TestMethod()
+    {
+        System.Threading.SemaphoreSlim sem = {|#0:new System.Threading.SemaphoreSlim(1, 1)|};
+    }
+}";
+        DiagnosticResult expected = Diagnostic(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock)
+            .WithLocation(0)
+            .WithArguments("sem");
+
+        await VerifyAnalyzerAsync(code, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task AssignmentExpressionReportsDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private SemaphoreSlim _sem;
+
+    public void Init()
+    {
+        _sem = {|#0:new SemaphoreSlim(1, 1)|};
+    }
+}";
+        DiagnosticResult expected = Diagnostic(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock)
+            .WithLocation(0)
+            .WithArguments("_sem");
+
+        await VerifyAnalyzerAsync(code, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task ImplicitObjectCreationReportsDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private readonly SemaphoreSlim _sem = {|#0:new(1, 1)|};
+}";
+        DiagnosticResult expected = Diagnostic(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock)
+            .WithLocation(0)
+            .WithArguments("_sem");
+
+        await VerifyAnalyzerAsync(code, expected).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task ConstantArgumentsReportsDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private const int One = 1;
+    private readonly SemaphoreSlim _sem = {|#0:new SemaphoreSlim(One, One)|};
+}";
+        DiagnosticResult expected = Diagnostic(DiagnosticDescriptors.SemaphoreSlimAsAsyncLock)
+            .WithLocation(0)
+            .WithArguments("_sem");
+
+        await VerifyAnalyzerAsync(code, expected).ConfigureAwait(false);
+    }
+
+    // ── Negative cases (no diagnostic expected) ───────────────────────────────
+
+    [Test]
+    public async Task SemaphoreSlimWithInitialCountGreaterThanOneNoDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private readonly SemaphoreSlim _sem = new SemaphoreSlim(2, 2);
+}";
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SemaphoreSlimWithDifferentCountsNoDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private readonly SemaphoreSlim _sem = new SemaphoreSlim(0, 1);
+}";
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SemaphoreSlimWithSingleArgNoDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private readonly SemaphoreSlim _sem = new SemaphoreSlim(1);
+}";
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SemaphoreSlimWithZeroInitialCountNoDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private readonly SemaphoreSlim _sem = new SemaphoreSlim(0, 10);
+}";
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SemaphoreSlimWithNonConstantArgumentNoDiagnostic()
+    {
+        string code = @"
+using System.Threading;
+
+public class TestClass
+{
+    private readonly int _count = 1;
+    private readonly SemaphoreSlim _sem;
+
+    public TestClass()
+    {
+        _sem = new SemaphoreSlim(_count, _count);
+    }
+}";
+        await VerifyNoDiagnosticsAsync(code).ConfigureAwait(false);
+    }
+}

--- a/tests/Threading.Analyzers/Threading.Analyzers.Tests.csproj
+++ b/tests/Threading.Analyzers/Threading.Analyzers.Tests.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>CryptoHives.Foundation.Threading.Analyzers.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);NETSDK1005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +26,6 @@
 
   <ItemGroup>
     <Compile Include="../Common/AssemblyInfo.cs" Link="Properties/AssemblyInfo.cs" />
-    <ProjectReference Include="..\..\src\Threading.Analyzers\Threading.Analyzers.csproj" />
     <ProjectReference Include="../../src/Threading.Analyzers/Threading.Analyzers.csproj" />
   </ItemGroup>
 

--- a/tests/Threading.Analyzers/Threading.Analyzers.Tests.csproj
+++ b/tests/Threading.Analyzers/Threading.Analyzers.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>CryptoHives.Foundation.Threading.Analyzers.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);NETSDK1005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -1,15 +1,13 @@
 ﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
-#pragma warning disable CHT001  // ValueTask awaited multiple times - intentionally testing cancellation behavior
-#pragma warning disable IDE1006 // 
+#pragma warning disable CHT001 // ValueTask awaited multiple times - intentionally testing cancellation behavior
 
 namespace Threading.Tests.Async.Pooled;
 
 using CryptoHives.Foundation.Threading.Async.Pooled;
 using NUnit.Framework;
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Threading.Tests.Pools;

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -1,7 +1,8 @@
 ﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
-#pragma warning disable CHT001 // ValueTask awaited multiple times - intentionally testing cancellation behavior
+#pragma warning disable CHT001  // ValueTask awaited multiple times - intentionally testing cancellation behavior
+#pragma warning disable IDE1006 // 
 
 namespace Threading.Tests.Async.Pooled;
 
@@ -320,8 +321,11 @@ public class AsyncLockTests
             Assert.ThrowsAsync<OperationCanceledException>(async () => await vt.ConfigureAwait(false));
         }
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -413,8 +417,11 @@ public class AsyncLockTests
         // Cancel after lock is released, should not throw
         await AsyncAssert.CancelAsync(cts).ConfigureAwait(false);
 
-        Assert.That(al.InternalWaiterInUse, Is.False);
-        Assert.That(customPool.ActiveCount, Is.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(al.InternalWaiterInUse, Is.False);
+            Assert.That(customPool.ActiveCount, Is.Zero);
+        }
     }
 
     [Test]
@@ -425,9 +432,12 @@ public class AsyncLockTests
         Assert.That(ev.IsTaken, Is.False);
 
         bool reset = ev.TryReset();
-        Assert.That(reset, Is.True);
 
-        Assert.That(ev.IsTaken, Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reset, Is.True);
+            Assert.That(ev.IsTaken, Is.False);
+        }
     }
 
     private static TaskCompletionSource<TResult> CreateAsyncTaskSource<TResult>()


### PR DESCRIPTION
- New analyzer rule CHT009, that detects the use of `SemaphoreSlim(1, 1)` as an async-compatible exclusive lock and recommends replacing it with `AsyncLock`. 
- Minor improvements were made to diagnostic descriptor links and tags.


