### PR TITLE
Remove analyzers from threading library, require reference of threading analyzers nuget instead

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,5 +55,6 @@
     <PackageVersion Include="CryptoHives.Foundation.Memory$(_NuGetPackageSuffix)" Version="$(NuGetPackageVersion)" />
     <PackageVersion Include="CryptoHives.Foundation.Security.Cryptography$(_NuGetPackageSuffix)" Version="$(NuGetPackageVersion)" />
     <PackageVersion Include="CryptoHives.Foundation.Threading$(_NuGetPackageSuffix)" Version="$(NuGetPackageVersion)" />
+    <PackageVersion Include="CryptoHives.Foundation.Threading.Analyzers$(_NuGetPackageSuffix)" Version="$(NuGetPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/docfx/getting-started.md
+++ b/docfx/getting-started.md
@@ -30,7 +30,7 @@ dotnet add package CryptoHives.Foundation.Security.Cryptography
 
 ### 🔍 [Threading Analyzers (Standalone)](packages/threading.analyzers/index.md)
 
-Roslyn analyzers for `ValueTask` misuse detection. Already included in the Threading package — this standalone package is for projects that want analyzers without the Threading library.
+Roslyn analyzers for `ValueTask` misuse detection. This package is for projects that want threading analyzers for the Threading library.
 
 ```bash
 dotnet add package CryptoHives.Foundation.Threading.Analyzers

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -37,7 +37,7 @@ The Threading package provides high-performance async synchronization primitives
 
 **Key Features:**
 - All waiters implemented as `ValueTask`-based synchronization primitives with low memory allocation design
-- Built-in Roslyn analyzers to detect common `ValueTask` misuse patterns at compile time
+- Optional Roslyn analyzer package to detect common `ValueTask` misuse patterns at compile time
 - Full `CancellationToken` support in all Wait/Lock primitives 
 - Implementations use `IValueTaskSource<T>` based classes backed by `ObjectPool<T>` to avoid allocations by recycling waiter objects
 - Async mutual exclusion with `AsyncLock` and scoped locking via `IDisposable` pattern

--- a/docfx/packages/threading/index.md
+++ b/docfx/packages/threading/index.md
@@ -20,7 +20,7 @@ By demand, more primitives might be added in the future.
 - **Timeout support**: Optional timeout parameters on all lock acquisition methods
 - **Configurable continuations**: Control synchronous vs asynchronous continuation execution
 - **Custom ObjectPools**: Supply your own object pools for fine-grained control
-- **Included Analyzers**: Roslyn analyzers automatically detect common ValueTask misuse patterns
+- **Optional Analyzers**: Roslyn analyzers automatically detect common ValueTask misuse patterns
 
 ## Installation
 
@@ -28,7 +28,7 @@ By demand, more primitives might be added in the future.
 dotnet add package CryptoHives.Foundation.Threading
 ```
 
-> **Note:** This package includes [Threading Analyzers](../threading.analyzers/index.md) automatically. The analyzers are transitive, so any project that references a project using this package will also benefit from the ValueTask misuse detection at compile time.
+> **Note:** This package does not include [Threading Analyzers](../threading.analyzers/index.md) automatically.
 
 ## Namespaces
 

--- a/src/Threading.Analyzers/README.md
+++ b/src/Threading.Analyzers/README.md
@@ -11,7 +11,7 @@ developed and maintained by **The Keepers of the CryptoHives**.
 
 Roslyn analyzers that detect common `ValueTask` misuse patterns at compile time — helping you avoid subtle bugs, undefined behavior, and performance pitfalls when working with `ValueTask` and pooled async primitives.
 
-> **Note:** These analyzers are automatically included in the [CryptoHives.Foundation.Threading](https://www.nuget.org/packages/CryptoHives.Foundation.Threading) package. Install this package separately only if you need the analyzers without the Threading library.
+> **Note:** These analyzers are note anymore automatically included in the [CryptoHives.Foundation.Threading](https://www.nuget.org/packages/CryptoHives.Foundation.Threading) package. Install this separately if you need the analyzers with the Threading library.
 
 ---
 

--- a/src/Threading/README.md
+++ b/src/Threading/README.md
@@ -59,7 +59,7 @@ Namespace: `CryptoHives.Foundation.Threading.Pools`
 - **Custom pools** — supply your own `IGetPooledManualResetValueTaskSource<T>` for fine-grained control
 - **Drop-in replacement** — change namespace, keep the same `using`-based patterns
 - **Custom ObjectPools**: Supply your own object pools for fine-grained control
-- **Included analyzers** — ValueTask misuse caught at compile time
+- **Optional analyzers** — ValueTask misuse caught at compile time, available in `Threading.Analyzers` package
 
 ---
 

--- a/src/Threading/Threading.csproj
+++ b/src/Threading/Threading.csproj
@@ -64,19 +64,6 @@
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
   </ItemGroup>
 
-  <!-- Include the Threading.Analyzers in this package for transitive analyzer support -->
-  <ItemGroup>
-    <ProjectReference Include="../Threading.Analyzers/Threading.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" />
-  </ItemGroup>
-
-  <!-- Pack the analyzer DLL into the analyzers folder - this makes it transitive to consumers -->
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)../Threading.Analyzers/bin/$(Configuration)/netstandard2.0/$(AssemblyPrefix).Threading.Analyzers.dll" 
-          Pack="true" 
-          PackagePath="analyzers/dotnet/cs" 
-          Visible="false" 
-          Condition="Exists('$(MSBuildThisFileDirectory)../Threading.Analyzers/bin/$(Configuration)/netstandard2.0/$(AssemblyPrefix).Threading.Analyzers.dll')" />
-  </ItemGroup>
 
   <!-- DocFX Documentation -->
   <ItemGroup>

--- a/tests/Threading/Threading.Tests.csproj
+++ b/tests/Threading/Threading.Tests.csproj
@@ -43,8 +43,8 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(UsePackedNuGetPackages)' == 'true'">
-    <!-- The Threading NuGet package bundles the analyzer in analyzers/dotnet/cs -->
     <PackageReference Include="CryptoHives.Foundation.Threading$(_NuGetPackageSuffix)" />
+    <PackageReference Include="CryptoHives.Foundation.Threading.Analyzers$(_NuGetPackageSuffix)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Due to inherent not well understood issues with the analyzer make it optional