### PR TITLE
Return the timeout exception when the timer expires

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ All lock waiters link into `WaiterQueue<T>` without heap allocation per waiter; 
 
 ### `CryptoHives.Foundation.Threading.Analyzers`
 
-Roslyn analyzer + code-fix provider that ships bundled inside the `Threading` NuGet package (transitive via `analyzers/dotnet/cs`).
+Roslyn analyzer + code-fix provider for the `Threading` NuGet package. Needs to be added separately.
 
 Diagnostics:
 | ID | Severity | Description |

--- a/CryptoHives .NET Foundation.sln
+++ b/CryptoHives .NET Foundation.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		CLA.txt = CLA.txt
+		CLAUDE.md = CLAUDE.md
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE = LICENSE
 		ORG-OWNERSHIP.md = ORG-OWNERSHIP.md

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-## 🛡️ CryptoHives Open Source Initiative 🐝
+## CryptoHives Open Source Initiative 🐝
 
-An open, community-driven cryptography and performance library collection for the .NET ecosystem.
+An open, community-driven collection of cryptography and performance libraries for the .NET ecosystem.
 
-While .NET has become a powerful platform for building secure and high-performance applications for any use case on many platforms, there is a need to expose high performance patterns as simple-to-use libraries and to rethink how cryptography is relying on vastly different OS implementations with varying feature and performance characteristics.
-The goal of the CryptoHives Open Source Initiative is to provide a collection of packages for that matter.
+.NET is a solid platform for building secure, high-performance applications across almost any target, but two gaps keep showing up: high-performance patterns rarely get packaged as simple, drop-in libraries, and cryptography still leans heavily on whatever the underlying OS happens to provide, with all the inconsistency in features and performance that brings. CryptoHives exists to close both gaps, one package at a time.
 
 ---
 
-## 🏗️ Architecture Overview
+## Architecture Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────┐
@@ -72,64 +71,62 @@ Keccak class hierarchy (Security.Cryptography):
 ```
 
 ---
-The **CryptoHives Open Source Initiative** is a collection of modern, high-assurance libraries for .NET, developed and maintained by **The Keepers of the CryptoHives**. 
-Each package is designed for security, interoperability, and clarity — making it easy to build secure systems for high performance transformation pipelines and for cryptography workloads without sacrificing developer experience.
 
-Each library targets a specific use case:
-- **Threading** — high-performance async synchronization primitives optimized for no/low allocation and high throughput scenarios using ValueTask-based waiters and ObjectPool-backed resource management
-- **Memory** — pooled buffer management utilities leveraging ArrayPool<T> and modern .NET memory APIs to minimize GC pressure for transformation pipelines and cryptographic workloads which use ReadOnlySpan or IBufferWriter
-- **Cryptography** — OS independent implementations of .NET cryptography as a plug in replacement
+The **CryptoHives Open Source Initiative** is maintained by **The Keepers of the CryptoHives** and built around three packages, each aimed at a specific problem:
 
----
-
-## 📚 Documentation
-
-- 📖 **[Full Documentation](https://cryptohives.github.io/Foundation/)** - Comprehensive guides, API reference, and examples
-- 🚀 [Getting Started Guide](https://cryptohives.github.io/Foundation/getting-started.html)
-- 📦 [Package Documentation](https://cryptohives.github.io/Foundation/packages/index.html)
-- 📚 [API Reference](https://cryptohives.github.io/Foundation/api/index.html)
+- **Threading** — async synchronization primitives built for low/no allocation and high throughput, using `ValueTask`-based waiters backed by pooled resources
+- **Memory** — buffer management on top of `ArrayPool<T>` and the modern .NET memory APIs, meant to keep GC pressure out of transformation pipelines and crypto workloads that work in terms of `ReadOnlySpan` or `IBufferWriter`
+- **Security.Cryptography** — OS-independent reimplementations of algorithms already in `System.Security.Cryptography`, usable as drop-in replacements
 
 ---
 
-## 🧬 Features and Design Principles
+## Documentation
 
-### 🧱 Orthogonal Design
-- All development is done on free and open-source tools, e.g. .NET SDK, Visual Studio Community Edition, Visual Studio Code, GitHub, Azure DevOps, etc.
-- Each package is designed to be orthogonal and composable with other CryptoHives packages to avoid deep cross dependencies
-- Dependencies on other packages are kept to a minimum and shall only include widely adopted, well-maintained libraries, e.g. the Microsoft.Extensions
-- OS and hardware dependencies are avoided wherever possible to ensure deterministic behavior across all platforms and runtimes, specifically for security implementations
-- There is no intention to replace or shadow existing .NET class libraries; instead, CryptoHives packages are designed to complement and extend existing functionality
-
-### ⚡ High-Performance Primitives
-- All CryptoHives packages are designed for high performance and no operational allocations to optimize high performance transformation pipelines and cryptography workloads
-- Algorithms may use managed SIMD intrinsics with scalar fallback.
-- Package performance and memory usage are benchmarked against reference implementations
-
-### 🔐 Secure Development Policy
-- Standards-Based Cryptography – Implementations are written from official public specifications and standards (NIST, RFC, ISO)
-- All algorithms are verified against official test vectors from specification documents
-- Review process includes algorithm validation against reference implementations
-- Threat-Modeled by Design – All public APIs and network interfaces assume hostile input
-- Secure by Default & Validation – Minimal attack surface, explicit configuration, strict input checks, and resource bounds
-- Dependency & Supply-Chain Safety – Minimal, vetted dependencies; reproducible signed (planned) releases.
-- Automated Verification – Fuzzing (planned), static analysis, and safe error handling to prevent misuse and information leaks.
-- Development may use AI-assisted tooling; no guarantee of clean-room provenance is claimed
+- 📖 **[Full Documentation](https://cryptohives.github.io/Foundation/)** — guides, API reference, examples
+- [Getting Started Guide](https://cryptohives.github.io/Foundation/getting-started.html)
+- [Package Documentation](https://cryptohives.github.io/Foundation/packages/index.html)
+- [API Reference](https://cryptohives.github.io/Foundation/api/index.html)
 
 ---
 
-## 🐝 Available CryptoHives
+## Design Principles
 
-### 🛠️ Buffer Pools (Memory)
+### Orthogonal by design
+- Everything is built with free and open-source tooling — the .NET SDK, Visual Studio Community, VS Code, GitHub, Azure DevOps.
+- Packages are meant to stand on their own; we try hard to avoid deep cross-dependencies between them.
+- Dependencies on anything outside CryptoHives are kept minimal and limited to widely adopted, well-maintained libraries (e.g. `Microsoft.Extensions.*`).
+- OS and hardware dependencies are avoided where possible, so behavior stays deterministic across platforms and runtimes — this matters especially for the crypto implementations.
+- None of this is meant to replace or compete with the existing .NET class library. It's meant to complement it.
+
+### Built for performance
+- Every package targets high throughput with no steady-state allocations, for both transformation pipelines and crypto workloads.
+- Where it helps, algorithms use managed SIMD intrinsics with a scalar fallback for platforms that don't support them.
+- Performance and memory usage are benchmarked against reference implementations, not just asserted.
+
+### Secure development policy
+- Implementations are written directly from public specifications (NIST, RFC, ISO) rather than ported from other codebases.
+- Every algorithm is checked against official test vectors from its specification.
+- Reviews include validation against independent reference implementations.
+- Public APIs and anything touching the network are treated as hostile-input surfaces by default.
+- Defaults favor a minimal attack surface: explicit configuration, strict input validation, bounded resource use.
+- Dependencies are kept minimal and vetted; reproducible, signed releases are on the roadmap.
+- Fuzzing is planned; static analysis and defensive error handling are already in place to limit misuse and information leaks.
+- Some development uses AI-assisted tooling — we're not claiming clean-room provenance for every line.
+
+---
+
+## Available CryptoHives
+
+### Buffer Pools (Memory)
 Pooled buffer management for transformation pipelines and high-frequency I/O:
 
-- `ArrayPoolMemoryStream` — drop-in `MemoryStream` replacement backed by `ArrayPool<byte>` with `ReadOnlySequence` handoff support
-- `ReadOnlySequenceMemoryStream` — read from `ReadOnlySequence<byte>` as `MemoryStream` without copying
-- `ArrayPoolBufferWriter<T>` — `IBufferWriter<T>` over pooled arrays for e.g. `Utf8JsonWriter`
+- `ArrayPoolMemoryStream` — drop-in `MemoryStream` replacement backed by `ArrayPool<byte>`, with `ReadOnlySequence` handoff support
+- `ReadOnlySequenceMemoryStream` — reads a `ReadOnlySequence<byte>` as a `MemoryStream` without copying
+- `ArrayPoolBufferWriter<T>` — `IBufferWriter<T>` over pooled arrays, e.g. for `Utf8JsonWriter`
 - Ownership primitives for zero-copy handoff of pooled buffers
 
-### 🚀 Concurrency Tools (Threading)
-Async-compatible synchronization primitives built on `ObjectPool` and `ValueTask<T>`.
-Designed to eliminate `Task` / `TaskCompletionSource<T>` allocations on the hot path.
+### Concurrency Tools (Threading)
+Async-compatible synchronization primitives built on `ObjectPool` and `ValueTask<T>`, designed to keep `Task` / `TaskCompletionSource<T>` allocations off the hot path.
 
 - `AsyncLock` — mutual exclusion
 - `AsyncSemaphore` — counting semaphore
@@ -137,16 +134,14 @@ Designed to eliminate `Task` / `TaskCompletionSource<T>` allocations on the hot 
 - `AsyncReaderWriterLock`
 - `AsyncBarrier` / `AsyncCountdownEvent`
 
-All primitives support `CancellationToken` and `ConfigureAwait(false)` without the need for extra allocations.
-New in 0.6: Timeout support using `TimeProvider` (`ITimer` may be allocated on contention)
+All primitives support `CancellationToken` and `ConfigureAwait(false)` without extra allocations. New in 0.6: timeout support via `TimeProvider` (an `ITimer` is only allocated once there's actual contention).
 
-A C# analyzer to avoid common ValueTask usage mistakes is available as standalone package.
+A Roslyn analyzer that catches common `ValueTask` usage mistakes ships as a standalone package.
 
-⏱️ [Async primitive benchmarks](https://cryptohives.github.io/Foundation/packages/threading/benchmarks.html) — contested and uncontested scenarios, comparing pooled `ValueTask` vs. existing `Task`-based alternatives.
+⏱️ [Async primitive benchmarks](https://cryptohives.github.io/Foundation/packages/threading/benchmarks.html) — contested and uncontested scenarios, pooled `ValueTask` vs. existing `Task`-based alternatives.
 
-### 🔐 Managed Code Cryptography (Security.Cryptography)
-Fully managed implementations of cryptographic hash algorithms, MACs, and cipher algorithms, written from NIST/RFC/ISO specifications and verified against official test vectors.
-No OS crypto dependency — deterministic results on every platform. Hardware acceleration via AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics is automatically enabled on supported hardware, in some cases even outperforming OS implementations.
+### Managed Code Cryptography (Security.Cryptography)
+Fully managed hash, MAC, and cipher implementations, written from NIST/RFC/ISO specifications and checked against official test vectors. No OS crypto dependency, so results are deterministic on every platform. Where the hardware supports it, AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics kick in automatically — in some cases outperforming the OS-provided implementation.
 
 **Algorithms:**
 
@@ -165,19 +160,19 @@ No OS crypto dependency — deterministic results on every platform. Hardware ac
 | Cipher (Block) | AES-128, AES-192, AES-256 (ECB/CBC/CTR), ChaCha20 |
 | Cipher (Regional) | SM4, ARIA (128/192/256), Camellia (128/192/256), Kuznyechik, Kalyna (128/256), SEED |
 | Regional | SM3, Streebog, Kupyna, LSH, Whirlpool, RIPEMD-160 |
-| Legacy | SHA-1, MD5 (backward compatibility only) |
+| Legacy | SHA-1, MD5 (kept for backward compatibility only) |
 
 All XOF algorithms implement `IExtendableOutput` for streaming variable-length output via `Absorb` / `Squeeze` / `Reset`.
 
-**⏱️ Cryptography Benchmarks**
+**Benchmarks**
 
-Measured with BenchmarkDotNet across various payloads, comparing managed vs. reference vs. OS implementations.
+Measured with BenchmarkDotNet across a range of payload sizes, comparing our managed implementations against reference libraries and the OS-provided versions.
 - [Hash algorithms](https://cryptohives.github.io/Foundation/packages/security/cryptography/benchmarks-hash.html)
 - [Cipher algorithms](https://cryptohives.github.io/Foundation/packages/security/cryptography/benchmarks-cipher.html)
 
 ---
 
-### 📦 Nuget Packages
+### NuGet Packages
 
 | Package | Description | NuGet | Documentation |
 |----------|--------------|--------|---------------|
@@ -185,9 +180,9 @@ Measured with BenchmarkDotNet across various payloads, comparing managed vs. ref
 | `Threading` | Pooled async synchronization | [![NuGet](https://img.shields.io/nuget/v/CryptoHives.Foundation.Threading.svg)](https://www.nuget.org/packages/CryptoHives.Foundation.Threading) | [Docs](https://cryptohives.github.io/Foundation/packages/threading/index.html) |
 | `Security.Cryptography` | Hash, MAC & cipher algorithms | [![NuGet](https://img.shields.io/nuget/v/CryptoHives.Foundation.Security.Cryptography.svg)](https://www.nuget.org/packages/CryptoHives.Foundation.Security.Cryptography) | [Docs](https://cryptohives.github.io/Foundation/packages/security/cryptography/index.html) |
 
-All packages are published under the `CryptoHives.Foundation` prefix and namespace — see the Nuget [CryptoHives](https://www.nuget.org/packages?q=CryptoHives) for details.
+All packages are published under the `CryptoHives.Foundation` prefix and namespace — see [CryptoHives on NuGet](https://www.nuget.org/packages?q=CryptoHives) for the full list.
 
-### 🩺 CryptoHives Health
+### Build Status
 
 [![Azure DevOps](https://dev.azure.com/cryptohives/Foundation/_apis/build/status%2FCryptoHives.Foundation?branchName=main)](https://dev.azure.com/cryptohives/Foundation/_build/latest?definitionId=6&branchName=main)
 [![Tests](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml)
@@ -196,15 +191,15 @@ All packages are published under the `CryptoHives.Foundation` prefix and namespa
 
 ---
 
-## 🧩 Installation
+## Installation
 
-Install via NuGet CLI:
+Via the NuGet CLI:
 
 ```bash
 dotnet add package CryptoHives.Foundation.Threading
 ```
 
-Or using the Visual Studio Package Manager:
+Or from the Visual Studio Package Manager:
 
 ```powershell
 Install-Package CryptoHives.Foundation.Threading
@@ -212,9 +207,7 @@ Install-Package CryptoHives.Foundation.Threading
 
 ---
 
-## 🧠 Usage Examples
-
----
+## Usage Examples
 
 ```csharp
 using CryptoHives.Foundation.Security.Cryptography.Hash;
@@ -232,12 +225,10 @@ Span<byte> output = stackalloc byte[128];
 shake.Squeeze(output);
 ```
 
----
-
 ```csharp
 using CryptoHives.Foundation.Threading.Async.Pooled;
 
-// Allocation-free async lock, even with cancellation token
+// Allocation-free async lock, even with a cancellation token
 private readonly AsyncLock _lock = new();
 
 public async Task DoWorkAsync(CancellationToken ct)
@@ -249,62 +240,52 @@ public async Task DoWorkAsync(CancellationToken ct)
 
 ---
 
-## 🔐 Security Policy
+## Security Policy
 
-Security is our top priority.
-
-If you discover a vulnerability, **please do not open a public issue.**  
-Instead, please follow the guidelines on the [CryptoHives Open Source Initiative Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md).
+Security comes first here. If you find a vulnerability, please don't open a public issue — follow the process described on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md) instead.
 
 ---
 
-## 🔏 Nuget Package Assembly Code Signing
+## NuGet Package Signing
 
-Assemblies in our Nuget packages are currently not code signed. Once there is sufficient demand and funding available, the Keepers plan to implement code signing for all released packages.
-
----
-
-## 📝 No-Nonsense Matters
-
-This project is released under the MIT License because open collaboration matters.  
-However, the Keepers are well aware that MIT-licensed code often gets copied, repackaged, or commercialized without giving credit.  
-
-If you use this code, please do so responsibly:
-- Give visible credit to the **CryptoHives Open Source Initiative** or **The Keepers of the CryptoHives** and refer to the original source.
-- Contribute improvements back and report issues.
-
-Open source thrives on respect, not just permissive licenses.
+Packages aren't code-signed yet. The Keepers plan to add signing once there's enough demand (and funding) to justify it.
 
 ---
 
-## ⚖️ License
+## A Note on Licensing
 
-Each component of the CryptoHives Open Source Initiative is licensed under a SPDX-compatible MIT license.  
-By default, packages use the following license tags:
+This project is MIT-licensed because we believe in open collaboration. That said, we're aware MIT code gets copied, repackaged, and resold without credit fairly often — if you use this code, we'd appreciate it if you didn't do that:
+
+- Give visible credit to the **CryptoHives Open Source Initiative** / **The Keepers of the CryptoHives** and link back to the source.
+- Send improvements back upstream and report issues rather than silently forking.
+
+None of that is legally required under MIT — it's just what makes open source worth doing.
+
+---
+
+## License
+
+Every component is licensed under MIT. Source files carry the following SPDX header by default:
 
 ```csharp
 // SPDX-FileCopyrightText: <year> The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 ```
 
-Some inherited components may use alternative MIT license headers, according to their origin and specific requirements those headers are retained.
+A few inherited components use their original MIT-style headers instead, kept as-is for provenance.
 
 ---
 
-## 🐝 About The Keepers of the CryptoHives
+## About The Keepers of the CryptoHives
 
-The **CryptoHives Open Source Initiative** project is maintained by **The Keepers of the CryptoHives** —  
-a collective of developers dedicated to advancing open, verifiable, and high-performance cryptography in .NET.
+The CryptoHives Open Source Initiative is maintained by **The Keepers of the CryptoHives**, a loose collective of developers working on open, verifiable, high-performance cryptography for .NET.
 
 ---
 
-## 🧩 Contributing
+## Contributing
 
-Contributions, issue reports, and pull requests are welcome!
-
-Please see the [Contributing Guide](https://github.com/CryptoHives/.github/blob/main/CONTRIBUTING.md) before submitting code.
+Issues and pull requests are welcome. Please read the [Contributing Guide](https://github.com/CryptoHives/.github/blob/main/CONTRIBUTING.md) before sending a PR.
 
 ---
 
 © 2026 The Keepers of the CryptoHives
-

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Each package is designed for security, interoperability, and clarity — making 
 Each library targets a specific use case:
 - **Threading** — high-performance async synchronization primitives optimized for no/low allocation and high throughput scenarios using ValueTask-based waiters and ObjectPool-backed resource management
 - **Memory** — pooled buffer management utilities leveraging ArrayPool<T> and modern .NET memory APIs to minimize GC pressure for transformation pipelines and cryptographic workloads which use ReadOnlySpan or IBufferWriter
-- **Cryptography** — OS independent implementation of all .NET cryptography as a plug in replacement
+- **Cryptography** — OS independent implementations of .NET cryptography as a plug in replacement
 
 ---
 

--- a/docfx/getting-started.md
+++ b/docfx/getting-started.md
@@ -1,36 +1,36 @@
-## Getting Started with CryptoHives.Foundation libraries
+## Getting Started with CryptoHives.Foundation
 
-Welcome to the CryptoHives .NET Foundation libraries! Each package includes installation instructions, quick-start examples, and detailed API documentation.
+Each package below installs independently and comes with its own quick-start examples and API reference.
 
 ## Packages
 
-### 💾 [Memory Package](packages/memory/index.md)
+### [Memory Package](packages/memory/index.md)
 
-Allocation-efficient buffer management using `ArrayPool<T>` — pooled memory streams, buffer writers, and `ReadOnlySequence<byte>` support.
+Allocation-efficient buffer management on top of `ArrayPool<T>` — pooled memory streams, buffer writers, and `ReadOnlySequence<byte>` support.
 
 ```bash
 dotnet add package CryptoHives.Foundation.Memory
 ```
 
-### 🔄 [Threading Package](packages/threading/index.md)
+### [Threading Package](packages/threading/index.md)
 
-`ValueTask`-based async synchronization primitives with pooled waiter objects — includes `AsyncLock`, `AsyncAutoResetEvent`, `AsyncManualResetEvent`, `AsyncBarrier`, `AsyncReaderWriterLock`, `AsyncSemaphore`, and `AsyncCountdownEvent`.
+`ValueTask`-based async synchronization primitives with pooled waiter objects: `AsyncLock`, `AsyncAutoResetEvent`, `AsyncManualResetEvent`, `AsyncBarrier`, `AsyncReaderWriterLock`, `AsyncSemaphore`, and `AsyncCountdownEvent`.
 
 ```bash
 dotnet add package CryptoHives.Foundation.Threading
 ```
 
-### 🔐 [Security.Cryptography Package](packages/security/cryptography/index.md)
+### [Security.Cryptography Package](packages/security/cryptography/index.md)
 
-Specification-based cryptographic hash algorithms, MACs, ciphers, and key derivation functions — SHA-2, SHA-3, SHAKE, cSHAKE, TurboSHAKE, KangarooTwelve, KMAC, BLAKE2, BLAKE3, Ascon, Keccak, SM3, Streebog, Kupyna, LSH, Whirlpool, RIPEMD-160, AES-CBC/GCM/CCM, ChaCha20, ChaCha20-Poly1305, XChaCha20-Poly1305, Ascon-AEAD128, regional ciphers (SM4, ARIA, Camellia, Kuznyechik, Kalyna, SEED), HKDF/KBKDF/PBKDF2, and legacy MD5/SHA-1.
+Specification-based hash algorithms, MACs, ciphers, and key derivation functions — SHA-2, SHA-3, SHAKE, cSHAKE, TurboSHAKE, KangarooTwelve, KMAC, BLAKE2, BLAKE3, Ascon, Keccak, SM3, Streebog, Kupyna, LSH, Whirlpool, RIPEMD-160, AES-CBC/GCM/CCM, ChaCha20, ChaCha20-Poly1305, XChaCha20-Poly1305, Ascon-AEAD128, regional ciphers (SM4, ARIA, Camellia, Kuznyechik, Kalyna, SEED), HKDF/KBKDF/PBKDF2, and legacy MD5/SHA-1.
 
 ```bash
 dotnet add package CryptoHives.Foundation.Security.Cryptography
 ```
 
-### 🔍 [Threading Analyzers (Standalone)](packages/threading.analyzers/index.md)
+### [Threading Analyzers (Standalone)](packages/threading.analyzers/index.md)
 
-Roslyn analyzers for `ValueTask` misuse detection. This package is for projects that want threading analyzers for the Threading library.
+Roslyn analyzers for `ValueTask` misuse. Install this alongside the Threading package if you want the compile-time checks.
 
 ```bash
 dotnet add package CryptoHives.Foundation.Threading.Analyzers
@@ -38,7 +38,6 @@ dotnet add package CryptoHives.Foundation.Threading.Analyzers
 
 ## Support
 
-For issues and questions:
 - [GitHub Issues](https://github.com/CryptoHives/Foundation/issues)
 - [Security Policy](https://github.com/CryptoHives/Foundation/SECURITY.md)
 

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -4,74 +4,74 @@ _layout: landing
 
 # CryptoHives .NET Foundation
 
-Welcome to the **CryptoHives .NET Foundation** documentation!
+Welcome to the **CryptoHives .NET Foundation** documentation.
 
 ## Overview
 
-The CryptoHives .NET Foundation provides libraries for .NET applications focusing on high performance memory management, threading primitives, and cryptographic algorithms.
+CryptoHives .NET Foundation is a set of libraries for .NET applications, covering high-performance memory management, async threading primitives, and cryptographic algorithms.
 
 ## Ecosystem
 
-The initiative currently includes:
-- [Threading](packages/threading/index.md) — high-performance async synchronization primitives optimized for no/low allocation and high throughput scenarios using ValueTask-based waiters and ObjectPool-backed resource management
-- [Memory](packages/memory/index.md) — pooled buffer management utilities leveraging ArrayPool<T> and modern .NET memory APIs to minimize GC pressure for transformation pipelines and cryptographic workloads which use ReadOnlySpan or IBufferWriter
-- [Cryptography](packages/security/cryptography/index.md) — OS independent implementations of .NET cryptography as a plug in replacement
+The initiative currently includes three packages:
+
+- [Threading](packages/threading/index.md) — async synchronization primitives built for low/no allocation and high throughput, using `ValueTask`-based waiters backed by pooled resources
+- [Memory](packages/memory/index.md) — buffer management on top of `ArrayPool<T>` and the modern .NET memory APIs, for transformation pipelines and crypto workloads that work in terms of `ReadOnlySpan` or `IBufferWriter`
+- [Cryptography](packages/security/cryptography/index.md) — OS-independent reimplementations of `System.Security.Cryptography` algorithms, usable as drop-in replacements
 
 ## Available Packages
 
-### 💾 [Memory Package](packages/memory/index.md)
+### [Memory Package](packages/memory/index.md)
 
-The Memory package provides allocation-efficient buffer management utilities that leverage `ArrayPool<T>` and modern .NET memory APIs to minimize garbage collection pressure for transformation pipelines and cryptographic workloads.
+Buffer management utilities that lean on `ArrayPool<T>` and modern .NET memory APIs to keep GC pressure out of transformation pipelines and cryptographic workloads.
 
-**Key Features:**
-- `ArrayPoolMemoryStream` and `ArrayPoolBufferWriter<T>` classes backed by `ArrayPool<byte>.Shared`
-- Lifetime managed `ReadOnlySequence<byte>` support with pooled storage
-- `ReadOnlySequenceMemoryStream` to stream from `ReadOnlySequence<byte>`
-- `ObjectPool` backed resource management helpers, e.g. for `StringBuilder`
+**Key features:**
+- `ArrayPoolMemoryStream` and `ArrayPoolBufferWriter<T>`, both backed by `ArrayPool<byte>.Shared`
+- Lifetime-managed `ReadOnlySequence<byte>` support over pooled storage
+- `ReadOnlySequenceMemoryStream` for streaming from an existing `ReadOnlySequence<byte>`
+- `ObjectPool`-backed resource management helpers, e.g. for `StringBuilder`
 
-[Explore Memory Package](packages/memory/index.md)
+[Explore the Memory package →](packages/memory/index.md)
 
-### 🔄 [Threading Package](packages/threading/index.md)
+### [Threading Package](packages/threading/index.md)
 
-The Threading package provides high-performance async synchronization primitives optimized for low allocation and high throughput scenarios.
+Async synchronization primitives built for low allocation and high throughput.
 
-**Key Features:**
-- All waiters implemented as `ValueTask`-based synchronization primitives with low memory allocation design
-- Optional Roslyn analyzer package to detect common `ValueTask` misuse patterns at compile time
-- Full `CancellationToken` support in all Wait/Lock primitives 
-- Implementations use `IValueTaskSource<T>` based classes backed by `ObjectPool<T>` to avoid allocations by recycling waiter objects
-- Async mutual exclusion with `AsyncLock` and scoped locking via `IDisposable` pattern
-- `AsyncAutoResetEvent` and `AsyncManualResetEvent` complementing existing implementations which are `Task` based
-- Replacement for .NET barriers with `AsyncBarrier` supporting async waits
-- Pooled implementations of `AsyncReaderWriterLock`, `AsyncSemaphore` and `AsyncCountdownEvent` with async wait support
-- Fast path optimizations for uncontended scenarios
-- No allocation design for hot-path code and cancellation tokens (see [Benchmarks](packages/threading/benchmarks.md))
-- [Benchmarks](packages/threading/benchmarks.md) comparing performance against existing .NET synchronization primitives and various other popular implementations
+**Key features:**
+- All waiters are `ValueTask`-based synchronization primitives, designed around low memory allocation
+- An optional Roslyn analyzer package that catches common `ValueTask` misuse at compile time
+- Full `CancellationToken` support across every wait/lock primitive
+- `IValueTaskSource<T>`-based implementations backed by `ObjectPool<T>`, so waiter objects get recycled instead of allocated
+- `AsyncLock` for async mutual exclusion, with scoped locking via the `IDisposable` pattern
+- `AsyncAutoResetEvent` and `AsyncManualResetEvent`, complementing the existing `Task`-based equivalents
+- `AsyncBarrier` as an async-aware replacement for the .NET barrier
+- Pooled `AsyncReaderWriterLock`, `AsyncSemaphore`, and `AsyncCountdownEvent`, all with async wait support
+- Fast-path optimizations for the uncontended case
+- No-allocation design for hot-path code and cancellation tokens (see [Benchmarks](packages/threading/benchmarks.md))
 
-[Explore Threading Package](packages/threading/index.md)
+[Explore the Threading package →](packages/threading/index.md)
 
-### 🔐 [Security.Cryptography Package](packages/security/cryptography/index.md)
+### [Security.Cryptography Package](packages/security/cryptography/index.md)
 
-The Cryptography package provides specification-based implementations of cryptographic hash algorithms, message authentication codes (MACs), cipher algorithms, and key derivation functions, all implemented as fully managed code without OS dependencies.
+Specification-based implementations of hash algorithms, MACs, ciphers, and key derivation functions, all fully managed and OS-independent.
 
-**Key Features:**
-- SHA-1, SHA-2, SHA-3 family implementations with full test vector validation
+**Key features:**
+- SHA-1, SHA-2, SHA-3 families, all validated against full test vectors
 - SHAKE and cSHAKE extendable-output functions (XOF) for variable-length output
-- TurboSHAKE and KangarooTwelve (KT128/KT256) high-performance XOFs
+- TurboSHAKE and KangarooTwelve (KT128/KT256), the high-performance XOFs
 - KMAC (Keccak Message Authentication Code) for authenticated hashing
 - Ascon lightweight hashing and AEAD (NIST SP 800-232) for constrained environments
-- BLAKE2b, BLAKE2s, and BLAKE3 high-performance hashing with keyed modes
-- Keccak-256, Keccak-384, Keccak-512 for Ethereum compatibility
-- International standards: SM3 (Chinese), Streebog/GOST (Russian), Kupyna/DSTU (Ukrainian), LSH/KS (Korean), Whirlpool (ISO)
-- Legacy algorithms: MD5, SHA-1, RIPEMD-160 (for compatibility only)
-- AES-CBC, AES-GCM, AES-CCM, ChaCha20, ChaCha20-Poly1305, XChaCha20-Poly1305, and Ascon-AEAD128 cipher implementations
+- BLAKE2b, BLAKE2s, and BLAKE3, with keyed modes
+- Keccak-256/384/512 for Ethereum compatibility
+- Regional standards: SM3 (China), Streebog/GOST (Russia), Kupyna/DSTU (Ukraine), LSH/KS (Korea), Whirlpool (ISO)
+- Legacy algorithms MD5, SHA-1, RIPEMD-160, kept for compatibility only
+- AES-CBC, AES-GCM, AES-CCM, ChaCha20, ChaCha20-Poly1305, XChaCha20-Poly1305, and Ascon-AEAD128 ciphers
 - Regional block ciphers: SM4, ARIA, Camellia, Kuznyechik, Kalyna, SEED
 - Key derivation: HKDF, KBKDF, Concat KDF, PBKDF2, BLAKE3 DeriveKey
 - MACs: HMAC, AES-CMAC, AES-GMAC, Poly1305, KMAC, BLAKE2/3 keyed
 - AES Key Wrap with Padding (RFC 3394/5649)
-- Cross-platform consistency without OS crypto API dependencies
+- Cross-platform consistency with no dependency on OS crypto APIs
 
-[Explore Security.Cryptography Package](packages/security/cryptography/index.md)
+[Explore the Security.Cryptography package →](packages/security/cryptography/index.md)
 
 ## Platform Support
 
@@ -83,9 +83,9 @@ The Cryptography package provides specification-based implementations of cryptog
 
 ## Resources
 
-- 🔐 [Cryptographic Specifications](packages/security/cryptography/specs/README.md)
-- 🐛 [Report Issues](https://github.com/CryptoHives/Foundation/issues)
-- 💬 [Security Policy](https://github.com/CryptoHives/.github/blob/main/SECURITY.md)
+- [Cryptographic Specifications](packages/security/cryptography/specs/README.md)
+- [Report Issues](https://github.com/CryptoHives/Foundation/issues)
+- [Security Policy](https://github.com/CryptoHives/.github/blob/main/SECURITY.md)
 
 ## License
 
@@ -96,4 +96,3 @@ This project is licensed under the MIT License. See the [LICENSE](https://github
 [Impressum (Legal Notice)](impressum.md)
 
 © 2026 The Keepers of the CryptoHives
-

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -15,7 +15,7 @@ The CryptoHives .NET Foundation provides libraries for .NET applications focusin
 The initiative currently includes:
 - [Threading](packages/threading/index.md) — high-performance async synchronization primitives optimized for no/low allocation and high throughput scenarios using ValueTask-based waiters and ObjectPool-backed resource management
 - [Memory](packages/memory/index.md) — pooled buffer management utilities leveraging ArrayPool<T> and modern .NET memory APIs to minimize GC pressure for transformation pipelines and cryptographic workloads which use ReadOnlySpan or IBufferWriter
-- [Cryptography](packages/security/cryptography/index.md) — OS independent implementation of all .NET cryptography as a plug in replacement
+- [Cryptography](packages/security/cryptography/index.md) — OS independent implementations of .NET cryptography as a plug in replacement
 
 ## Available Packages
 

--- a/docfx/packages/memory/index.md
+++ b/docfx/packages/memory/index.md
@@ -1,17 +1,6 @@
-﻿# CryptoHives.Foundation.Memory Package
+# CryptoHives.Foundation.Memory Package
 
-The Memory package provides high-performance, allocation-efficient buffer management utilities for .NET applications.
-
-## Overview
-
-This package contains classes that leverage `ArrayPool<T>` and modern .NET memory APIs to minimize allocations and reduce garbage collection pressure in high-throughput scenarios.
-
-## Key Features
-
-- **Pooled Memory Streams**: Memory streams backed by `ArrayPool<byte>.Shared`
-- **Zero-Copy APIs**: Support for `ReadOnlySequence<T>` and `Span<T>`
-- **Buffer Writers**: IBufferWriter implementations with pooled storage
-- **RAII Pattern**: Safe object pool resource management with `ObjectOwner<T>`
+Buffer management utilities for .NET, built on `ArrayPool<T>` and the modern .NET memory APIs to keep allocations and GC pressure out of high-throughput code.
 
 ## Installation
 
@@ -60,13 +49,13 @@ using var stream = new ArrayPoolMemoryStream();
 // Write data
 await stream.WriteAsync(data, cancellationToken);
 
-// Get zero-copy ReadOnlySequence
+// Get a zero-copy ReadOnlySequence
 ReadOnlySequence<byte> sequence = stream.GetReadOnlySequence();
 
 // Process without copying
 ProcessSequence(sequence);
 
-// sequence memory is returned to pool after stream is disposed
+// The sequence's memory is returned to the pool once the stream is disposed
 ```
 
 ### ArrayPoolBufferWriter
@@ -74,7 +63,7 @@ ProcessSequence(sequence);
 ```csharp
 using var writer = new ArrayPoolBufferWriter<byte>();
 
-// Get span and write
+// Get a span and write into it
 Span<byte> span = writer.GetSpan(1024);
 int written = encoder.GetBytes(text, span);
 writer.Advance(written);
@@ -82,7 +71,7 @@ writer.Advance(written);
 // Get the complete sequence
 ReadOnlySequence<byte> result = writer.GetReadOnlySequence();
 
-// sequence memory is returned to pool after writer is disposed
+// Pooled chunks are returned once the writer is disposed
 ```
 
 ### ObjectOwner
@@ -95,45 +84,26 @@ MyClass obj = owner.Object;
 
 // Use obj...
 
-// Automatically returned to pool when owner is disposed
+// Automatically returned to the pool when owner is disposed
 ```
 
-## Benefits
+## Why Pooled Buffers
 
-### Reduced Allocations
-
-- Rents buffers from `ArrayPool<T>.Shared` instead of allocating new arrays
-- Reuses pooled segments to avoid allocation churn
-- No resize-copy operations during growth
-
-### Lower GC Pressure
-
-- Fewer short-lived objects
-- Avoids Large Object Heap (LOH) allocations
-- Better for high-throughput scenarios
-
-### Zero-Copy Access
-
-- `ReadOnlySequence<T>` exposes internal segments without copying
-- `Span<T>` based Read/Write APIs
-- Efficient data processing pipelines
-
-## Performance Characteristics
+Renting from `ArrayPool<T>.Shared` instead of allocating avoids resize-copy churn and keeps large buffers off the Large Object Heap, which matters once you're pushing enough throughput that allocations start showing up in GC pauses. `ReadOnlySequence<T>` then lets you hand that pooled data to a consumer without copying it at all.
 
 - **ArrayPoolMemoryStream**: O(1) segment append, no copy-on-grow
-- **ArrayPoolBufferWriter**: Exponential chunk growth with configurable limits
-- **ReadOnlySequenceMemoryStream**: Zero-copy wrapper with O(n) seeking
+- **ArrayPoolBufferWriter**: exponential chunk growth with configurable limits
+- **ReadOnlySequenceMemoryStream**: zero-copy wrapper with O(n) seeking
 
-## Best Practices
+## A Few Things to Watch For
 
-1. **Always dispose**: Use `using` statements to ensure buffers are returned
-2. **Don't hold references**: ReadOnlySequence is only valid until the next write or dispose
-3. **Size hints**: Provide size hints to minimize reallocations
-4. **Scope carefully**: Keep writer/stream lifetime as short as possible
+- Always wrap streams and writers in a `using` so pooled buffers actually get returned.
+- A `ReadOnlySequence<byte>` from these types is only valid until the next write or dispose — don't hold onto it past that point.
+- If you know roughly how much you'll write, pass a size hint; it cuts down on reallocations.
+- Keep writer/stream lifetimes short and scoped to the operation that needs them.
 
 ## See Also
 
-- [Memory Package Classes](arraypoolmemorystream.md)
 - [Threading Package](../threading/index.md)
 
 ---

--- a/docfx/packages/security/cryptography/index.md
+++ b/docfx/packages/security/cryptography/index.md
@@ -2,19 +2,19 @@
 
 ## Overview
 
-The Cryptography package provides specification-based implementations of cryptographic hash algorithms, message authentication codes (MACs), and cipher algorithms for .NET applications. Core implementations are fully managed code with optional hardware acceleration via AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics, ensuring consistent behavior across all platforms with automatic SIMD dispatch on supported hardware.
+The Cryptography package implements hash algorithms, message authentication codes, and ciphers for .NET. The core is fully managed code, with optional hardware acceleration via AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics — dispatched automatically where the hardware supports it, with consistent behavior everywhere else.
 
 ## Key Features
 
-- **Specification-Based Implementations**: Written based on official specifications (NIST, RFC, ISO)
-- **No OS Dependencies**: Works identically on all platforms without calling OS crypto APIs
-- **Hardware Acceleration**: Optional AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics with automatic fallback
-- **Comprehensive Coverage**: SHA-1/2/3, BLAKE2/3, KMAC, AES-GCM/CCM, ChaCha20-Poly1305, Ascon-AEAD128, and many more
-- **AEAD Support**: Authenticated encryption with AES-GCM, AES-CCM, ChaCha20-Poly1305, XChaCha20-Poly1305, and Ascon-AEAD128
-- **Key Management Support**: AES Key Wrap (RFC 3394) and AES Key Wrap with Padding (RFC 5649)
-- **Variable Output**: XOF support for SHAKE, cSHAKE, KMAC, and BLAKE3
-- **Keyed Hashing**: Built-in MAC modes for BLAKE2, BLAKE3, and KMAC
-- **Standards Compliant**: Verified against NIST, RFC, and ISO test vectors
+- **Specification-based** — implemented from official NIST, RFC, and ISO specifications
+- **No OS dependencies** — behaves identically on every platform without calling OS crypto APIs
+- **Hardware acceleration** — optional AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics, with automatic fallback
+- **Broad coverage** — SHA-1/2/3, BLAKE2/3, KMAC, AES-GCM/CCM, ChaCha20-Poly1305, Ascon-AEAD128, and more
+- **AEAD support** — AES-GCM, AES-CCM, ChaCha20-Poly1305, XChaCha20-Poly1305, and Ascon-AEAD128
+- **Key management** — AES Key Wrap (RFC 3394) and AES Key Wrap with Padding (RFC 5649)
+- **Variable-length output** — XOF support for SHAKE, cSHAKE, KMAC, and BLAKE3
+- **Keyed hashing** — built-in MAC modes for BLAKE2, BLAKE3, and KMAC
+- **Standards compliant** — verified against NIST, RFC, and ISO test vectors
 
 ## Installation
 
@@ -22,8 +22,8 @@ The Cryptography package provides specification-based implementations of cryptog
 dotnet add package CryptoHives.Foundation.Security.Cryptography
 ```
 
-> Performance optimizations including AES-NI, PCLMULQDQ, VPCLMULQDQ, and SIMD intrinsics are implemented
-> for AES-GCM, AES-CCM, AES-CBC, and ChaCha20 families on .NET 8+. VPCLMULQDQ requires .NET 10+.
+> Hardware-accelerated paths (AES-NI, PCLMULQDQ, VPCLMULQDQ, SIMD intrinsics) are implemented
+> for AES-GCM, AES-CCM, AES-CBC, and ChaCha20 on .NET 8+. VPCLMULQDQ requires .NET 10+.
 
 ## Namespaces
 
@@ -141,13 +141,11 @@ using CryptoHives.Foundation.Security.Cryptography.Kdf;
 
 ## Getting Started
 
-All CryptoHives algorithms inherit from `System.Security.Cryptography.HashAlgorithm` and support two ways of computing a hash.
+Every CryptoHives algorithm inherits from `System.Security.Cryptography.HashAlgorithm` and supports two ways of computing a hash.
 
 ### Zero-allocation approach (recommended)
 
-Use `TryComputeHash` with a stack-allocated or reusable buffer to avoid heap allocations entirely.
-This is the preferred approach for performance-critical code such as tight loops, network packet processing, or blockchain validation.
-CryptoHives provides a polyfill so this API works on every target framework, including .NET Framework 4.x.
+Use `TryComputeHash` with a stack-allocated or reusable buffer to skip heap allocation entirely — the right choice for tight loops, packet processing, or anything on a hot path. CryptoHives ships a polyfill so this API works on every target framework, including .NET Framework 4.x.
 
 ```csharp
 using CryptoHives.Foundation.Security.Cryptography.Hash;
@@ -175,7 +173,7 @@ Span<byte> mac = stackalloc byte[64];
 kmac.TryComputeHash(message, mac, out _);
 ```
 
-> **Note:** The `ComputeHash(byte[])` method is also available for convenience but allocates a new `byte[]` on every call, which adds GC pressure in hot paths. Prefer `TryComputeHash` whenever possible.
+> **Note:** `ComputeHash(byte[])` is also available for convenience, but it allocates a new `byte[]` on every call. Prefer `TryComputeHash` on any hot path.
 
 ## More Examples
 
@@ -364,7 +362,7 @@ sha256.TryGetHashAndReset(hash, out _);
 
 ## Standards Compliance
 
-All implementations are verified against official test vectors:
+Every implementation is verified against its official test vectors:
 
 - **NIST FIPS 180-4**: SHA-1, SHA-2 family
 - **NIST FIPS 197**: AES (128/192/256)
@@ -396,7 +394,7 @@ See the [Cryptographic Specifications](specs/README.md) for detailed test vector
 
 ### Allocation-Free Operations
 
-All hash algorithms support `Span<T>`-based APIs for zero-allocation hashing:
+Every hash algorithm supports `Span<T>`-based APIs for zero-allocation hashing:
 
 ```csharp
 Span<byte> destination = stackalloc byte[32];
@@ -406,13 +404,13 @@ sha256.TryComputeHash(data, destination, out int bytesWritten);
 
 ### Recommended for High Throughput
 
-- **BLAKE3**: Designed for parallel processing, fastest on modern CPUs
-- **BLAKE2b**: Faster than SHA-256 on 64-bit systems
-- **BLAKE2s**: Faster than SHA-256 on 32-bit systems
+- **BLAKE3**: designed for parallel processing, fastest on modern CPUs
+- **BLAKE2b**: faster than SHA-256 on 64-bit systems
+- **BLAKE2s**: faster than SHA-256 on 32-bit systems
 
 ### Memory Usage
 
-All implementations use fixed-size internal buffers based on their block size. No dynamic allocations occur during hashing operations.
+Every implementation uses fixed-size internal buffers sized to its block size — no dynamic allocation happens during hashing.
 
 ## Comparison with System.Security.Cryptography
 
@@ -439,7 +437,7 @@ All implementations use fixed-size internal buffers based on their block size. N
 
 ## Thread Safety
 
-All hash algorithm instances are **not thread-safe**. Create separate instances for concurrent operations or use synchronization.
+Hash algorithm instances are **not thread-safe**. Create a separate instance per concurrent operation rather than sharing one across threads.
 
 ```csharp
 // Thread-safe pattern

--- a/docfx/packages/security/index.md
+++ b/docfx/packages/security/index.md
@@ -1,33 +1,33 @@
 # CryptoHives.Foundation.Security Packages
 
-The Security package family provides specification-based cryptographic implementations for .NET applications.
+The Security package family provides specification-based cryptographic implementations for .NET.
 
 ## Overview
 
-The CryptoHives Security packages deliver fully managed, cross-platform cryptographic primitives that do not rely on OS or hardware cryptographic APIs. This ensures deterministic behavior across all platforms and runtimes, making them ideal for:
+These packages are fully managed and cross-platform — they don't call into OS or hardware crypto APIs, which keeps behavior deterministic across every platform and runtime. That matters for:
 
-- **Cross-platform consistency** - Same results on Windows, Linux, macOS, and any .NET runtime
-- **Embedded systems** - Works where OS crypto APIs may not be available
-- **Testing and verification** - Predictable behavior for cryptographic testing
-- **Educational purposes** - Clear, readable implementations for learning
+- **Cross-platform consistency** — the same results on Windows, Linux, macOS, and any .NET runtime
+- **Embedded systems** — works where OS crypto APIs may not be available
+- **Testing and verification** — predictable behavior for cryptographic test suites
+- **Learning** — implementations written to be read, not just used
 
 ## Available Packages
 
 ### Cryptography Package
 
-**CryptoHives.Foundation.Security.Cryptography** - Hash and MAC implementations
+**CryptoHives.Foundation.Security.Cryptography** — hash and MAC implementations
 
-Comprehensive suite of cryptographic hash algorithms and message authentication codes (MACs), all implemented as fully managed code without OS dependencies.
+A broad set of cryptographic hash algorithms and message authentication codes, all fully managed and OS-independent.
 
-**Key Features:**
-- SHA-1, SHA-2, SHA-3 family implementations
+**Key features:**
+- SHA-1, SHA-2, SHA-3 families
 - SHAKE and cSHAKE extendable-output functions (XOF)
 - KMAC (Keccak Message Authentication Code)
-- Keccak (Ethereum), TurboShake and KangarooTwelve
+- Keccak (Ethereum), TurboShake, and KangarooTwelve
 - Ascon hashing and MAC
-- BLAKE2 and BLAKE3 high-performance hashing
+- BLAKE2 and BLAKE3, tuned for high throughput
 - Legacy algorithms (MD5, RIPEMD-160)
-- International standards (SM3, Streebog, Kupyna, LSH, Whirlpool)
+- Regional standards (SM3, Streebog, Kupyna, LSH, Whirlpool)
 
 **[Cryptography Package Documentation](cryptography/index.md)**
 
@@ -36,7 +36,7 @@ Comprehensive suite of cryptographic hash algorithms and message authentication 
 dotnet add package CryptoHives.Foundation.Security.Cryptography
 ```
 
-**Quick Example:**
+**Quick example:**
 ```csharp
 using CryptoHives.Foundation.Security.Cryptography.Hash;
 
@@ -55,19 +55,17 @@ blake3.TryComputeHash(data, longHash, out _);
 
 ## Planned Packages
 
-The following packages are planned for future development:
-
 ### Certificates (Planned)
 
-**CryptoHives.Foundation.Security.Certificates** - Certificate handling and validation
+**CryptoHives.Foundation.Security.Certificates** — certificate handling and validation
 
-- X.509 certificate building, parsing and validation
+- X.509 certificate building, parsing, and validation
 - Certificate chain building and validation
 - CRL and OCSP support
 
 ### Encryption (Planned)
 
-**CryptoHives.Foundation.Security.Encryption** - Symmetric and asymmetric encryption
+**CryptoHives.Foundation.Security.Encryption** — symmetric and asymmetric encryption
 
 - AES, ChaCha20-Poly1305
 - RSA, ECDH, ECDSA
@@ -79,30 +77,27 @@ The following packages are planned for future development:
 
 ### Development Policy
 
-All cryptographic code is written from scratch based on official specifications:
-- Implementations are written from official public specifications and standards (NIST, RFC, ISO)
-- Development may use AI-assisted tooling; no guarantee of clean-room provenance is claimed
-- All algorithms are verified against official test vectors from specification documents
-- Review process includes algorithm validation against reference implementations
+- Implementations are written from official public specifications (NIST, RFC, ISO), not ported from other codebases.
+- Some development uses AI-assisted tooling — clean-room provenance isn't claimed for every line.
+- Every algorithm is checked against official test vectors from its specification.
+- Reviews include validation against independent reference implementations.
 
 ### No OS Dependencies
 
 Unlike `System.Security.Cryptography`, these implementations:
-- Do not call into OS cryptographic APIs (CNG, OpenSSL, etc.)
-- Work identically across all platforms and .NET versions
+- Don't call into OS cryptographic APIs (CNG, OpenSSL, etc.)
+- Behave identically across platforms and .NET versions
 - Produce deterministic output regardless of the host system
-- Are optimized with .NET intrinsic hardware acceleration when available, but can always fall back to pure managed code
+- Use hardware intrinsics for speed when available, but always have a pure managed fallback
 
 ### Standards Compliance
 
-All implementations follow official standards:
 - NIST FIPS 180-4, FIPS 202, SP 800-185
 - RFCs (7693 for BLAKE2, 6986 for Streebog)
 - ISO/IEC standards where applicable
 
 ## Target Frameworks
 
-All Security packages support:
 - .NET 10.0
 - .NET 8.0
 - .NET Framework 4.6.2
@@ -111,10 +106,10 @@ All Security packages support:
 
 ## Getting Help
 
-- 📖 [Full Documentation](https://cryptohives.github.io/Foundation/)
-- 📋 [Cryptographic Specifications](cryptography/specs/README.md)
-- 🐛 [Report Issues](https://github.com/CryptoHives/Foundation/issues)
-- 💬 [Discussions](https://github.com/CryptoHives/Foundation/discussions)
+- [Full Documentation](https://cryptohives.github.io/Foundation/)
+- [Cryptographic Specifications](cryptography/specs/README.md)
+- [Report Issues](https://github.com/CryptoHives/Foundation/issues)
+- [Discussions](https://github.com/CryptoHives/Foundation/discussions)
 
 ## See Also
 

--- a/docfx/packages/threading/asyncautoresetevent.md
+++ b/docfx/packages/threading/asyncautoresetevent.md
@@ -116,7 +116,7 @@ await vt;  // Throws InvalidOperationException!
 public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
-Asynchronously waits for the event to be signaled, or throws `OperationCanceledException` if the timeout elapses first.
+Asynchronously waits for the event to be signaled, or throws `TimeoutException` if the timeout elapses first.
 
 **Parameters**:
 - `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocation).
@@ -124,7 +124,8 @@ Asynchronously waits for the event to be signaled, or throws `OperationCanceledE
 **Returns**: A `ValueTask` that completes when the event is signaled.
 
 **Throws**:
-- `OperationCanceledException` — If the timeout elapses before the event is signaled.
+- `TimeoutException` — If the timeout elapses before the event is signaled.
+- `OperationCanceledException` — If the operation is canceled via the cancellation token.
 - `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
 
 **Allocation notes**:
@@ -356,7 +357,7 @@ try
     await _event.WaitAsync(TimeSpan.FromSeconds(2));
     ProcessSignal();
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     HandleTimeout();
 }

--- a/docfx/packages/threading/asyncbarrier.md
+++ b/docfx/packages/threading/asyncbarrier.md
@@ -148,7 +148,7 @@ Signals the barrier and waits for all participants to arrive.
 public ValueTask SignalAndWaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
-Signals the barrier and waits for all participants to arrive, or throws `OperationCanceledException` if the timeout elapses before all participants arrive.
+Signals the barrier and waits for all participants to arrive, or throws `TimeoutException` if the timeout elapses before all participants arrive.
 
 The last participant to arrive is never subject to the timeout — it releases all other waiters immediately. A `TimeProvider` is allocated only for non-final participants with a finite positive timeout; it is disposed automatically when the returned `ValueTask` is awaited.
 
@@ -158,7 +158,8 @@ The last participant to arrive is never subject to the timeout — it releases a
 **Returns**: A `ValueTask` that completes when all participants have arrived.
 
 **Throws**:
-- `OperationCanceledException` — If the timeout elapses before all participants arrive.
+- `TimeoutException` — If the timeout elapses before all participants arrive.
+- `OperationCanceledException` — If the operation is canceled via the cancellation token.
 - `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
 - `InvalidOperationException` — If more participants signal than registered.
 - `BarrierPostPhaseException` — If the post-phase action throws.
@@ -180,7 +181,7 @@ try
     await _barrier.SignalAndWaitAsync(TimeSpan.FromSeconds(10));
     await DoPhase2WorkAsync();
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     // Not all participants arrived in time
     HandleTimeout();
@@ -291,7 +292,7 @@ try
 {
     await _barrier.SignalAndWaitAsync(TimeSpan.FromSeconds(30));
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     // Phase did not complete in time; handle accordingly
     HandleTimeout();

--- a/docfx/packages/threading/asynccountdownevent.md
+++ b/docfx/packages/threading/asynccountdownevent.md
@@ -102,7 +102,7 @@ Asynchronously waits for the countdown to reach zero.
 public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
-Asynchronously waits for the countdown to reach zero, or throws `OperationCanceledException` if the timeout elapses first.
+Asynchronously waits for the countdown to reach zero, or throws `TimeoutException` if the timeout elapses first.
 
 **Parameters**:
 - `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely.
@@ -110,7 +110,8 @@ Asynchronously waits for the countdown to reach zero, or throws `OperationCancel
 **Returns**: A `ValueTask` that completes when the count reaches zero.
 
 **Throws**:
-- `OperationCanceledException` — If the timeout elapses before the count reaches zero.
+- `TimeoutException` — If the timeout elapses before the count reaches zero.
+- `OperationCanceledException` — If the operation is canceled via the cancellation token.
 - `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
 
 **Allocation notes**:
@@ -130,7 +131,7 @@ try
     await _countdown.WaitAsync(TimeSpan.FromSeconds(30));
     ProcessResults();
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     HandleTimeout();
 }
@@ -236,7 +237,7 @@ try
 {
     await countdown.WaitAsync(TimeSpan.FromMinutes(1));
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     HandleTimeout();
 }

--- a/docfx/packages/threading/asynclock.md
+++ b/docfx/packages/threading/asynclock.md
@@ -75,7 +75,7 @@ Asynchronously acquires the lock. Returns a disposable that releases the lock wh
 public ValueTask<Releaser> LockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
-Asynchronously acquires the lock, or throws `OperationCanceledException` if the timeout elapses before the lock becomes available.
+Asynchronously acquires the lock, or throws `TimeoutException` if the timeout elapses before the lock becomes available.
 
 **Parameters**:
 - `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `LockAsync()` without allocating a `TimeProvider`).
@@ -83,7 +83,8 @@ Asynchronously acquires the lock, or throws `OperationCanceledException` if the 
 **Returns**: A `ValueTask<Releaser>` that completes when the lock is acquired. Dispose the result to release the lock.
 
 **Throws**:
-- `OperationCanceledException` — If the timeout elapses before the lock can be acquired.
+- `TimeoutException` — If the timeout elapses before the lock can be acquired.
+- `OperationCanceledException` — If the operation is canceled via the cancellation token.
 - `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
 
 **Allocation notes**:
@@ -105,7 +106,7 @@ try
         await DoWorkAsync();
     }
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     // Could not acquire lock within 2 seconds
     HandleTimeout();
@@ -257,7 +258,7 @@ try
         _data = await FetchAsync();
     }
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     HandleTimeout();
 }

--- a/docfx/packages/threading/asyncmanualresetevent.md
+++ b/docfx/packages/threading/asyncmanualresetevent.md
@@ -112,7 +112,7 @@ await vt;  // Throws InvalidOperationException!
 public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
-Asynchronously waits for the event to be set, or throws `OperationCanceledException` if the timeout elapses first.
+Asynchronously waits for the event to be set, or throws `TimeoutException` if the timeout elapses first.
 
 **Parameters**:
 - `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely (delegates to `WaitAsync()` without allocating a `TimeProvider`).
@@ -120,7 +120,8 @@ Asynchronously waits for the event to be set, or throws `OperationCanceledExcept
 **Returns**: A `ValueTask` that completes when the event is set.
 
 **Throws**:
-- `OperationCanceledException` — If the timeout elapses before the event is set.
+- `TimeoutException` — If the timeout elapses before the event is set.
+- `OperationCanceledException` — If the operation is canceled via the cancellation token.
 - `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
 
 **Allocation notes**:
@@ -357,7 +358,7 @@ try
     await _event.WaitAsync(TimeSpan.FromSeconds(10));
     ProcessData();
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     HandleTimeout();
 }

--- a/docfx/packages/threading/asyncreaderwriterlock.md
+++ b/docfx/packages/threading/asyncreaderwriterlock.md
@@ -145,9 +145,9 @@ Asynchronously acquires a reader lock. Multiple readers can hold the lock concur
 public ValueTask<Releaser> ReaderLockAsync(TimeSpan timeout)
 ```
 
-Asynchronously acquires a reader lock, or throws `OperationCanceledException` if the timeout elapses first.
+Asynchronously acquires a reader lock, or throws `TimeoutException` if the timeout elapses first.
 
-**Throws**: `OperationCanceledException` if the timeout elapses, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
+**Throws**: `TimeoutException` if the timeout elapses, `OperationCanceledException` if the operation is canceled via the cancellation token, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
 
 ### UpgradeableReaderLockAsync
 
@@ -163,9 +163,9 @@ Asynchronously acquires an upgradeable reader lock. One upgradeable reader can c
 public ValueTask<Releaser> UpgradeableReaderLockAsync(TimeSpan timeout)
 ```
 
-Asynchronously acquires an upgradeable reader lock, or throws `OperationCanceledException` if the timeout elapses first.
+Asynchronously acquires an upgradeable reader lock, or throws `TimeoutException` if the timeout elapses first.
 
-**Throws**: `OperationCanceledException` if the timeout elapses, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
+**Throws**: `TimeoutException` if the timeout elapses, `OperationCanceledException` if the operation is canceled via the cancellation token, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
 
 ### WriterLockAsync
 
@@ -181,9 +181,9 @@ Asynchronously acquires a writer lock. Only one writer can hold the lock.
 public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
-Asynchronously acquires a writer lock, or throws `OperationCanceledException` if the timeout elapses first.
+Asynchronously acquires a writer lock, or throws `TimeoutException` if the timeout elapses first.
 
-**Throws**: `OperationCanceledException` if the timeout elapses, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
+**Throws**: `TimeoutException` if the timeout elapses, `OperationCanceledException` if the operation is canceled via the cancellation token, `ArgumentOutOfRangeException` if `timeout` is negative and not `Timeout.InfiniteTimeSpan`.
 
 **Allocation notes for all timeout overloads**:
 
@@ -208,7 +208,7 @@ try
         return await ReadDataAsync();
     }
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     HandleTimeout();
 }
@@ -307,7 +307,7 @@ try
         await SaveDataAsync();
     }
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     HandleTimeout();
 }

--- a/docfx/packages/threading/asyncsemaphore.md
+++ b/docfx/packages/threading/asyncsemaphore.md
@@ -87,7 +87,7 @@ Asynchronously waits to acquire a permit from the semaphore.
 public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
 ```
 
-Asynchronously waits to acquire a permit, or throws `OperationCanceledException` if the timeout elapses first.
+Asynchronously waits to acquire a permit, or throws `TimeoutException` if the timeout elapses first.
 
 **Parameters**:
 - `timeout` — The maximum time to wait. Pass `Timeout.InfiniteTimeSpan` to wait indefinitely.
@@ -95,7 +95,8 @@ Asynchronously waits to acquire a permit, or throws `OperationCanceledException`
 **Returns**: A `ValueTask` that completes when a permit is acquired.
 
 **Throws**:
-- `OperationCanceledException` — If the timeout elapses before a permit becomes available.
+- `TimeoutException` — If the timeout elapses before a permit becomes available.
+- `OperationCanceledException` — If the operation is canceled via the cancellation token.
 - `ArgumentOutOfRangeException` — If `timeout` is negative and not equal to `Timeout.InfiniteTimeSpan`.
 
 **Allocation notes**:
@@ -122,7 +123,7 @@ try
         _semaphore.Release();
     }
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     // Permit was not available within 5 seconds
     HandleTimeout();
@@ -206,7 +207,7 @@ try
     await DoWorkAsync();
     _semaphore.Release();
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     // No permit available within the timeout
     HandleTimeout();

--- a/docfx/packages/threading/index.md
+++ b/docfx/packages/threading/index.md
@@ -2,25 +2,21 @@
 
 ## Overview
 
-The Threading package provides high-performance, pooled async synchronization primitives for .NET applications with high throughput workloads, where many small memory allocations matter. All synchronization primitives leverage `ValueTask` and pooled `IValueTaskSource` for efficient async operations. They are not meant to replace but to complement existing popular async libraries.
+The Threading package provides pooled, `ValueTask`-based async synchronization primitives for .NET applications where high-throughput workloads make per-waiter allocations matter. They're meant to complement the existing async synchronization libraries for .NET, not replace them.
 
-There are already a number of popular async synchronization libraries available for .NET, but many of these incur significant memory allocations under high contention due to per-waiter `Task` and `TaskCompletionSource` allocations or cancellation handling.
-In recent years, the introduction of `ValueTask` and `IValueTaskSource` has enabled the creation of low-allocation async primitives that can be pooled and reused to minimize allocations in high-throughput scenarios.
-This library is the result of the research done by the *Keepers of the CryptoHives* into building efficient, pooled async synchronization primitives that leverage these modern .NET features.
-By demand, more primitives might be added in the future.
+Most popular async synchronization libraries allocate a `Task` and/or `TaskCompletionSource` per waiter, and cancellation handling often adds more. `ValueTask` and `IValueTaskSource`, introduced a few years ago, make it possible to build low-allocation primitives that can be pooled and reused instead. This library is what came out of the Keepers of the CryptoHives digging into that approach. More primitives may get added as the need comes up.
 
 ## Core Guarantees
 
-- **Pooled Primitives**: Synchronization objects backed by object pools
-- **ValueTask-based**: Low-allocation async operations
-- **High Performance**: Optimized for concurrent access patterns using interlocked state transitions
-- **Thread-safe**: All operations are thread-safe
-- **Ease of use**: Drop-in replacement to replace other popular libraries by changing the namespace
-- **Cancellation support**: Full `CancellationToken` support across all primitives
-- **Timeout support**: Optional timeout parameters on all lock acquisition methods
-- **Configurable continuations**: Control synchronous vs asynchronous continuation execution
-- **Custom ObjectPools**: Supply your own object pools for fine-grained control
-- **Optional Analyzers**: Roslyn analyzers automatically detect common ValueTask misuse patterns
+- **Pooled primitives** — synchronization objects backed by object pools
+- **`ValueTask`-based** — low-allocation async operations
+- **Thread-safe** — every operation is safe under concurrent access, using interlocked state transitions
+- **Drop-in replacement** — swap the namespace to migrate from other popular libraries
+- **Cancellation support** — full `CancellationToken` support across all primitives
+- **Timeout support** — optional timeout parameters on every lock acquisition method
+- **Configurable continuations** — control synchronous vs. asynchronous continuation execution
+- **Custom object pools** — supply your own for fine-grained control
+- **Optional analyzers** — Roslyn analyzers that catch common `ValueTask` misuse at compile time
 
 ## Installation
 
@@ -70,35 +66,23 @@ using CryptoHives.Foundation.Threading.Pools;
 | `ValueTaskSourceObjectPool<T>` | Specialized provider that implements `IGetPooledManualResetValueTaskSource<T>` and returns pooled task sources | `CryptoHives.Foundation.Threading.Pools` |
 | `ValueTaskSourceObjectPools` | Static helper with shared pool instances and constants | `CryptoHives.Foundation.Threading.Pools` |
 
-## ⚠️ Known Issues and Caveats
+## Known Issues and Caveats
 
-1. **Strictly only await a ValueTask once**. An additional await or AsTask() may throw an `InvalidOperationException`.
-2. **Strictly only use AsTask() once**, and only if you have to. An additional await or AsTask() may throw an `InvalidOperationException`. Adds also a Task allocation on contention.
-3. **Pool Exhaustion**: In extreme high-throughput scenarios with many waiters, the pool may exhaust. Monitor and adjust usage patterns accordingly. Use a custom pool if necessary.
-4. **Architecture-Specific Performance**: Performance characteristics vary significantly between Windows x64 and Apple Silicon (M4). 
-    - **Windows x64**: Exhibits superior performance at low concurrency (1–2 waiters) due to efficient ThreadPool inline task scheduling.
-    - **macOS M4**: Exhibits superior performance at high concurrency (100+ waiters) and on uncontended paths due to ARM64 JIT optimizations.
-    - **Recommendation**: For maximum throughput at all contention levels, prefer `AsValueTask()` where possible.
-5. **Always Await**: Always await a `ValueTask` or `Task` waiter primitive; otherwise, the underlying `IValueTaskSource` is not returned to the pool, causing a leak.
+1. **Await a `ValueTask` exactly once.** A second `await` or `AsTask()` call may throw `InvalidOperationException`.
+2. **Use `AsTask()` at most once, and only when you actually need a `Task`.** Beyond the same `InvalidOperationException` risk, it also adds a `Task` allocation under contention.
+3. **Pool exhaustion.** Under extreme concurrency with many waiters, the pool can run dry. Watch usage patterns and adjust, or supply a custom pool if needed.
+4. **Always await.** If a `ValueTask` or `Task` waiter isn't awaited, its underlying `IValueTaskSource` never makes it back to the pool — that's a leak.
 
 ## Performance Characteristics
 
-- **Pooled Primitives**: Synchronization objects backed by object pools to minimize GC pressure.
-- **ValueTask-based**: Low-allocation async operations that avoid heap allocations on the fast path.
-- **Lock-Free Fast Paths**: Optimized for uncontended access using atomic operations.
-- **Scheduling**: 
-    - Uses `RunContinuationsAsynchronously` by default to prevent deadlocks.
+- Synchronization objects are backed by object pools to keep GC pressure down.
+- `ValueTask`-based operations avoid heap allocation on the fast path.
+- Uncontended access uses lock-free atomic operations.
+- Continuations run via `RunContinuationsAsynchronously` by default, to avoid deadlocks.
 
-Please be aware that not all new replacement classes behave better than existing popular implementations in all scenarios; But most of the time they do.
+Not every primitive here beats its popular-library equivalent in every scenario — most of the time it does, but there are exceptions. `AsyncManualResetEvent`, for instance, pays for one `IValueTaskSource` per waiter because a single `ValueTask` can't be awaited by more than one caller. A `Task`-based implementation can let every waiter share the same underlying `Task`/`TaskCompletionSource` instead.
 
-For example the `AsyncManualResetEvent` implementation has an overhead of a `IValueTaskSource` per waiter, because `ValueTask` cannot be awaited by multiple instances. In contrast to a Task-based implementation all waiters can share the same wake-up Task and `TaskCompletionSource`.
-
-See the Benchmarks overview:
-
-- [Benchmarks Overview](benchmarks.md)
-
-Run reports are stored under:
-- `tests/Threading/BenchmarkDotNet.Artifacts/results/`
+See the [Benchmarks overview](benchmarks.md) for numbers. Raw run reports live under `tests/Threading/BenchmarkDotNet.Artifacts/results/`.
 
 ## Quick Examples
 
@@ -238,7 +222,7 @@ public async Task WriteAsync(CancellationToken ct)
 
 ## Timeout Support
 
-All synchronization primitives support optional timeout parameters to prevent indefinite waiting. This enables non-blocking attempts and timeout-based retry logic:
+Every synchronization primitive accepts an optional timeout, so you can attempt a non-blocking acquire or build timeout-based retry logic instead of waiting indefinitely:
 
 ```csharp
 // Non-blocking attempt using TimeSpan.Zero
@@ -280,29 +264,7 @@ public async Task<bool> TryAcquireWithRetryAsync(TimeSpan timeout, int maxRetrie
 }
 ```
 
-## Benefits
-
-### Reduced Allocations
-
-- Reuses `IValueTaskSource` instances from object pools
-- ValueTask-based APIs avoid Task allocations when operations complete synchronously
-- Best case: zero allocation overhead for async state machines
-- On latest .NET versions cancellation token registration is allocation free
-
-### High Throughput
-
-- Optimized for high-contention scenarios
-- Lock-free operations where possible
-- Configurable continuation scheduling
-
-### Compatibility
-
-- Drop in replacement of existing libraries by changing namespace
-- Works with async/await patterns
-- Cancellation token support
-- ConfigureAwait support
-
-## Performance Characteristics
+## Performance Characteristics by Primitive
 
 - **AsyncLock**: O(1) acquire when uncontended, FIFO queue for waiters
 - **AsyncAutoResetEvent**: O(1) Set/Wait, FIFO queue for single waiter release
@@ -310,14 +272,14 @@ public async Task<bool> TryAcquireWithRetryAsync(TimeSpan timeout, int maxRetrie
 
 ## Best Practices
 
-1. **Determine benefits**: Are pooled primitives and ValueTask beneficial for your workload?
-2. **Reuse instances**: Create synchronization primitives once and reuse them
-3. **Do not reuse ValueTask**: Always await or AsTask() only once per ValueTask instance
-4. **Always Await ValueTask and Task**: If not awaited, resources are not returned to the pool
-5. **Avoid holding locks**: Keep critical sections as short as possible
-6. **Use cancellation**: Always pass CancellationToken for long waits (remember, its almost free!)
-7. **ConfigureAwait(false)**: Use in library code to avoid context capture
-8. **Avoid AsTask() before signaling**: When `RunContinuationAsynchronously=true`, this causes severe performance degradation
+1. Confirm pooled primitives and `ValueTask` actually help your workload before switching — they shine under high throughput, less so at low concurrency (see the architecture caveats above).
+2. Create synchronization primitives once and reuse them rather than constructing per call.
+3. Await or call `AsTask()` on each `ValueTask` exactly once — never both, never twice.
+4. Always await a `ValueTask`/`Task` waiter; otherwise its resources never return to the pool.
+5. Keep critical sections short — don't hold a lock across unrelated work.
+6. Pass a `CancellationToken` for any wait that could be long — the check is nearly free.
+7. Use `ConfigureAwait(false)` in library code to avoid capturing the sync context.
+8. Don't call `AsTask()` before the primitive signals when `RunContinuationAsynchronously=true` — it causes a severe performance hit.
 
 ## Common Patterns
 
@@ -385,7 +347,7 @@ public async Task<T> RateLimitedOperationAsync<T>(Func<Task<T>> operation, Cance
 
 ## Advanced: Custom Pooling
 
-You can provide a custom provider that implements `IGetPooledManualResetValueTaskSource<T>` for fine-grained control over pool behavior. The built-in `ValueTaskSourceObjectPool<T>` implements this interface and can be used directly.
+You can supply your own provider implementing `IGetPooledManualResetValueTaskSource<T>` for fine-grained control over pool behavior. The built-in `ValueTaskSourceObjectPool<T>` already implements this interface and can be used directly.
 
 ```csharp
 using CryptoHives.Foundation.Threading.Pools;
@@ -404,30 +366,30 @@ var evt = new AsyncAutoResetEvent(
 
 ## ValueTaskSource Details
 
-The `ManualResetValueTaskSource<T>` abstract base class provides:
-- `Version` property for versioning support
-- `RunContinuationsAsynchronously` property to control continuation scheduling
+`ManualResetValueTaskSource<T>` (abstract base) provides:
+- `Version` for versioning support
+- `RunContinuationsAsynchronously` to control continuation scheduling
 - `CancellationToken` and `CancellationTokenRegistration` for cancellation support
-- `SetResult()` and `SetException()` for completion
+- `SetResult()` / `SetException()` for completion
 - `TryReset()` for pool reuse
 
-The `PooledManualResetValueTaskSource<T>` sealed implementation:
-- Automatically returns to pool after `GetResult()` is called
+`PooledManualResetValueTaskSource<T>` (sealed implementation):
+- Returns to the pool automatically after `GetResult()` is called
 - Integrates with `IResettable` for pool compatibility
-- Manages cancellation token registration lifecycle
+- Manages the cancellation token registration lifecycle
 
 ## See Also
 
-- [Threading Analyzers](../threading.analyzers/index.md) - Roslyn analyzers for detecting ValueTask misuse
+- [Threading Analyzers](../threading.analyzers/index.md) — Roslyn analyzers for detecting ValueTask misuse
 - [Memory Package](../memory/index.md)
-- [AsyncAutoResetEvent](asyncautoresetevent.md) - Auto-reset event variant
-- [AsyncManualResetEvent](asyncmanualresetevent.md) - Manual-reset event variant
-- [AsyncReaderWriterLock](asyncreaderwriterlock.md) - Async reader-writer lock
-- [AsyncLock](asynclock.md) - Async mutual exclusion lock
-- [AsyncCountdownEvent](asynccountdownevent.md) - Async countdown event
-- [AsyncBarrier](asyncbarrier.md) - Async barrier synchronization primitive
-- [AsyncSemaphore](asyncsemaphore.md) - Async semaphore primitive
-- [Benchmarks](benchmarks.md) - Benchmark description
+- [AsyncAutoResetEvent](asyncautoresetevent.md)
+- [AsyncManualResetEvent](asyncmanualresetevent.md)
+- [AsyncReaderWriterLock](asyncreaderwriterlock.md)
+- [AsyncLock](asynclock.md)
+- [AsyncCountdownEvent](asynccountdownevent.md)
+- [AsyncBarrier](asyncbarrier.md)
+- [AsyncSemaphore](asyncsemaphore.md)
+- [Benchmarks](benchmarks.md)
 
 ---
 

--- a/docfx/packages/threading/index.md
+++ b/docfx/packages/threading/index.md
@@ -249,7 +249,7 @@ try
         await DoWorkAsync();
     }
 }
-catch (OperationCanceledException)
+catch (TimeoutException)
 {
     // Lock not immediately available
 }
@@ -270,7 +270,7 @@ public async Task<bool> TryAcquireWithRetryAsync(TimeSpan timeout, int maxRetrie
                 return await PerformWorkAsync();
             }
         }
-        catch (OperationCanceledException) when (i < maxRetries - 1)
+        catch (TimeoutException) when (i < maxRetries - 1)
         {
             // Timeout occurred, retry
             continue;

--- a/src/Memory/README.md
+++ b/src/Memory/README.md
@@ -1,7 +1,6 @@
-## 🛡️ CryptoHives Open Source Initiative 🐝
+## CryptoHives Open Source Initiative 🐝
 
-An open, community-driven cryptography and performance library collection for the .NET ecosystem,
-developed and maintained by **The Keepers of the CryptoHives**.
+An open, community-driven collection of cryptography and performance libraries for the .NET ecosystem, maintained by **The Keepers of the CryptoHives**.
 
 ---
 
@@ -10,11 +9,11 @@ developed and maintained by **The Keepers of the CryptoHives**.
 [![NuGet](https://img.shields.io/nuget/v/CryptoHives.Foundation.Memory.svg)](https://www.nuget.org/packages/CryptoHives.Foundation.Memory)
 [![Tests](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml)
 
-Pooled buffer management utilities for .NET — designed to minimize allocations and reduce GC pressure in high-throughput transformation pipelines and cryptographic workloads.
+Pooled buffer management for .NET, built to keep allocations and GC pressure out of high-throughput transformation pipelines and crypto workloads.
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 dotnet add package CryptoHives.Foundation.Memory
@@ -22,17 +21,17 @@ dotnet add package CryptoHives.Foundation.Memory
 
 ---
 
-## ✨ Key Features
+## Key Features
 
-- **Pooled memory streams** — `MemoryStream` replacement backed by `ArrayPool<byte>.Shared`; no resize-copy, no LOH pressure
-- **Zero-copy handoff** — expose written data as `ReadOnlySequence<byte>` without any copying
-- **`IBufferWriter<T>` support** — `ArrayPoolBufferWriter<T>` works directly with `Utf8JsonWriter`, `PipeWriter`, and any `IBufferWriter` consumer
+- **Pooled memory streams** — a `MemoryStream` replacement backed by `ArrayPool<byte>.Shared`; no resize-copy, no LOH pressure
+- **Zero-copy handoff** — expose written data as a `ReadOnlySequence<byte>` without copying anything
+- **`IBufferWriter<T>` support** — `ArrayPoolBufferWriter<T>` works directly with `Utf8JsonWriter`, `PipeWriter`, or any other `IBufferWriter` consumer
 - **Read-only sequence streaming** — wrap an existing `ReadOnlySequence<byte>` as a `Stream` without copying
-- **RAII ownership** — `ObjectOwner<T>` safely returns pooled objects when disposed
+- **RAII ownership** — `ObjectOwner<T>` returns pooled objects automatically on dispose
 
 ---
 
-## 🚀 Quick Examples
+## Quick Examples
 
 ### Pooled Memory Stream
 
@@ -49,7 +48,7 @@ await stream.WriteAsync(payloadBytes, ct).ConfigureAwait(false);
 ReadOnlySequence<byte> sequence = stream.GetReadOnlySequence();
 await SendAsync(sequence, ct).ConfigureAwait(false);
 
-// Pooled buffers are returned when stream is disposed
+// Pooled buffers are returned when the stream is disposed
 ```
 
 ### Buffer Writer (e.g. with `Utf8JsonWriter`)
@@ -96,12 +95,12 @@ MyExpensiveObject obj = owner.Object;
 
 // Use obj...
 
-// Automatically returned to pool when owner is disposed — even on exception
+// Automatically returned to the pool when owner is disposed — even on exception
 ```
 
 ---
 
-## 📚 Documentation
+## Documentation
 
 | Resource | Link |
 |----------|------|
@@ -111,13 +110,12 @@ MyExpensiveObject obj = owner.Object;
 
 ---
 
-## 🔐 Security Policy
+## Security Policy
 
-If you discover a vulnerability, **please do not open a public issue.**
-Follow the guidelines on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md).
+If you discover a vulnerability, please don't open a public issue — follow the process on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md) instead.
 
 ---
 
-## ⚖️ License
+## License
 
 MIT — © 2026 The Keepers of the CryptoHives

--- a/src/Security/Cryptography/README.md
+++ b/src/Security/Cryptography/README.md
@@ -1,7 +1,6 @@
-## 🛡️ CryptoHives Open Source Initiative 🐝
+## CryptoHives Open Source Initiative 🐝
 
-An open, community-driven cryptography and performance library collection for the .NET ecosystem,
-developed and maintained by **The Keepers of the CryptoHives**.
+An open, community-driven collection of cryptography and performance libraries for the .NET ecosystem, maintained by **The Keepers of the CryptoHives**.
 
 ---
 
@@ -10,14 +9,13 @@ developed and maintained by **The Keepers of the CryptoHives**.
 [![NuGet](https://img.shields.io/nuget/v/CryptoHives.Foundation.Security.Cryptography.svg)](https://www.nuget.org/packages/CryptoHives.Foundation.Security.Cryptography)
 [![Tests](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml)
 
-Fully managed, OS-independent implementations of cryptographic hash, MAC, KDF, and cipher algorithms for .NET —
-written from NIST/RFC/ISO specifications and verified against official test vectors.
+Fully managed, OS-independent implementations of hash, MAC, KDF, and cipher algorithms for .NET, written directly from NIST/RFC/ISO specifications and checked against official test vectors.
 
-No OS crypto dependency — deterministic results on every platform. Hardware acceleration via AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics is automatically enabled on supported hardware.
+No OS crypto dependency means deterministic results on every platform. Where the hardware supports it, AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics are used automatically.
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 dotnet add package CryptoHives.Foundation.Security.Cryptography
@@ -25,19 +23,19 @@ dotnet add package CryptoHives.Foundation.Security.Cryptography
 
 ---
 
-## ✨ Key Features
+## Key Features
 
-- **OS-independent** — identical results on Windows, Linux, macOS, and any .NET-supported platform
+- **OS-independent** — identical results on Windows, Linux, macOS, and anywhere else .NET runs
 - **Standards-based** — implemented from NIST, RFC, and ISO specifications; validated against official test vectors
-- **Hardware-accelerated** — automatic AES-NI, AVX2, SSSE3 dispatch; scalar fallback always available
-- **Allocation-free hot paths** — `Span<byte>`-based APIs, `stackalloc`-friendly
-- **XOF streaming** — `IExtendableOutput` interface (`Absorb` / `Squeeze` / `Reset`) on all XOF algorithms
-- **`HashAlgorithm` compatible** — drop-in for any existing `System.Security.Cryptography.HashAlgorithm` consumer
-- **Comprehensive algorithm coverage** — SHA-2/3, Keccak, SHAKE, BLAKE2/3, Ascon, regional ciphers, and more
+- **Hardware-accelerated** — automatic AES-NI, AVX2, SSSE3 dispatch, with a scalar fallback always available
+- **Allocation-free hot paths** — `Span<byte>`-based APIs, friendly to `stackalloc`
+- **XOF streaming** — `IExtendableOutput` (`Absorb` / `Squeeze` / `Reset`) on all XOF algorithms
+- **`HashAlgorithm` compatible** — drop-in for anything consuming `System.Security.Cryptography.HashAlgorithm`
+- **Broad algorithm coverage** — SHA-2/3, Keccak, SHAKE, BLAKE2/3, Ascon, regional ciphers, and more
 
 ---
 
-## 🔐 Supported Algorithms
+## Supported Algorithms
 
 | Family | Algorithms |
 |--------|-----------|
@@ -50,7 +48,7 @@ dotnet add package CryptoHives.Foundation.Security.Cryptography
 | BLAKE | BLAKE2b, BLAKE2s (SIMD-accelerated), BLAKE3 |
 | Ascon | Ascon-Hash256, Ascon-XOF128 (NIST SP 800-232 lightweight) |
 | Regional hash | SM3, Streebog, Kupyna, LSH, Whirlpool, RIPEMD-160 |
-| Legacy | SHA-1, MD5 (backward compatibility only) |
+| Legacy | SHA-1, MD5 (kept for backward compatibility only) |
 | MAC | HMAC-SHA-256/384/512, HMAC-SHA3-256, AES-CMAC, AES-GMAC, Poly1305, KMAC128/256, BLAKE2/3 keyed |
 | Cipher (AEAD) | AES-GCM (128/192/256), AES-CCM (128/192/256), ChaCha20-Poly1305, XChaCha20-Poly1305, Ascon-AEAD128 |
 | Cipher (block/stream) | AES-128/192/256 (ECB/CBC/CTR), ChaCha20 |
@@ -59,7 +57,7 @@ dotnet add package CryptoHives.Foundation.Security.Cryptography
 
 ---
 
-## 🚀 Quick Examples
+## Quick Examples
 
 ### Allocation-Free Hash (`Blake3`)
 
@@ -130,7 +128,7 @@ cshake.Squeeze(derived);
 
 ---
 
-## 📚 Documentation
+## Documentation
 
 | Resource | Link |
 |----------|------|
@@ -145,15 +143,14 @@ cshake.Squeeze(derived);
 
 ---
 
-## 🔐 Security Policy
+## Security Policy
 
-Standards-based implementations, validated against official test vectors. Threat-modeled by design — all public APIs assume hostile input.
+Every algorithm is implemented from its published specification and validated against official test vectors. Public APIs are designed assuming hostile input.
 
-If you discover a vulnerability, **please do not open a public issue.**
-Follow the guidelines on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md).
+If you discover a vulnerability, please don't open a public issue — follow the process on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md) instead.
 
 ---
 
-## ⚖️ License
+## License
 
 MIT — © 2026 The Keepers of the CryptoHives

--- a/src/Threading.Analyzers/README.md
+++ b/src/Threading.Analyzers/README.md
@@ -1,7 +1,6 @@
-## 🛡️ CryptoHives Open Source Initiative 🐝
+## CryptoHives Open Source Initiative 🐝
 
-An open, community-driven cryptography and performance library collection for the .NET ecosystem,
-developed and maintained by **The Keepers of the CryptoHives**.
+An open, community-driven collection of cryptography and performance libraries for the .NET ecosystem, maintained by **The Keepers of the CryptoHives**.
 
 ---
 
@@ -9,13 +8,13 @@ developed and maintained by **The Keepers of the CryptoHives**.
 
 [![NuGet](https://img.shields.io/nuget/v/CryptoHives.Foundation.Threading.Analyzers.svg)](https://www.nuget.org/packages/CryptoHives.Foundation.Threading.Analyzers)
 
-Roslyn analyzers that detect common `ValueTask` misuse patterns at compile time — helping you avoid subtle bugs, undefined behavior, and performance pitfalls when working with `ValueTask` and pooled async primitives.
+Roslyn analyzers that catch common `ValueTask` misuse at compile time — the kind of subtle bugs, undefined behavior, and performance pitfalls that tend to show up when working with `ValueTask` and pooled async primitives.
 
-> **Note:** These analyzers are note anymore automatically included in the [CryptoHives.Foundation.Threading](https://www.nuget.org/packages/CryptoHives.Foundation.Threading) package. Install this separately if you need the analyzers with the Threading library.
+> **Note:** These analyzers are no longer bundled automatically with the [CryptoHives.Foundation.Threading](https://www.nuget.org/packages/CryptoHives.Foundation.Threading) package. Install this package separately if you want the analyzers alongside the Threading library.
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 dotnet add package CryptoHives.Foundation.Threading.Analyzers
@@ -31,7 +30,7 @@ Or as a development-only dependency (no runtime reference):
 
 ---
 
-## 🔍 Diagnostic Rules
+## Diagnostic Rules
 
 | ID | Severity | Description |
 |----|----------|-------------|
@@ -40,15 +39,15 @@ Or as a development-only dependency (no runtime reference):
 | [CHT003](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT003.html) | Warning | `ValueTask` stored in a field |
 | [CHT004](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT004.html) | Error | `ValueTask.AsTask()` called multiple times |
 | [CHT005](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT005.html) | Warning | `ValueTask.Result` accessed directly |
-| [CHT006](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT006.html) | Warning | `ValueTask` passed to potentially unsafe method |
-| [CHT007](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT007.html) | Info | `AsTask()` stored before signaling (performance degradation) |
+| [CHT006](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT006.html) | Warning | `ValueTask` passed to a potentially unsafe method |
+| [CHT007](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT007.html) | Info | `AsTask()` stored before signaling (causes a performance hit) |
 | [CHT008](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT008.html) | Warning | `ValueTask` not awaited or consumed |
-| [CHT009](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT009.html) | Info | `SemaphoreSlim(1, 1)` used as async lock; replace with `AsyncLock` |
-| [CHT010](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT010.html) | Error | `ValueTask` captured in lambda/closure  |
+| [CHT009](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT009.html) | Info | `SemaphoreSlim(1, 1)` used as an async lock; consider `AsyncLock` instead |
+| [CHT010](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT010.html) | Error | `ValueTask` captured in a lambda/closure |
 
 ---
 
-## ❌ Anti-Patterns Detected
+## Anti-Patterns Detected
 
 ```csharp
 // CHT001: Multiple await — Error
@@ -87,7 +86,7 @@ GetValueTask(); // Warning: result not awaited or discarded
 private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1); // Info: consider AsyncLock
 ```
 
-## ✅ Correct Patterns
+## Correct Patterns
 
 ```csharp
 // Single await — correct
@@ -118,25 +117,25 @@ _ = GetValueTask();
 
 ---
 
-## 🔧 Automatic Code Fixes
+## Automatic Code Fixes
 
-The analyzer package includes code fixes for most diagnostics:
+Most diagnostics come with a code fix:
 
 | Diagnostic | Available Fixes |
 |------------|-----------------|
 | CHT001 | Convert to `AsTask()` at declaration; use `Preserve()` |
 | CHT002 | Convert to `await`; use `AsTask()` before `GetAwaiter().GetResult()` |
 | CHT003 | Change field type to `Task` |
-| CHT004 | Store `AsTask()` result in variable |
+| CHT004 | Store `AsTask()` result in a variable |
 | CHT005 | Convert to `await`; use `AsTask().Result` |
-| CHT007 | Await `ValueTask` directly |
-| CHT008 | Add `await`; explicitly discard with `_ =` |
-| CHT009 | Replace SemaphoreSlim(1,1) with `AsyncLock` |
+| CHT007 | Await the `ValueTask` directly |
+| CHT008 | Add `await`; discard explicitly with `_ =` |
+| CHT009 | Replace `SemaphoreSlim(1,1)` with `AsyncLock` |
 | CHT010 | Convert to `AsTask()` at declaration; use `Preserve()` |
 
 ---
 
-## ⚙️ Configuration
+## Configuration
 
 Adjust rule severity in `.editorconfig`:
 
@@ -148,7 +147,7 @@ dotnet_diagnostic.CHT007.severity = warning
 dotnet_diagnostic.CHT003.severity = none
 ```
 
-Suppress inline when necessary:
+Or suppress inline when it's genuinely intentional:
 
 ```csharp
 #pragma warning disable CHT002
@@ -158,7 +157,7 @@ valueTask.GetAwaiter().GetResult(); // intentional blocking call
 
 ---
 
-## 📚 Documentation
+## Documentation
 
 | Resource | Link |
 |----------|------|
@@ -168,13 +167,12 @@ valueTask.GetAwaiter().GetResult(); // intentional blocking call
 
 ---
 
-## 🔐 Security Policy
+## Security Policy
 
-If you discover a vulnerability, **please do not open a public issue.**
-Follow the guidelines on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md).
+If you discover a vulnerability, please don't open a public issue — follow the process on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md) instead.
 
 ---
 
-## ⚖️ License
+## License
 
 MIT — © 2026 The Keepers of the CryptoHives

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -405,7 +405,7 @@ public sealed class AsyncAutoResetEvent : IResettable
         }
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncAutoResetEvent.cs
@@ -232,8 +232,11 @@ public sealed class AsyncAutoResetEvent : IResettable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before the event is signalled.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before the event is signalled.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -253,7 +256,7 @@ public sealed class AsyncAutoResetEvent : IResettable
 
             if (timeout == TimeSpan.Zero)
             {
-                return new ValueTask(Task.FromException(new OperationCanceledException()));
+                return new ValueTask(Task.FromException(new TimeoutException()));
             }
 
             throw new ArgumentOutOfRangeException(nameof(timeout));

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -446,7 +446,7 @@ public sealed class AsyncBarrier
         }
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -195,8 +195,11 @@ public sealed class AsyncBarrier
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before all participants arrive.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before all participants arrive.
     /// </exception>
     /// <exception cref="InvalidOperationException">Thrown when more participants signal than expected.</exception>
     /// <exception cref="BarrierPostPhaseException">Thrown when the post-phase action throws an exception.</exception>
@@ -229,7 +232,7 @@ public sealed class AsyncBarrier
                 if (timeout == TimeSpan.Zero)
                 {
                     _participantsRemaining++;
-                    return new ValueTask(Task.FromException(new OperationCanceledException()));
+                    return new ValueTask(Task.FromException(new TimeoutException()));
                 }
 
                 PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this);

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -421,7 +421,7 @@ public sealed class AsyncCountdownEvent
         }
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncCountdownEvent.cs
@@ -165,8 +165,11 @@ public sealed class AsyncCountdownEvent
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before the countdown reaches zero.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before the countdown reaches zero.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -180,7 +183,7 @@ public sealed class AsyncCountdownEvent
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask(Task.FromException(new OperationCanceledException()));
+            return new ValueTask(Task.FromException(new TimeoutException()));
         }
 
         return WaitAsyncImpl(timeout, cancellationToken);

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks.Sources;
 /// Note that this lock is <b>not</b> recursive!
 /// </summary>
 /// <remarks>
-/// /// <para>
+/// <para>
 /// <b>Optional timeout and cancellation token</b> parameters on <see cref="LockAsync(TimeSpan, CancellationToken)"/>.
 /// </para>
 /// 
@@ -52,7 +52,7 @@ using System.Threading.Tasks.Sources;
 /// of a <c>lock</c>.</para>
 /// <para>So, we use the <c>async</c>-compatible <see cref="AsyncLock"/> instead:</para>
 /// <code>
-/// private readonly var _mutex = new AsyncLock();
+/// private var _mutex = new AsyncLock();
 /// public async Task DoStuffAsync()
 /// {
 ///     using (await _mutex.LockAsync())
@@ -84,8 +84,9 @@ public sealed class AsyncLock : IResettable
         _pool = pool ?? ValueTaskSourceObjectPools.ValueTaskSourcePoolAsyncLockReleaser;
         _spinLock = new();
         _taken = 0;
-        _localWaiter = new(this);
-        _localWaiter.RunContinuationsAsynchronously = true;
+        _localWaiter = new(this) {
+            RunContinuationsAsynchronously = true
+        };
     }
 
     /// <inheritdoc/>
@@ -360,7 +361,7 @@ public sealed class AsyncLock : IResettable
         }
 
         ManualResetValueTaskSource<Releaser>? toCancel = RemoveWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Threading/Async/Pooled/AsyncLock.cs
+++ b/src/Threading/Async/Pooled/AsyncLock.cs
@@ -229,8 +229,11 @@ public sealed class AsyncLock : IResettable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask<Releaser> LockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -244,7 +247,7 @@ public sealed class AsyncLock : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask<Releaser>(Task.FromException<Releaser>(new OperationCanceledException()));
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
         }
 
         return LockAsyncImpl(timeout, cancellationToken);

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -232,8 +232,11 @@ public sealed class AsyncManualResetEvent : IResettable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before the event is set.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before the event is set.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -247,7 +250,7 @@ public sealed class AsyncManualResetEvent : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask(Task.FromException(new OperationCanceledException()));
+            return new ValueTask(Task.FromException(new TimeoutException()));
         }
 
         return WaitAsyncImpl(timeout, cancellationToken);

--- a/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
+++ b/src/Threading/Async/Pooled/AsyncManualResetEvent.cs
@@ -379,7 +379,7 @@ public sealed class AsyncManualResetEvent : IResettable
         }
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -321,6 +321,12 @@ public sealed class AsyncReaderWriterLock : IResettable
         /// </param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the attempt to upgrade to the write lock.</param>
         /// <exception cref="InvalidOperationException">Thrown if the current instance is not in the upgradeable reader state.</exception>
+        /// <exception cref="TimeoutException">
+        /// Thrown when the timeout elapses before the lock can be upgraded.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        /// Thrown when <paramref name="cancellationToken"/> is cancelled before the lock can be upgraded.
+        /// </exception>
         public ValueTask<Releaser> UpgradeToWriterLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
         {
             if (_owner is null)
@@ -663,8 +669,11 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask<Releaser> ReaderLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -683,7 +692,7 @@ public sealed class AsyncReaderWriterLock : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
         }
 
         return ReaderLockAsyncImplWithTimeout(timeout, cancellationToken);
@@ -854,8 +863,11 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask<Releaser> UpgradeableReaderLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -874,7 +886,7 @@ public sealed class AsyncReaderWriterLock : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
         }
 
         return UpgradeableReaderLockAsyncImplWithTimeout(timeout, cancellationToken);
@@ -981,8 +993,11 @@ public sealed class AsyncReaderWriterLock : IResettable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before the lock can be acquired.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before the lock can be acquired.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask<Releaser> WriterLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -996,7 +1011,7 @@ public sealed class AsyncReaderWriterLock : IResettable
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
+            return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
         }
 
         return WriterLockAsyncImpl(timeout, cancellationToken);

--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -1104,7 +1104,7 @@ public sealed class AsyncReaderWriterLock : IResettable
 
             if (timeout == TimeSpan.Zero)
             {
-                return new ValueTask<Releaser>(Task.FromException<Releaser>(ManualResetValueTaskSource<Releaser>.OperationCanceled));
+                return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
             }
 
             if (!_localUpgradedWriterWaiter.TryGetValueTaskSource(out waiter))
@@ -1403,7 +1403,7 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 
         ManualResetValueTaskSource<Releaser>? toCancel = RemoveReadersWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER
@@ -1439,7 +1439,7 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 
         ManualResetValueTaskSource<Releaser>? toCancel = RemoveUpgradeableReadersWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1510,7 +1510,7 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 
         ManualResetValueTaskSource<Releaser>? toCancel = RemoveWritersWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER
@@ -1562,7 +1562,7 @@ public sealed class AsyncReaderWriterLock : IResettable
         }
 
         ManualResetValueTaskSource<Releaser>? toCancel = RemoveUpgradedWritersWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Threading/Async/Pooled/AsyncSemaphore.cs
+++ b/src/Threading/Async/Pooled/AsyncSemaphore.cs
@@ -341,7 +341,7 @@ public sealed class AsyncSemaphore
         }
 
         ManualResetValueTaskSource<bool>? toCancel = RemoveWaiter(waiter);
-        toCancel?.SetException(ManualResetValueTaskSource<bool>.OperationCanceled);
+        toCancel?.SetException(new TimeoutException());
     }
 
     /// <summary>

--- a/src/Threading/Async/Pooled/AsyncSemaphore.cs
+++ b/src/Threading/Async/Pooled/AsyncSemaphore.cs
@@ -170,8 +170,11 @@ public sealed class AsyncSemaphore
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="timeout"/> is negative and not equal to <see cref="Timeout.InfiniteTimeSpan"/>.
     /// </exception>
-    /// <exception cref="OperationCanceledException">
+    /// <exception cref="TimeoutException">
     /// Thrown when the timeout elapses before a permit becomes available.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken"/> is cancelled before a permit becomes available.
     /// </exception>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -200,7 +203,7 @@ public sealed class AsyncSemaphore
 
         if (timeout == TimeSpan.Zero)
         {
-            return new ValueTask(Task.FromException(ManualResetValueTaskSource<bool>.OperationCanceled));
+            return new ValueTask(Task.FromException(new TimeoutException()));
         }
 
         return WaitAsyncImpl(timeout, cancellationToken);

--- a/src/Threading/Pools/ManualResetValueTaskSource{T}.cs
+++ b/src/Threading/Pools/ManualResetValueTaskSource{T}.cs
@@ -23,11 +23,6 @@ using System.Threading.Tasks.Sources;
 public abstract class ManualResetValueTaskSource<T> : IValueTaskSource<T>, IValueTaskSource, IResettable
 {
     /// <summary>
-    /// Shared operation cancelled exception.
-    /// </summary>
-    internal static OperationCanceledException OperationCanceled = new("The operation timed out.");
-
-    /// <summary>
     /// Link to the next node in the intrusive <see cref="WaiterQueue{T}"/>.
     /// </summary>
     internal ManualResetValueTaskSource<T>? Next { get; set; }
@@ -77,7 +72,7 @@ public abstract class ManualResetValueTaskSource<T> : IValueTaskSource<T>, IValu
     /// </summary>
     /// <remarks>
     /// Set to a non-<see langword="null"/> value when the waiter is created with a timeout.
-    /// The source is disposed automatically by <see cref="GetResult"/> and cleared by <see cref="TryReset"/>.
+    /// The timer is disposed and cleared by <see cref="TryReset"/> when the waiter is recycled.
     /// </remarks>
     public abstract ITimer? TimeoutTimer { get; set; }
 

--- a/src/Threading/README.md
+++ b/src/Threading/README.md
@@ -54,7 +54,7 @@ Namespace: `CryptoHives.Foundation.Threading.Pools`
 - **`ValueTask`-based APIs** — minimal/no memory allocations with object pools
 - **`CancellationToken` support** — full cancellation across all primitives, allocation-free on modern .NET
 - **`ConfigureAwait` support** — works naturally with `.ConfigureAwait(false)` in library code
-- **Timeout support**: all lock acquisition methods support timeout parameters
+- **Timeout support**: all lock acquisition methods support timeout parameters; a timed-out wait throws `TimeoutException`, a cancelled wait throws `OperationCanceledException`
 - **Configurable continuations** — control synchronous vs. asynchronous continuation scheduling
 - **Custom pools** — supply your own `IGetPooledManualResetValueTaskSource<T>` for fine-grained control
 - **Drop-in replacement** — change namespace, keep the same `using`-based patterns

--- a/src/Threading/README.md
+++ b/src/Threading/README.md
@@ -1,7 +1,6 @@
-## 🛡️ CryptoHives Open Source Initiative 🐝
+## CryptoHives Open Source Initiative 🐝
 
-An open, community-driven cryptography and performance library collection for the .NET ecosystem,
-developed and maintained by **The Keepers of the CryptoHives**.
+An open, community-driven collection of cryptography and performance libraries for the .NET ecosystem, maintained by **The Keepers of the CryptoHives**.
 
 ---
 
@@ -10,7 +9,7 @@ developed and maintained by **The Keepers of the CryptoHives**.
 [![NuGet](https://img.shields.io/nuget/v/CryptoHives.Foundation.Threading.svg)](https://www.nuget.org/packages/CryptoHives.Foundation.Threading)
 [![Tests](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml/badge.svg)](https://github.com/CryptoHives/Foundation/actions/workflows/buildandtest.yml)
 
-High-performance, pooled async synchronization primitives for .NET — designed to eliminate `Task` and `TaskCompletionSource<T>` allocations on the hot path.
+Pooled async synchronization primitives for .NET, built to keep `Task` and `TaskCompletionSource<T>` allocations off the hot path.
 
 ## Classes
 
@@ -28,7 +27,7 @@ Namespace: `CryptoHives.Foundation.Threading.Async.Pooled`
 | [AsyncBarrier](https://cryptohives.github.io/Foundation/packages/threading/asyncbarrier.html) | Pooled async barrier (synchronizes multiple participants)
 | [AsyncReaderWriterLock](https://cryptohives.github.io/Foundation/packages/threading/asyncreaderwriterlock.html) | Pooled async reader-writer lock (multiple readers or single writer)
 
-All primitives are backed by `ObjectPool<T>` and return `ValueTask<T>` to minimize per-operation allocations in high-throughput scenarios.
+All primitives are backed by `ObjectPool<T>` and return `ValueTask<T>`, which keeps per-operation allocations out of high-throughput code paths.
 
 ### Pooling Support Classes
 
@@ -36,7 +35,7 @@ Namespace: `CryptoHives.Foundation.Threading.Pools`
 
 | Class | Description | Namespace |
 |-------|-------------|-----------|
-| `IGetPooledManualResetValueTaskSource<T>` | Interface to get pooled `IValueTaskSource<T>` implementations (providers return `PooledManualResetValueTaskSource<T>` instances)
+| `IGetPooledManualResetValueTaskSource<T>` | Interface for obtaining pooled `IValueTaskSource<T>` implementations (providers return `PooledManualResetValueTaskSource<T>` instances)
 | `ManualResetValueTaskSource<T>` | Abstract base for pooled `IValueTaskSource<T>` implementations 
 | `PooledManualResetValueTaskSource<T>` | Pooled `IValueTaskSource<T>` implementation with automatic pool return 
 | `LocalManualResetValueTaskSource<T>` | Object-local `IValueTaskSource<T>` without pool integration 
@@ -44,26 +43,25 @@ Namespace: `CryptoHives.Foundation.Threading.Pools`
 | `ValueTaskSourceObjectPool<T>` | Specialized provider that implements `IGetPooledManualResetValueTaskSource<T>` and returns pooled task sources
 | `ValueTaskSourceObjectPools` | Static helper with shared pool instances and constants
 
-> **Included:** This package automatically bundles [CryptoHives.Foundation.Threading.Analyzers](https://www.nuget.org/packages/CryptoHives.Foundation.Threading.Analyzers) — Roslyn analyzers that detect common `ValueTask` misuse patterns at compile time, applied transitively to all consumers.
+> **Note:** This package no longer bundles [CryptoHives.Foundation.Threading.Analyzers](https://www.nuget.org/packages/CryptoHives.Foundation.Threading.Analyzers) automatically. Install it separately if you want the Roslyn analyzers alongside the Threading library.
 
 ---
 
-## ✨ Key Features
+## Key Features
 
 - **Pooled primitives** — synchronization objects backed by `Microsoft.Extensions.ObjectPool`
-- **`ValueTask`-based APIs** — minimal/no memory allocations with object pools
+- **`ValueTask`-based APIs** — minimal to no allocations thanks to object pooling
 - **`CancellationToken` support** — full cancellation across all primitives, allocation-free on modern .NET
 - **`ConfigureAwait` support** — works naturally with `.ConfigureAwait(false)` in library code
-- **Timeout support**: all lock acquisition methods support timeout parameters; a timed-out wait throws `TimeoutException`, a cancelled wait throws `OperationCanceledException`
-- **Configurable continuations** — control synchronous vs. asynchronous continuation scheduling
-- **Custom pools** — supply your own `IGetPooledManualResetValueTaskSource<T>` for fine-grained control
-- **Drop-in replacement** — change namespace, keep the same `using`-based patterns
-- **Custom ObjectPools**: Supply your own object pools for fine-grained control
-- **Optional analyzers** — ValueTask misuse caught at compile time, available in `Threading.Analyzers` package
+- **Timeouts** — every lock acquisition method accepts a timeout; a timed-out wait throws `TimeoutException`, a cancelled one throws `OperationCanceledException`
+- **Configurable continuations** — control whether continuations run synchronously or asynchronously
+- **Custom pools** — supply your own `IGetPooledManualResetValueTaskSource<T>` (or `ObjectPool<T>`) for fine-grained control
+- **Drop-in replacement** — swap the namespace, keep the same `using`-based patterns
+- **Optional analyzers** — ValueTask misuse caught at compile time via the separate `Threading.Analyzers` package
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 dotnet add package CryptoHives.Foundation.Threading
@@ -71,7 +69,7 @@ dotnet add package CryptoHives.Foundation.Threading
 
 ---
 
-## 🚀 Quick Examples
+## Quick Examples
 
 ### Mutual Exclusion — `AsyncLock`
 
@@ -182,17 +180,17 @@ var evt = new AsyncAutoResetEvent(
 
 ---
 
-## ⚠️ ValueTask Contract
+## ValueTask Contract
 
-1. **Await a `ValueTask` exactly once** — multiple `await` or `AsTask()` calls may throw `InvalidOperationException`.
-2. **Avoid `AsTask()` before signaling** — when `RunContinuationsAsynchronously=true` (the default), storing the result of `AsTask()` before the primitive is signaled causes severe performance degradation. Await the `ValueTask` directly wherever possible.
-3. **Always await or discard** — if a waiter is not consumed, the underlying `IValueTaskSource` is not returned to the pool.
+1. **Await a `ValueTask` exactly once.** A second `await` or `AsTask()` call may throw `InvalidOperationException`.
+2. **Avoid calling `AsTask()` before the primitive signals.** With `RunContinuationsAsynchronously=true` (the default), storing the result of `AsTask()` too early causes a severe performance hit. Await the `ValueTask` directly wherever you can.
+3. **Always await or discard a waiter.** If it's left unconsumed, the underlying `IValueTaskSource` never makes it back to the pool.
 
-The included **Threading.Analyzers** enforce these rules automatically at compile time.
+The bundled **Threading.Analyzers** package enforces these rules at compile time.
 
 ---
 
-## 📚 Documentation
+## Documentation
 
 | Resource | Link |
 |----------|------|
@@ -204,13 +202,12 @@ The included **Threading.Analyzers** enforce these rules automatically at compil
 
 ---
 
-## 🔐 Security Policy
+## Security Policy
 
-If you discover a vulnerability, **please do not open a public issue.**
-Follow the guidelines on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md).
+If you discover a vulnerability, please don't open a public issue — follow the process on the [CryptoHives Security Page](https://github.com/CryptoHives/.github/blob/main/SECURITY.md) instead.
 
 ---
 
-## ⚖️ License
+## License
 
 MIT — © 2026 The Keepers of the CryptoHives

--- a/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncAutoResetEventTests.cs
@@ -678,7 +678,7 @@ public class AsyncAutoResetEventTests
     {
         var ev = new AsyncAutoResetEvent();
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await ev.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -691,7 +691,7 @@ public class AsyncAutoResetEventTests
     {
         var ev = new AsyncAutoResetEvent();
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
     }
 
@@ -760,8 +760,8 @@ public class AsyncAutoResetEventTests
         var waiter2 = ev.WaitAsync(TimeSpan.FromMilliseconds(200));
 
 #pragma warning disable CHT010 // ValueTask captured in lambda or closure
-        Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter1.ConfigureAwait(false));
-        Assert.ThrowsAsync<OperationCanceledException>(async () => await waiter2.ConfigureAwait(false));
+        Assert.ThrowsAsync<TimeoutException>(async () => await waiter1.ConfigureAwait(false));
+        Assert.ThrowsAsync<TimeoutException>(async () => await waiter2.ConfigureAwait(false));
 #pragma warning restore CHT010 // ValueTask captured in lambda or closure
 
         await Task.Delay(50).ConfigureAwait(false);

--- a/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
@@ -657,7 +657,7 @@ public class AsyncBarrierTests
     {
         var barrier = new AsyncBarrier(2);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await barrier.SignalAndWaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -668,7 +668,7 @@ public class AsyncBarrierTests
     {
         var barrier = new AsyncBarrier(2);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await barrier.SignalAndWaitAsync(TimeSpan.Zero).ConfigureAwait(false));
     }
 
@@ -738,23 +738,23 @@ public class AsyncBarrierTests
         // whichever one the spinlock admits first should actually fire the post-phase action.
         // If RemoveParticipants wins, the third signal becomes a non-last signal for the new
         // (2-participant) phase and would queue forever with nothing left to complete it, so it
-        // is bounded by a timeout and a resulting cancellation is an accepted outcome.
+        // is bounded by a timeout and a resulting timeout is an accepted outcome.
         var removeTask = Task.Run(() => barrier.RemoveParticipants(1));
-        bool cancellationObserved = false;
+        bool timeoutObserved = false;
         var signalTask = Task.Run(async () => {
             try
             {
                 await barrier.SignalAndWaitAsync(TimeSpan.FromMilliseconds(300)).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (TimeoutException)
             {
-                // Expected in one race outcome: third signal may time out/cancel.
-                cancellationObserved = true;
+                // Expected in one race outcome: third signal may time out.
+                timeoutObserved = true;
             }
         });
 
         await Task.WhenAll(removeTask, signalTask).ConfigureAwait(false);
-        _ = cancellationObserved;
+        _ = timeoutObserved;
 
         await p1.ConfigureAwait(false);
         await p2.ConfigureAwait(false);

--- a/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncCountdownEventTests.cs
@@ -311,7 +311,7 @@ public class AsyncCountdownEventTests
     {
         var countdown = new AsyncCountdownEvent(1);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await countdown.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -331,7 +331,7 @@ public class AsyncCountdownEventTests
     {
         var countdown = new AsyncCountdownEvent(1);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await countdown.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
     }
 

--- a/tests/Threading/Async/Pooled/AsyncLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTests.cs
@@ -485,7 +485,7 @@ public class AsyncLockTests
 
         using var outerReleaser = await mutex.LockAsync().ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await mutex.LockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -516,7 +516,7 @@ public class AsyncLockTests
 
         using var outerReleaser = await mutex.LockAsync().ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             _ = await mutex.LockAsync(TimeSpan.Zero).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);

--- a/tests/Threading/Async/Pooled/AsyncLockTimeoutBenchmark.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTimeoutBenchmark.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace Threading.Tests.Async.Pooled;

--- a/tests/Threading/Async/Pooled/AsyncLockTimeoutBenchmark.cs
+++ b/tests/Threading/Async/Pooled/AsyncLockTimeoutBenchmark.cs
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace Threading.Tests.Async.Pooled;
+
+#pragma warning disable IDE0058 // Expression value is never used
+#pragma warning disable CA2012 // Use ValueTasks correctly
+
+using BenchmarkDotNet.Attributes;
+using CryptoHives.Foundation.Threading.Async.Pooled;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Benchmarks measuring lock/unlock performance and memory allocations when queued waiters
+/// specify a timeout.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This benchmark suite quantifies the cost of the timed wait path under contention: each
+/// queued waiter arms a timer (plus its timeout state) that is disposed again when the waiter
+/// completes. The timeout is long enough to never elapse, so the measurement isolates the
+/// arm/dispose overhead from actual timeout handling.
+/// </para>
+/// <para>
+/// <b>Test scenario:</b> Hold the lock, queue multiple timed lock requests, then release and
+/// sequentially acquire each queued lock.
+/// </para>
+/// <para>
+/// <b>Compared implementations:</b>
+/// </para>
+/// <list type="bullet">
+/// <item><description><b>Pooled (no timeout) (baseline):</b> Allocation-free contended path without a timer; shows the timed path overhead as the ratio.</description></item>
+/// <item><description><b>Pooled (ValueTask):</b> Same pooled implementation with a timeout per queued waiter.</description></item>
+/// <item><description><b>SemaphoreSlim:</b> System primitive used as async lock with timed WaitAsync.</description></item>
+/// <item><description><b>VS.Threading:</b> VS threading library AsyncSemaphore with timed EnterAsync.</description></item>
+/// </list>
+/// <para>
+/// <b>Key metrics:</b> Allocated bytes per operation for the timed contended path with varying
+/// numbers of queued waiters (controlled by <see cref="Iterations"/> parameter: 0, 1, 10, 100).
+/// </para>
+/// </remarks>
+[TestFixture]
+[TestFixtureSource(nameof(FixtureArgs))]
+[Config(typeof(ThreadingConfig))]
+[NonParallelizable]
+[BenchmarkCategory("AsyncLock")]
+public class AsyncLockTimeoutBenchmark : AsyncLockBaseBenchmark
+{
+    /// <summary>
+    /// A timeout that never elapses during the benchmark, so only the arm/dispose cost is measured.
+    /// </summary>
+    private static readonly TimeSpan LongTimeout = TimeSpan.FromMinutes(10);
+
+    private ValueTask<AsyncLock.Releaser>[]? _lockHandle;
+    private Task<bool>[]? _semaphoreSlimHandle;
+    private Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>[]? _lockVSThreadingHandle;
+
+    public static readonly object[] FixtureArgs = {
+        new object[] { 0 },
+        new object[] { 1 },
+        new object[] { 10 },
+        new object[] { 100 }
+    };
+
+    [Params(0, 1, 10, 100)]
+    public int Iterations { get; set; } = 10;
+
+    public AsyncLockTimeoutBenchmark() { }
+
+    public AsyncLockTimeoutBenchmark(int iterations)
+    {
+        Iterations = iterations;
+    }
+
+    [Test]
+    public Task LockUnlockPooledNoTimeoutMultipleTestAsync()
+    {
+        PooledNoTimeoutGlobalSetup();
+        return LockUnlockPooledNoTimeoutMultipleAsync();
+    }
+
+    [GlobalSetup(Target = nameof(LockUnlockPooledNoTimeoutMultipleAsync))]
+    public void PooledNoTimeoutGlobalSetup()
+    {
+        base.GlobalSetup();
+        _lockHandle = new ValueTask<AsyncLock.Releaser>[Iterations];
+    }
+
+    /// <summary>
+    /// Benchmark for pooled async lock with multiple queued waiters without a timeout (baseline).
+    /// </summary>
+    /// <remarks>
+    /// The allocation-free contended path: queued waiters reuse pooled IValueTaskSource
+    /// instances and arm no timer. The timed variants below show their overhead relative
+    /// to this baseline.
+    /// </remarks>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("MultipleTimeout", "Pooled (no timeout)")]
+    public async Task LockUnlockPooledNoTimeoutMultipleAsync()
+    {
+        using (await _lockPooled.LockAsync().ConfigureAwait(false))
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                _lockHandle![i] = _lockPooled.LockAsync();
+            }
+        }
+
+        foreach (ValueTask<AsyncLock.Releaser> handle in _lockHandle!)
+        {
+            using (await handle.ConfigureAwait(false)) { }
+        }
+    }
+
+    [Test]
+    public Task LockUnlockPooledTimeoutMultipleTestAsync()
+    {
+        PooledTimeoutGlobalSetup();
+        return LockUnlockPooledTimeoutMultipleAsync();
+    }
+
+    [GlobalSetup(Target = nameof(LockUnlockPooledTimeoutMultipleAsync))]
+    public void PooledTimeoutGlobalSetup()
+    {
+        base.GlobalSetup();
+        _lockHandle = new ValueTask<AsyncLock.Releaser>[Iterations];
+    }
+
+    /// <summary>
+    /// Benchmark for pooled async lock with multiple queued waiters that specify a timeout.
+    /// </summary>
+    /// <remarks>
+    /// Each queued waiter arms a timer and its timeout state; both are released when the
+    /// waiter acquires the lock. The allocation delta to the no-timeout baseline is the
+    /// per-waiter cost of the timed contended path.
+    /// </remarks>
+    [Benchmark]
+    [BenchmarkCategory("MultipleTimeout", "Pooled (ValueTask)")]
+    public async Task LockUnlockPooledTimeoutMultipleAsync()
+    {
+        using (await _lockPooled.LockAsync().ConfigureAwait(false))
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                _lockHandle![i] = _lockPooled.LockAsync(LongTimeout);
+            }
+        }
+
+        foreach (ValueTask<AsyncLock.Releaser> handle in _lockHandle!)
+        {
+            using (await handle.ConfigureAwait(false)) { }
+        }
+    }
+
+    [Test]
+    public Task LockUnlockSemaphoreSlimTimeoutMultipleTestAsync()
+    {
+        SemaphoreSlimTimeoutGlobalSetup();
+        return LockUnlockSemaphoreSlimTimeoutMultipleAsync();
+    }
+
+    [GlobalSetup(Target = nameof(LockUnlockSemaphoreSlimTimeoutMultipleAsync))]
+    public void SemaphoreSlimTimeoutGlobalSetup()
+    {
+        base.GlobalSetup();
+        _semaphoreSlimHandle = new Task<bool>[Iterations];
+    }
+
+    /// <summary>
+    /// Benchmark for SemaphoreSlim used as async lock with multiple queued waiters that specify a timeout.
+    /// </summary>
+    [Benchmark]
+    [BenchmarkCategory("MultipleTimeout", "System", "SemaphoreSlim")]
+    public async Task LockUnlockSemaphoreSlimTimeoutMultipleAsync()
+    {
+        await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                _semaphoreSlimHandle![i] = _semaphoreSlim.WaitAsync(LongTimeout);
+            }
+        }
+        finally
+        {
+            _semaphoreSlim.Release();
+        }
+
+        foreach (Task<bool> handle in _semaphoreSlimHandle!)
+        {
+            await handle.ConfigureAwait(false);
+            _semaphoreSlim.Release();
+        }
+    }
+
+    [Test]
+    public Task LockUnlockVSThreadingTimeoutMultipleTestAsync()
+    {
+        VSThreadingTimeoutGlobalSetup();
+        return LockUnlockVSThreadingTimeoutMultipleAsync();
+    }
+
+    [GlobalSetup(Target = nameof(LockUnlockVSThreadingTimeoutMultipleAsync))]
+    public void VSThreadingTimeoutGlobalSetup()
+    {
+        base.GlobalSetup();
+        _lockVSThreadingHandle = new Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>[Iterations];
+    }
+
+    /// <summary>
+    /// Benchmark for Visual Studio Threading async semaphore used as an async lock with multiple
+    /// queued waiters that specify a timeout.
+    /// </summary>
+    [Benchmark]
+    [BenchmarkCategory("MultipleTimeout", "VS.Threading", "AsyncSemaphore")]
+    public async Task LockUnlockVSThreadingTimeoutMultipleAsync()
+    {
+        using (await _lockVSThreading.EnterAsync().ConfigureAwait(false))
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                _lockVSThreadingHandle![i] = _lockVSThreading.EnterAsync(LongTimeout);
+            }
+        }
+
+        foreach (var handle in _lockVSThreadingHandle!)
+        {
+            using (await handle.ConfigureAwait(false)) { }
+        }
+    }
+}

--- a/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncManualResetEventTests.cs
@@ -437,7 +437,7 @@ public class AsyncManualResetEventTests
         using var pool = new TestObjectPool<bool>();
         var ev = new AsyncManualResetEvent(pool: pool);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await ev.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -451,7 +451,7 @@ public class AsyncManualResetEventTests
         using var pool = new TestObjectPool<bool>();
         var ev = new AsyncManualResetEvent(pool: pool);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await ev.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
     }
 

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -1727,7 +1727,7 @@ public class AsyncReaderWriterLockTests
 
         using var outerWriter = await rwLock.WriterLockAsync().ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await rwLock.ReaderLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -1759,7 +1759,7 @@ public class AsyncReaderWriterLockTests
 
         using var outerReader = await rwLock.ReaderLockAsync().ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -1789,7 +1789,7 @@ public class AsyncReaderWriterLockTests
 
         using var outerUpgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await rwLock.UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(100), ct).ConfigureAwait(false));
 
         await Task.Delay(50, ct).ConfigureAwait(false);
@@ -1824,7 +1824,7 @@ public class AsyncReaderWriterLockTests
 
         using var writer = await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await rwLock.ReaderLockAsync(TimeSpan.Zero, ct).ConfigureAwait(false));
     }
 
@@ -1838,7 +1838,7 @@ public class AsyncReaderWriterLockTests
 
         using var reader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await rwLock.WriterLockAsync(TimeSpan.Zero, ct).ConfigureAwait(false));
     }
 
@@ -1852,7 +1852,7 @@ public class AsyncReaderWriterLockTests
 
         using var writer = await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await rwLock.UpgradeableReaderLockAsync(TimeSpan.Zero, ct).ConfigureAwait(false));
     }
 
@@ -1868,7 +1868,7 @@ public class AsyncReaderWriterLockTests
         using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
         using var reader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await upgr.UpgradeToWriterLockAsync(TimeSpan.Zero, ct).ConfigureAwait(false));
     }
 
@@ -2008,17 +2008,17 @@ public class AsyncReaderWriterLockTests
                 .WriterLockAsync(innerCts.Token)
                 .ConfigureAwait(false));
 
-        Assert.ThrowsAsync<OperationCanceledException>(
+        Assert.ThrowsAsync<TimeoutException>(
             async () => await rwLock
                 .WriterLockAsync(TimeSpan.FromMilliseconds(100), ct)
                 .ConfigureAwait(false));
 
-        Assert.ThrowsAsync<OperationCanceledException>(
+        Assert.ThrowsAsync<TimeoutException>(
             async () => await rwLock
                 .ReaderLockAsync(TimeSpan.FromMilliseconds(100), ct)
                 .ConfigureAwait(false));
 
-        Assert.ThrowsAsync<OperationCanceledException>(
+        Assert.ThrowsAsync<TimeoutException>(
             async () => await rwLock
                 .UpgradeableReaderLockAsync(TimeSpan.FromMilliseconds(100), ct)
                 .ConfigureAwait(false));
@@ -2047,7 +2047,7 @@ public class AsyncReaderWriterLockTests
         {
             writer = await rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(75), ct).ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (TimeoutException)
         {
             // Timeout won the race - acceptable outcome.
         }
@@ -2087,7 +2087,7 @@ public class AsyncReaderWriterLockTests
         {
             upgWriter = await upgr.UpgradeToWriterLockAsync(TimeSpan.FromMilliseconds(75), ct).ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (TimeoutException)
         {
             // Timeout won the race - acceptable outcome.
         }

--- a/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncSemaphoreTests.cs
@@ -264,7 +264,7 @@ public class AsyncSemaphoreTests
     {
         var semaphore = new AsyncSemaphore(0);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await semaphore.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false));
 
         await Task.Delay(50).ConfigureAwait(false);
@@ -287,7 +287,7 @@ public class AsyncSemaphoreTests
     {
         var semaphore = new AsyncSemaphore(0);
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TimeoutException>(async () =>
             await semaphore.WaitAsync(TimeSpan.Zero).ConfigureAwait(false));
     }
 

--- a/tests/Threading/Async/Pooled/CancellationRegistrationStressTests.cs
+++ b/tests/Threading/Async/Pooled/CancellationRegistrationStressTests.cs
@@ -1,0 +1,282 @@
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+#pragma warning disable CA1849 // Call async methods when in an async method
+
+namespace Threading.Tests.Async.Pooled;
+
+using CryptoHives.Foundation.Threading.Async.Pooled;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Threading.Tests.Pools;
+
+/// <summary>
+/// Regression stress tests for the race between token cancellation and waiter registration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The waiter setup used to register the cancellation callback while holding the internal
+/// spin lock. A token cancelled concurrently with a contended acquisition could invoke the
+/// callback synchronously on the registering thread, which then re-entered the non-reentrant
+/// spin lock and spun forever, or the cancellation was lost because the waiter was not yet
+/// enqueued when the callback ran.
+/// </para>
+/// <para>
+/// Each test keeps the primitive permanently contended so the only valid outcome of an
+/// acquisition is cancellation, and sweeps the cancellation timing across the acquisition
+/// window. A regression shows up as an iteration that neither completes nor cancels.
+/// </para>
+/// </remarks>
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class CancellationRegistrationStressTests
+{
+    private const int Iterations = 1000;
+    private static readonly TimeSpan IterationTimeout = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public async Task AsyncLockCancelDuringContendedLockNeverHangs()
+    {
+        using var pool = new TestObjectPool<AsyncLock.Releaser>();
+        var mutex = new AsyncLock(pool: pool);
+
+        AsyncLock.Releaser held = await mutex.LockAsync().ConfigureAwait(false);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            await RaceCancellationAsync(i, async ct => {
+                using (await mutex.LockAsync(ct).ConfigureAwait(false))
+                {
+                    Assert.Fail("The lock is held; acquisition must not succeed.");
+                }
+            }).ConfigureAwait(false);
+        }
+
+        held.Dispose();
+
+        // liveness: the lock must still be acquirable after the stress
+        using (await mutex.LockAsync().ConfigureAwait(false)) { }
+        Assert.That(mutex.InternalWaiterInUse, Is.False);
+    }
+
+    [Test]
+    public async Task AsyncSemaphoreCancelDuringContendedWaitNeverHangs()
+    {
+        using var pool = new TestObjectPool<bool>();
+        var semaphore = new AsyncSemaphore(initialCount: 0, pool: pool);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            await RaceCancellationAsync(i, async ct => {
+                await semaphore.WaitAsync(ct).ConfigureAwait(false);
+                Assert.Fail("The semaphore has no permits; the wait must not succeed.");
+            }).ConfigureAwait(false);
+        }
+
+        // liveness: a released permit must still be acquirable after the stress
+        semaphore.Release();
+        await semaphore.WaitAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task AsyncAutoResetEventCancelDuringContendedWaitNeverHangs()
+    {
+        using var pool = new TestObjectPool<bool>();
+        var autoResetEvent = new AsyncAutoResetEvent(initialState: false, pool: pool);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            await RaceCancellationAsync(i, async ct => {
+                await autoResetEvent.WaitAsync(ct).ConfigureAwait(false);
+                Assert.Fail("The event is not signaled; the wait must not succeed.");
+            }).ConfigureAwait(false);
+        }
+
+        // liveness: a signal must still release a waiter after the stress
+        autoResetEvent.Set();
+        await autoResetEvent.WaitAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task AsyncManualResetEventCancelDuringContendedWaitNeverHangs()
+    {
+        using var pool = new TestObjectPool<bool>();
+        var manualResetEvent = new AsyncManualResetEvent(set: false, pool: pool);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            await RaceCancellationAsync(i, async ct => {
+                await manualResetEvent.WaitAsync(ct).ConfigureAwait(false);
+                Assert.Fail("The event is not set; the wait must not succeed.");
+            }).ConfigureAwait(false);
+        }
+
+        // liveness: setting the event must still release waiters after the stress
+        manualResetEvent.Set();
+        await manualResetEvent.WaitAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task AsyncCountdownEventCancelDuringContendedWaitNeverHangs()
+    {
+        using var pool = new TestObjectPool<bool>();
+        var countdownEvent = new AsyncCountdownEvent(initialCount: 1, pool: pool);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            await RaceCancellationAsync(i, async ct => {
+                await countdownEvent.WaitAsync(ct).ConfigureAwait(false);
+                Assert.Fail("The countdown has not reached zero; the wait must not succeed.");
+            }).ConfigureAwait(false);
+        }
+
+        // liveness: the final signal must still release waiters after the stress
+        countdownEvent.Signal();
+        await countdownEvent.WaitAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task AsyncBarrierCancelDuringContendedSignalAndWaitNeverHangs()
+    {
+        using var pool = new TestObjectPool<bool>();
+        var barrier = new AsyncBarrier(participantCount: 2, pool: pool);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            await RaceCancellationAsync(i, async ct => {
+                await barrier.SignalAndWaitAsync(ct).ConfigureAwait(false);
+                Assert.Fail("Only one participant signaled; the wait must not succeed.");
+            }).ConfigureAwait(false);
+        }
+
+        // every cancelled signal must have restored the participant count
+        Assert.That(barrier.ParticipantsRemaining, Is.EqualTo(2));
+
+        // liveness: a full phase must still complete after the stress
+        Task first = barrier.SignalAndWaitAsync().AsTask();
+        Task second = barrier.SignalAndWaitAsync().AsTask();
+        await Task.WhenAll(first, second).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task AsyncReaderWriterLockCancelDuringContendedLockNeverHangs()
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(pool: pool);
+
+        AsyncReaderWriterLock.Releaser writerHeld = await rwLock.WriterLockAsync().ConfigureAwait(false);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            // alternate the acquisition kind to cover the reader, writer and
+            // upgradeable reader registration paths
+            Func<CancellationToken, Task> acquire = (i % 3) switch
+            {
+                0 => async ct => {
+                    using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
+                    {
+                        Assert.Fail("A writer holds the lock; the reader must not succeed.");
+                    }
+                },
+                1 => async ct => {
+                    using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
+                    {
+                        Assert.Fail("A writer holds the lock; the writer must not succeed.");
+                    }
+                },
+                _ => async ct => {
+                    using (await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
+                    {
+                        Assert.Fail("A writer holds the lock; the upgradeable reader must not succeed.");
+                    }
+                },
+            };
+
+            await RaceCancellationAsync(i, acquire).ConfigureAwait(false);
+        }
+
+        writerHeld.Dispose();
+
+        // liveness: the lock must still be acquirable after the stress
+        (await rwLock.WriterLockAsync().ConfigureAwait(false)).Dispose();
+    }
+
+    [Test]
+    public async Task AsyncReaderWriterLockCancelDuringContendedUpgradeNeverHangs()
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(pool: pool);
+
+        // a plain reader keeps the upgrade contended for the whole stress
+        AsyncReaderWriterLock.Releaser readerHeld = await rwLock.ReaderLockAsync().ConfigureAwait(false);
+        AsyncReaderWriterLock.Releaser upgradeable = await rwLock.UpgradeableReaderLockAsync().ConfigureAwait(false);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            await RaceCancellationAsync(i, async ct => {
+                using (await upgradeable.UpgradeToWriterLockAsync(ct).ConfigureAwait(false))
+                {
+                    Assert.Fail("A reader holds the lock; the upgrade must not succeed.");
+                }
+            }).ConfigureAwait(false);
+        }
+
+        readerHeld.Dispose();
+
+        // liveness: with the reader gone the upgrade must still succeed
+        (await upgradeable.UpgradeToWriterLockAsync().ConfigureAwait(false)).Dispose();
+        upgradeable.Dispose();
+        (await rwLock.WriterLockAsync().ConfigureAwait(false)).Dispose();
+    }
+
+    /// <summary>
+    /// Starts the contended acquisition on the thread pool and cancels the token while the
+    /// acquisition is in flight, asserting that the operation observes the cancellation.
+    /// </summary>
+    /// <remarks>
+    /// The spin count derived from the iteration index sweeps the cancellation timing across
+    /// the acquisition window, so over many iterations the cancellation hits before, inside
+    /// and after the waiter registration.
+    /// </remarks>
+    /// <param name="iteration">The iteration index used to vary the cancellation timing.</param>
+    /// <param name="acquire">The acquisition that must observe the cancellation.</param>
+    private static async Task RaceCancellationAsync(int iteration, Func<CancellationToken, Task> acquire)
+    {
+        using var cts = new CancellationTokenSource();
+
+        int started = 0;
+        var waitTask = Task.Run(async () => {
+            Volatile.Write(ref started, 1);
+            try
+            {
+                await acquire(cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // expected: the acquisition observed the cancellation
+            }
+        });
+
+        while (Volatile.Read(ref started) == 0)
+        {
+            Thread.SpinWait(1);
+        }
+
+        Thread.SpinWait(iteration % 128);
+        cts.Cancel();
+
+        using var timeoutCts = new CancellationTokenSource();
+        Task completed = await Task.WhenAny(waitTask, Task.Delay(IterationTimeout, timeoutCts.Token)).ConfigureAwait(false);
+        if (ReferenceEquals(completed, waitTask))
+        {
+            timeoutCts.Cancel();
+            await waitTask.ConfigureAwait(false);
+        }
+        else
+        {
+            Assert.Fail($"Iteration {iteration}: the acquisition neither completed nor observed the cancellation (lost cancellation or deadlock).");
+        }
+    }
+}

--- a/tests/Threading/Async/Pooled/CancellationRegistrationStressTests.cs
+++ b/tests/Threading/Async/Pooled/CancellationRegistrationStressTests.cs
@@ -172,26 +172,28 @@ public class CancellationRegistrationStressTests
         {
             // alternate the acquisition kind to cover the reader, writer and
             // upgradeable reader registration paths
-            Func<CancellationToken, Task> acquire = (i % 3) switch
-            {
+            Func<CancellationToken, Task> acquire = (i % 3) switch {
                 0 => async ct => {
                     using (await rwLock.ReaderLockAsync(ct).ConfigureAwait(false))
                     {
                         Assert.Fail("A writer holds the lock; the reader must not succeed.");
                     }
-                },
+                }
+                ,
                 1 => async ct => {
                     using (await rwLock.WriterLockAsync(ct).ConfigureAwait(false))
                     {
                         Assert.Fail("A writer holds the lock; the writer must not succeed.");
                     }
-                },
+                }
+                ,
                 _ => async ct => {
                     using (await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false))
                     {
                         Assert.Fail("A writer holds the lock; the upgradeable reader must not succeed.");
                     }
-                },
+                }
+                ,
             };
 
             await RaceCancellationAsync(i, acquire).ConfigureAwait(false);


### PR DESCRIPTION
- return TimeoutException instead of OperationCancelled to follow existing sync primitives
- remove a shared exception object to ensure consistent stack traces
- typos and samples docs