### PR TITLE
Prep 0.6 (June) release

### DIFF
--- a/src/Security/Cryptography/Cryptography.csproj
+++ b/src/Security/Cryptography/Cryptography.csproj
@@ -19,6 +19,13 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
   </PropertyGroup>
 
+  <!-- override to tag Cryptography library as beta until API surface is finalized -->
+  <PropertyGroup Condition="'$(NBGV_PublicRelease)' == 'True' AND '$(NBGV_PrereleaseVersion)' != '-preview'">
+    <Version>$(NBGV_Version)-alpha</Version>
+    <VersionSuffix>$(NBGV_VersionRevision)-alpha</VersionSuffix>
+    <PackageVersion>$(NBGV_Version)-alpha</PackageVersion>
+  </PropertyGroup>  
+  
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <PackageId>$(PackageId).Debug</PackageId>
   </PropertyGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.5-preview",
+  "version": "0.6",
   "versionHeightOffset": 10,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
remove the -preview suffix for stable libraries, bump version due to API changes