### PR TITLE
Fix a race condition which may deadlock on cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ Designed to eliminate `Task` / `TaskCompletionSource<T>` allocations on the hot 
 - `AsyncBarrier` / `AsyncCountdownEvent`
 
 All primitives support `CancellationToken` and `ConfigureAwait(false)` without the need for extra allocations.
-Nuget package contains a C# analyzer to avoid common ValueTask usage mistakes. (Also available as standalone package)
+New in 0.6: Timeout support using `TimeProvider` (`ITimer` may be allocated on contention)
+
+A C# analyzer to avoid common ValueTask usage mistakes is available as standalone package.
 
 ⏱️ [Async primitive benchmarks](https://cryptohives.github.io/Foundation/packages/threading/benchmarks.html) — contested and uncontested scenarios, comparing pooled `ValueTask` vs. existing `Task`-based alternatives.
 

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -265,6 +265,9 @@ public sealed class AsyncAutoResetEvent : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<bool> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -279,42 +282,44 @@ public sealed class AsyncAutoResetEvent : IResettable
                 return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
             }
 
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
+            if (!_localWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
+            version = waiter.Version;
+            _waiters.Enqueue(waiter);
+
             if (timeout != Timeout.InfiniteTimeSpan)
             {
                 waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                     TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
             }
-
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask(waiter, version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -176,69 +176,7 @@ public sealed class AsyncBarrier
     /// <exception cref="InvalidOperationException">Thrown when more participants signal than expected.</exception>
     /// <exception cref="BarrierPostPhaseException">Thrown when the post-phase action throws an exception.</exception>
     public ValueTask SignalAndWaitAsync(CancellationToken cancellationToken = default)
-    {
-        ManualResetValueTaskSource<bool>? toReleaseChain = null;
-        Exception? postPhaseException = null;
-
-        _spinLock.Enter();
-        try
-        {
-            if (_participantsRemaining <= 0)
-            {
-                throw new InvalidOperationException("The number of threads using the barrier exceeded the total number of registered participants.");
-            }
-
-            _participantsRemaining--;
-
-            if (_participantsRemaining > 0)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    _participantsRemaining++;
-                    return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
-                }
-
-                PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this);
-                waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-                waiter.CancellationToken = cancellationToken;
-
-                return QueueWaiter(waiter);
-            }
-
-            // Last participant - execute post-phase action, then release all waiters and advance phase
-            if (_postPhaseAction is not null)
-            {
-                try
-                {
-                    _postPhaseAction(this);
-                }
-                catch (Exception ex) when (ex is not OutOfMemoryException
-                    && ex is not StackOverflowException
-                    && ex is not AccessViolationException)
-                {
-                    postPhaseException = new BarrierPostPhaseException(ex);
-                }
-            }
-
-            _participantsRemaining = _participantCount;
-            _currentPhase++;
-
-            toReleaseChain = _waiters.DetachAll(out _);
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
-
-        if (postPhaseException is not null)
-        {
-            WaiterQueue<bool>.SetChainException(toReleaseChain, postPhaseException);
-            return new ValueTask(Task.FromException(postPhaseException));
-        }
-
-        toReleaseChain?.SetChainResult(true);
-        return default;
-    }
+        => SignalAndWaitAsync(Timeout.InfiniteTimeSpan, cancellationToken);
 
     /// <summary>
     /// Signals the barrier and waits for all participants to arrive, or until the specified timeout elapses.
@@ -264,15 +202,11 @@ public sealed class AsyncBarrier
     /// <exception cref="BarrierPostPhaseException">Thrown when the post-phase action throws an exception.</exception>
     public ValueTask SignalAndWaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
-        if (timeout == Timeout.InfiniteTimeSpan)
-        {
-            return SignalAndWaitAsync(cancellationToken);
-        }
-
-        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan) throw new ArgumentOutOfRangeException(nameof(timeout));
 
         ManualResetValueTaskSource<bool>? toReleaseChain = null;
         Exception? postPhaseException = null;
+        bool earlyExit = false;
 
         _spinLock.Enter();
         try
@@ -298,14 +232,39 @@ public sealed class AsyncBarrier
                     return new ValueTask(Task.FromException(new OperationCanceledException()));
                 }
 
-                PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this); ;
+                PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this);
                 waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-
                 waiter.CancellationToken = cancellationToken;
-                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
-                    TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-                return QueueWaiter(waiter);
+                short version = waiter.Version;
+                _waiters.Enqueue(waiter);
+
+                if (timeout != Timeout.InfiniteTimeSpan)
+                {
+                    waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                        TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+                }
+
+                earlyExit = true;
+                _spinLock.Exit();
+
+                if (cancellationToken.CanBeCanceled)
+                {
+#if NET6_0_OR_GREATER
+                    // Use UnsafeRegister on .NET 6+ for allocation free registration
+                    waiter.CancellationTokenRegistration =
+                        cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                    waiter.CancellationTokenRegistration =
+                        cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+                }
+                else
+                {
+                    Debug.Assert(waiter.CancellationTokenRegistration == default);
+                }
+
+                return new ValueTask(waiter, version);
             }
 
             // Last participant - execute post-phase action, then release all waiters and advance phase
@@ -315,7 +274,9 @@ public sealed class AsyncBarrier
                 {
                     _postPhaseAction(this);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OutOfMemoryException
+                    && ex is not StackOverflowException
+                    && ex is not AccessViolationException)
                 {
                     postPhaseException = new BarrierPostPhaseException(ex);
                 }
@@ -328,7 +289,10 @@ public sealed class AsyncBarrier
         }
         finally
         {
-            _spinLock.Exit();
+            if (!earlyExit)
+            {
+                _spinLock.Exit();
+            }
         }
 
         if (postPhaseException is not null)
@@ -502,32 +466,6 @@ public sealed class AsyncBarrier
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
         toCancel?.SetException(new OperationCanceledException(waiter.CancellationToken));
-    }
-
-    /// <summary>
-    /// Queue and register the waiter if it can be canceled.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ValueTask QueueWaiter(ManualResetValueTaskSource<bool> waiter)
-    {
-        if (waiter.CancellationToken.CanBeCanceled)
-        {
-#if NET6_0_OR_GREATER
-            // Use UnsafeRegister on .NET 6+ for allocation free registration
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                waiter.CancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-        }
-        else
-        {
-            Debug.Assert(waiter.CancellationTokenRegistration == default);
-        }
-
-        _waiters.Enqueue(waiter);
-        return new ValueTask(waiter, waiter.Version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -189,6 +189,9 @@ public sealed class AsyncCountdownEvent
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        PooledManualResetValueTaskSource<bool> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -202,40 +205,41 @@ public sealed class AsyncCountdownEvent
                 return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
             }
 
-            PooledManualResetValueTaskSource<bool> waiter;
             waiter = _pool.GetPooledWaiter(this);
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
+
+            version = waiter.Version;
+            _waiters.Enqueue(waiter);
 
             if (timeout != Timeout.InfiniteTimeSpan)
             {
                 waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                     TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
             }
-
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask(waiter, version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -253,6 +253,9 @@ public sealed class AsyncLock : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask<Releaser> LockAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<Releaser> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -266,7 +269,7 @@ public sealed class AsyncLock : IResettable
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            if (!_localWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
                 waiter.RunContinuationsAsynchronously = true;
@@ -274,35 +277,37 @@ public sealed class AsyncLock : IResettable
 
             waiter.CancellationToken = cancellationToken;
 
+            version = waiter.Version;
+            _waiters.Enqueue(waiter);
+
             if (timeout != Timeout.InfiniteTimeSpan)
             {
                 waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                     TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
             }
-
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask<Releaser>(waiter, version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -256,6 +256,9 @@ public sealed class AsyncManualResetEvent : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask WaitAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<bool> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -269,42 +272,44 @@ public sealed class AsyncManualResetEvent : IResettable
                 return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
             }
 
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
+            if (!_localWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
+            version = waiter.Version;
+            _waiters.Enqueue(waiter);
+
             if (timeout != Timeout.InfiniteTimeSpan)
             {
                 waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                     TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
             }
-
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask(waiter, version);
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -588,6 +588,9 @@ public sealed class AsyncReaderWriterLock : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask<Releaser> ReaderLockAsyncImpl(CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<Releaser> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -610,35 +613,37 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
-            if (!_localReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            if (!_localReaderWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_readerCancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(ReaderCancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
+            version = waiter.Version;
             _waitingReaders.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_readerCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(ReaderCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask<Releaser>(waiter, version);
     }
 
     /// <summary>
@@ -687,6 +692,9 @@ public sealed class AsyncReaderWriterLock : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask<Releaser> ReaderLockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<Releaser> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -710,7 +718,7 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
-            if (!_localReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            if (!_localReaderWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
@@ -719,28 +727,30 @@ public sealed class AsyncReaderWriterLock : IResettable
             waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                 ReaderTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_readerCancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(ReaderCancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
+            version = waiter.Version;
             _waitingReaders.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_readerCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(ReaderCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask<Releaser>(waiter, version);
     }
 
     /// <summary>
@@ -770,6 +780,9 @@ public sealed class AsyncReaderWriterLock : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask<Releaser> UpgradeableReaderLockAsyncImpl(CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<Releaser> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -791,35 +804,37 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
-            if (!_localUpgradeableReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            if (!_localUpgradeableReaderWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_upgradeableReaderCancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(UpgradeableReaderCancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
+            version = waiter.Version;
             _waitingUpgradeableReaders.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_upgradeableReaderCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(UpgradeableReaderCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask<Releaser>(waiter, version);
     }
 
     /// <summary>
@@ -868,6 +883,9 @@ public sealed class AsyncReaderWriterLock : IResettable
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private ValueTask<Releaser> UpgradeableReaderLockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<Releaser> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -890,7 +908,7 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
-            if (!_localUpgradeableReaderWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            if (!_localUpgradeableReaderWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
@@ -899,28 +917,30 @@ public sealed class AsyncReaderWriterLock : IResettable
             waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                 UpgradeableReaderTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_upgradeableReaderCancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(UpgradeableReaderCancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
+            version = waiter.Version;
             _waitingUpgradeableReaders.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_upgradeableReaderCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(UpgradeableReaderCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask<Releaser>(waiter, version);
     }
 
     /// <summary>
@@ -941,55 +961,7 @@ public sealed class AsyncReaderWriterLock : IResettable
             return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Writer));
         }
 
-        return WriterLockAsyncImpl(cancellationToken);
-    }
-
-    [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> WriterLockAsyncImpl(CancellationToken cancellationToken)
-    {
-        _spinLock.Enter();
-        try
-        {
-            // double check for race conditions
-            if (Interlocked.CompareExchange(ref _status, (int)LockState.Writer, (int)LockState.Uncontested) == (int)LockState.Uncontested)
-            {
-                return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Writer));
-            }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
-            }
-
-            if (!_localWriterWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
-            {
-                waiter = _pool.GetPooledWaiter(this);
-            }
-            waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
-            waiter.CancellationToken = cancellationToken;
-
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_writerCancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(WriterCancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waitingWriters.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
-        }
-        finally
-        {
-            _spinLock.Exit();
-        }
+        return WriterLockAsyncImpl(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
     /// <summary>
@@ -1015,12 +987,7 @@ public sealed class AsyncReaderWriterLock : IResettable
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
-        if (timeout == Timeout.InfiniteTimeSpan)
-        {
-            return WriterLockAsync(cancellationToken);
-        }
-
-        if (timeout < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan) throw new ArgumentOutOfRangeException(nameof(timeout));
 
         if (Interlocked.CompareExchange(ref _status, (int)LockState.Writer, (int)LockState.Uncontested) == (int)LockState.Uncontested)
         {
@@ -1032,12 +999,15 @@ public sealed class AsyncReaderWriterLock : IResettable
             return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
         }
 
-        return WriterLockAsyncImplWithTimeout(timeout, cancellationToken);
+        return WriterLockAsyncImpl(timeout, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
-    private ValueTask<Releaser> WriterLockAsyncImplWithTimeout(TimeSpan timeout, CancellationToken cancellationToken)
+    private ValueTask<Releaser> WriterLockAsyncImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<Releaser> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -1051,30 +1021,39 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
             }
 
-            if (!_localWriterWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            if (!_localWriterWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
-            waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
-                WriterTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
 
-#if NET6_0_OR_GREATER
-            waiter.CancellationTokenRegistration =
-                cancellationToken.UnsafeRegister(_writerCancellationCallbackAction, waiter);
-#else
-            waiter.CancellationTokenRegistration =
-                cancellationToken.Register(WriterCancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-
+            version = waiter.Version;
             _waitingWriters.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
+
+            if (timeout != Timeout.InfiniteTimeSpan)
+            {
+                waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
+                    WriterTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
+            }
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_writerCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(WriterCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+
+        return new ValueTask<Releaser>(waiter, version);
     }
 
     /// <summary>
@@ -1090,6 +1069,9 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <returns>A <see cref="ValueTask{Releaser}"/> that completes when the writer lock is acquired.</returns>
     private ValueTask<Releaser> UpgradeToWriterLockImpl(TimeSpan timeout, CancellationToken cancellationToken)
     {
+        ManualResetValueTaskSource<Releaser> waiter;
+        short version;
+
         // no fast path because the upgrade always transitions from a contested state
         _spinLock.Enter();
         try
@@ -1110,41 +1092,43 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
             }
 
-            if (!_localUpgradedWriterWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<Releaser> waiter))
+            if (!_localUpgradedWriterWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
             waiter.CancellationToken = cancellationToken;
 
+            version = waiter.Version;
+            _waitingUpgradedWriters.Enqueue(waiter);
+
             if (timeout != Timeout.InfiniteTimeSpan)
             {
                 waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                     UpgradedWriterTimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
             }
-
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_upgradedWriterCancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(UpgradedWriterCancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waitingUpgradedWriters.Enqueue(waiter);
-            return new ValueTask<Releaser>(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_upgradedWriterCancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(UpgradedWriterCancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask<Releaser>(waiter, version);
     }
 
     internal bool InternalReaderWaiterInUse => _localReaderWaiter.InUse;

--- a/src/Threading/Async/Pooled/AsyncSemaphore.cs
+++ b/src/Threading/Async/Pooled/AsyncSemaphore.cs
@@ -214,6 +214,9 @@ public sealed class AsyncSemaphore
             return new ValueTask(Task.FromCanceled<bool>(cancellationToken));
         }
 
+        ManualResetValueTaskSource<bool> waiter;
+        short version;
+
         _spinLock.Enter();
         try
         {
@@ -237,42 +240,44 @@ public sealed class AsyncSemaphore
                 return new ValueTask(Task.FromCanceled(cancellationToken));
             }
 
-            if (!_localWaiter.TryGetValueTaskSource(out ManualResetValueTaskSource<bool> waiter))
+            if (!_localWaiter.TryGetValueTaskSource(out waiter))
             {
                 waiter = _pool.GetPooledWaiter(this);
             }
             waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
+            waiter.CancellationToken = cancellationToken;
+
+            version = waiter.Version;
+            _waiters.Enqueue(waiter);
 
             if (timeout != Timeout.InfiniteTimeSpan)
             {
                 waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                     TimerCallback, waiter, timeout, Timeout.InfiniteTimeSpan);
             }
-
-            waiter.CancellationToken = cancellationToken;
-            if (cancellationToken.CanBeCanceled)
-            {
-#if NET6_0_OR_GREATER
-                // Use UnsafeRegister on .NET 6+ for allocation free registration
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                waiter.CancellationTokenRegistration =
-                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
-            }
-            else
-            {
-                Debug.Assert(waiter.CancellationTokenRegistration == default);
-            }
-
-            _waiters.Enqueue(waiter);
-            return new ValueTask(waiter, waiter.Version);
         }
         finally
         {
             _spinLock.Exit();
         }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+#if NET6_0_OR_GREATER
+            // Use UnsafeRegister on .NET 6+ for allocation free registration
+            waiter.CancellationTokenRegistration =
+                cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+            waiter.CancellationTokenRegistration =
+                cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+        }
+        else
+        {
+            Debug.Assert(waiter.CancellationTokenRegistration == default);
+        }
+
+        return new ValueTask(waiter, version);
     }
 
     /// <summary>


### PR DESCRIPTION
A cancelled token may call itself on register and deadlock in the spinlock.
Fix: move registration outside of spinlock, ensure that version is consistent by capturing it inside the spinlock.