### PR TITLE
Improve security library in various areas

### DIFF
--- a/src/Security/Cryptography/Cipher/Aes/AesCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/Aes/AesCipherTransform.cs
@@ -328,21 +328,11 @@ internal sealed unsafe class AesCipherTransform : ICipherTransform
             else if (_padding != PaddingMode.None && written > 0)
             {
                 // Validate and remove PKCS#7 padding
-                int lastBlockStart = written - BlockSize;
                 byte padValue = output[written - 1];
 
-                if (padValue < 1 || padValue > BlockSize)
+                if (!IsPkcs7PaddingValid(output.Slice(written - BlockSize, BlockSize), padValue))
                 {
                     throw new CryptographicException("Invalid padding.");
-                }
-
-                // Validate all padding bytes
-                for (int i = 0; i < padValue; i++)
-                {
-                    if (output[written - 1 - i] != padValue)
-                    {
-                        throw new CryptographicException("Invalid padding.");
-                    }
                 }
 
                 written -= padValue;
@@ -350,6 +340,36 @@ internal sealed unsafe class AesCipherTransform : ICipherTransform
         }
 
         return written;
+    }
+
+    /// <summary>
+    /// Validates PKCS#7 padding on a full block in constant time.
+    /// </summary>
+    /// <remarks>
+    /// Scans every byte of <paramref name="block"/> unconditionally (no early exit) and combines
+    /// the result with a single bitwise OR, so execution time does not depend on the position of
+    /// the first invalid pad byte. A data-dependent early exit here is the classical CBC
+    /// padding-oracle side channel (Vaudenay 2002; exploited in practice by POODLE/Lucky 13-style
+    /// attacks) - even without a distinguishable error message, the timing difference alone is
+    /// enough to decrypt ciphertext one byte at a time.
+    /// </remarks>
+    /// <param name="block">The last decrypted block (exactly <see cref="BlockSize"/> bytes).</param>
+    /// <param name="padValue">The claimed pad length (<c>block[^1]</c>).</param>
+    /// <returns><see langword="true"/> if the padding is well-formed.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsPkcs7PaddingValid(ReadOnlySpan<byte> block, byte padValue)
+    {
+        int blockSize = BlockSize;
+        int badLength = ((uint)(padValue - 1) > (uint)(blockSize - 1)) ? 1 : 0;
+
+        int mismatch = 0;
+        for (int i = 0; i < blockSize; i++)
+        {
+            byte expected = i < padValue ? padValue : block[blockSize - 1 - i];
+            mismatch |= expected ^ block[blockSize - 1 - i];
+        }
+
+        return badLength == 0 && mismatch == 0;
     }
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Cipher/Aes/AesCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/Aes/AesCipherTransform.cs
@@ -184,8 +184,11 @@ internal sealed unsafe class AesCipherTransform : ICipherTransform
     public bool CanReuseTransform => true;
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public int TransformBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(AesCipherTransform));
         if (input.Length < BlockSize)
             throw new ArgumentException("Input must be at least one block.", nameof(input));
         if (output.Length < BlockSize)
@@ -233,8 +236,11 @@ internal sealed unsafe class AesCipherTransform : ICipherTransform
         => TransformBlock(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public int TransformFinalBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(AesCipherTransform));
         int fullBlocks = input.Length / BlockSize;
         int remainder = input.Length % BlockSize;
         int written = 0;

--- a/src/Security/Cryptography/Cipher/Aes/AesCore.cs
+++ b/src/Security/Cryptography/Cipher/Aes/AesCore.cs
@@ -19,9 +19,20 @@ using System.Runtime.CompilerServices;
 /// <b>Implementation notes:</b>
 /// <list type="bullet">
 ///   <item><description>Uses T-tables for optimized encryption/decryption</description></item>
-///   <item><description>Constant-time S-box lookups to resist timing attacks</description></item>
 ///   <item><description>Supports 128-bit block size only (standard AES)</description></item>
 /// </list>
+/// </para>
+/// <para>
+/// <b>Timing side channel:</b> this is the scalar, table-based fallback used when neither
+/// AES-NI (x86) nor the ARMv8 Crypto Extension is available (<c>AesCoreAesNi</c> /
+/// <c>AesCoreArm</c>, selected via <c>SimdSupport</c>). The T-tables (<c>Te0</c>-<c>Te3</c>,
+/// <c>Td0</c>-<c>Td3</c>) and S-box are indexed by the AES intermediate state, which is derived
+/// from the plaintext/ciphertext and the round key - the classic table-lookup cache-timing
+/// vulnerability described in Bernstein's "Cache-timing attacks on AES" (2005). This
+/// implementation makes no attempt to mitigate it (no table prefetching, no bitslicing). Do not
+/// rely on this fallback for key material processed in a shared/adversarial execution
+/// environment (e.g. multi-tenant cloud hosts, co-resident untrusted processes); prefer hardware
+/// AES acceleration wherever it's available.
 /// </para>
 /// </remarks>
 internal static class AesCore

--- a/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
@@ -106,8 +106,11 @@ internal abstract class BlockCipherTransform : ICipherTransform
     protected abstract void DecryptBlock(ReadOnlySpan<byte> input, Span<byte> output);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public virtual int TransformBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
         if (input.Length < BlockSizeConst)
             throw new ArgumentException("Input must be at least one block.", nameof(input));
         if (output.Length < BlockSizeConst)
@@ -147,8 +150,11 @@ internal abstract class BlockCipherTransform : ICipherTransform
         => TransformBlock(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public int TransformFinalBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
         int fullBlocks = input.Length / BlockSizeConst;
         int remainder = input.Length % BlockSizeConst;
         int written = 0;

--- a/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/BlockCipherTransform.cs
@@ -226,20 +226,43 @@ internal abstract class BlockCipherTransform : ICipherTransform
             {
                 byte padValue = output[written - 1];
 
-                if (padValue < 1 || padValue > BlockSizeConst)
+                if (!IsPkcs7PaddingValid(output.Slice(written - BlockSizeConst, BlockSizeConst), padValue))
                     throw new CryptographicException("Invalid padding.");
-
-                for (int i = 0; i < padValue; i++)
-                {
-                    if (output[written - 1 - i] != padValue)
-                        throw new CryptographicException("Invalid padding.");
-                }
 
                 written -= padValue;
             }
         }
 
         return written;
+    }
+
+    /// <summary>
+    /// Validates PKCS#7 padding on a full block in constant time.
+    /// </summary>
+    /// <remarks>
+    /// Scans every byte of <paramref name="block"/> unconditionally (no early exit) and combines
+    /// the result with a single bitwise OR, so execution time does not depend on the position of
+    /// the first invalid pad byte. A data-dependent early exit here is the classical CBC
+    /// padding-oracle side channel (Vaudenay 2002; exploited in practice by POODLE/Lucky 13-style
+    /// attacks) - even without a distinguishable error message, the timing difference alone is
+    /// enough to decrypt ciphertext one byte at a time.
+    /// </remarks>
+    /// <param name="block">The last decrypted block (exactly <see cref="BlockSizeConst"/> bytes).</param>
+    /// <param name="padValue">The claimed pad length (<c>block[^1]</c>).</param>
+    /// <returns><see langword="true"/> if the padding is well-formed.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsPkcs7PaddingValid(ReadOnlySpan<byte> block, byte padValue)
+    {
+        int badLength = ((uint)(padValue - 1) > (uint)(BlockSizeConst - 1)) ? 1 : 0;
+
+        int mismatch = 0;
+        for (int i = 0; i < BlockSizeConst; i++)
+        {
+            byte expected = i < padValue ? padValue : block[BlockSizeConst - 1 - i];
+            mismatch |= expected ^ block[BlockSizeConst - 1 - i];
+        }
+
+        return badLength == 0 && mismatch == 0;
     }
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Cipher/Ccm/AesCcm.cs
+++ b/src/Security/Cryptography/Cipher/Ccm/AesCcm.cs
@@ -103,6 +103,7 @@ public abstract class AesCcm : IAeadCipher
     /// <param name="ciphertext">Output buffer for ciphertext (must be same size as plaintext).</param>
     /// <param name="tag">Output buffer for authentication tag (4-16 bytes, even).</param>
     /// <param name="associatedData">Additional authenticated data (optional).</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Encrypt(
         ReadOnlySpan<byte> nonce,
         ReadOnlySpan<byte> plaintext,
@@ -110,6 +111,8 @@ public abstract class AesCcm : IAeadCipher
         Span<byte> tag,
         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
         if (ciphertext.Length < plaintext.Length)
             throw new ArgumentException("Ciphertext buffer too small.", nameof(ciphertext));
 
@@ -130,6 +133,7 @@ public abstract class AesCcm : IAeadCipher
     /// <param name="plaintext">Output buffer for plaintext (must be same size as ciphertext).</param>
     /// <param name="associatedData">Additional authenticated data (optional).</param>
     /// <returns>True if authentication succeeded; otherwise false.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public bool Decrypt(
         ReadOnlySpan<byte> nonce,
         ReadOnlySpan<byte> ciphertext,
@@ -137,6 +141,8 @@ public abstract class AesCcm : IAeadCipher
         Span<byte> plaintext,
         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
         if (plaintext.Length < ciphertext.Length)
             throw new ArgumentException("Plaintext buffer too small.", nameof(plaintext));
 

--- a/src/Security/Cryptography/Cipher/Ccm/CcmCore.cs
+++ b/src/Security/Cryptography/Cipher/Ccm/CcmCore.cs
@@ -23,7 +23,7 @@ using System.Runtime.Intrinsics;
 /// <list type="bullet">
 ///   <item><description>Defined for 128-bit block ciphers only (AES)</description></item>
 ///   <item><description>Authenticate-then-encrypt construction</description></item>
-///   <item><description>Variable tag length (4-16 bytes)</description></item>
+///   <item><description>Variable tag length (4-16 bytes, even values)</description></item>
 ///   <item><description>Variable nonce length (7-13 bytes)</description></item>
 /// </list>
 /// </para>

--- a/src/Security/Cryptography/Cipher/ChaCha/ChaCha20CipherTransform.cs
+++ b/src/Security/Cryptography/Cipher/ChaCha/ChaCha20CipherTransform.cs
@@ -82,8 +82,11 @@ internal sealed class ChaCha20CipherTransform : ICipherTransform
     public bool CanReuseTransform => true;
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public int TransformBlock(ReadOnlySpan<byte> input, Span<byte> output)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ChaCha20CipherTransform));
         if (output.Length < input.Length)
             throw new ArgumentException("Output buffer too small.", nameof(output));
 

--- a/src/Security/Cryptography/Cipher/ChaCha/ChaCha20Poly1305.cs
+++ b/src/Security/Cryptography/Cipher/ChaCha/ChaCha20Poly1305.cs
@@ -124,10 +124,13 @@ public sealed class ChaCha20Poly1305 : IAeadCipher
     internal static ChaCha20Poly1305 Create(SimdSupport simdSupport, byte[] key) => new(simdSupport, key);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Encrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> plaintext,
                         Span<byte> ciphertext, Span<byte> tag,
                         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ChaCha20Poly1305));
         if (nonce.Length != NonceSizeBytesConst)
             throw new ArgumentException($"Nonce must be {NonceSizeBytesConst} bytes.", nameof(nonce));
         if (ciphertext.Length < plaintext.Length)
@@ -148,10 +151,13 @@ public sealed class ChaCha20Poly1305 : IAeadCipher
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public bool Decrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> ciphertext,
                         ReadOnlySpan<byte> tag, Span<byte> plaintext,
                         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ChaCha20Poly1305));
         if (nonce.Length != NonceSizeBytesConst)
             throw new ArgumentException($"Nonce must be {NonceSizeBytesConst} bytes.", nameof(nonce));
         if (tag.Length != TagSizeBytesConst)

--- a/src/Security/Cryptography/Cipher/ChaCha/XChaCha20Poly1305.cs
+++ b/src/Security/Cryptography/Cipher/ChaCha/XChaCha20Poly1305.cs
@@ -127,6 +127,7 @@ public sealed class XChaCha20Poly1305 : IAeadCipher
     internal static XChaCha20Poly1305 Create(SimdSupport simdSupport, byte[] key) => new(simdSupport, key);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     [SkipLocalsInit]
     public void Encrypt(
         ReadOnlySpan<byte> nonce,
@@ -135,6 +136,8 @@ public sealed class XChaCha20Poly1305 : IAeadCipher
         Span<byte> tag,
         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(XChaCha20Poly1305));
         if (nonce.Length != NonceSizeBytesConst)
             throw new ArgumentException($"Nonce must be {NonceSizeBytesConst} bytes.", nameof(nonce));
         if (ciphertext.Length < plaintext.Length)
@@ -164,6 +167,7 @@ public sealed class XChaCha20Poly1305 : IAeadCipher
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public bool Decrypt(
         ReadOnlySpan<byte> nonce,
         ReadOnlySpan<byte> ciphertext,
@@ -171,6 +175,8 @@ public sealed class XChaCha20Poly1305 : IAeadCipher
         Span<byte> plaintext,
         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(XChaCha20Poly1305));
         if (nonce.Length != NonceSizeBytesConst)
             throw new ArgumentException($"Nonce must be {NonceSizeBytesConst} bytes.", nameof(nonce));
         if (tag.Length != TagSizeBytesConst)

--- a/src/Security/Cryptography/Cipher/Gcm/AesGcm.cs
+++ b/src/Security/Cryptography/Cipher/Gcm/AesGcm.cs
@@ -217,7 +217,7 @@ public abstract class AesGcm : IAeadCipher
         {
             if (disposing)
             {
-                _gcmCore = default;
+                _gcmCore.Clear();
             }
 
             _disposed = true;

--- a/src/Security/Cryptography/Cipher/Gcm/AesGcm.cs
+++ b/src/Security/Cryptography/Cipher/Gcm/AesGcm.cs
@@ -90,11 +90,14 @@ public abstract class AesGcm : IAeadCipher
     public int TagSizeBytes => GcmCore.TagSizeBytes;
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Encrypt(
         ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> plaintext,
         Span<byte> ciphertext, Span<byte> tag,
         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
         if (nonce.Length == 0)
             throw new ArgumentException("Nonce cannot be empty.", nameof(nonce));
         if (ciphertext.Length < plaintext.Length)
@@ -124,11 +127,14 @@ public abstract class AesGcm : IAeadCipher
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public bool Decrypt(
         ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> ciphertext,
         ReadOnlySpan<byte> tag, Span<byte> plaintext,
         ReadOnlySpan<byte> associatedData = default)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
         if (nonce.Length == 0)
             throw new ArgumentException("Nonce cannot be empty.", nameof(nonce));
         if (tag.Length != TagSizeBytes)

--- a/src/Security/Cryptography/Cipher/Gcm/AesGcm.cs
+++ b/src/Security/Cryptography/Cipher/Gcm/AesGcm.cs
@@ -118,8 +118,9 @@ public abstract class AesGcm : IAeadCipher
         Span<byte> fullTag = stackalloc byte[GcmCore.BlockSizeBytes];
         _gcmCore.GctrDispatch(j0, ghash, fullTag);
 
-        // Copy tag to output (truncate if necessary)
-        fullTag.Slice(0, tag.Length).CopyTo(tag);
+        // Write the fixed-size tag; larger caller-supplied buffers are left
+        // untouched beyond TagSizeBytes (tag.Length >= TagSizeBytes is guaranteed above).
+        fullTag.CopyTo(tag);
     }
 
     /// <inheritdoc/>

--- a/src/Security/Cryptography/Cipher/Gcm/GcmCore.cs
+++ b/src/Security/Cryptography/Cipher/Gcm/GcmCore.cs
@@ -33,7 +33,7 @@ using ArmAes = System.Runtime.Intrinsics.Arm.Aes;
 /// </list>
 /// </para>
 /// </remarks>
-internal readonly struct GcmCore
+internal struct GcmCore
 {
     /// <summary>
     /// GCM block size in bytes (128 bits).
@@ -121,7 +121,7 @@ internal readonly struct GcmCore
     private readonly bool _usePclmulV256;
     private readonly bool _useArmAes;
     private readonly bool _useArmPmull;
-    private readonly Vector128<byte> _hClmul;
+    private Vector128<byte> _hClmul;
     private readonly Vector128<byte>[] _hPowers;
 #endif
 
@@ -189,6 +189,24 @@ internal readonly struct GcmCore
                 _usePipeline = _usePclmul || _usePclmulV256;
                 _hPowers = PrepareHPowers(_hClmul);
             }
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Zeroes all key-derived material (round keys, hash subkey, and precomputed
+    /// GHASH tables) so it does not linger in memory after the owning cipher is disposed.
+    /// </summary>
+    public void Clear()
+    {
+        Array.Clear(_encRoundKeys, 0, _encRoundKeys.Length);
+        Array.Clear(_h, 0, _h.Length);
+        Array.Clear(_shoupTable, 0, _shoupTable.Length);
+#if NET8_0_OR_GREATER
+        _hClmul = default;
+        if (_hPowers is not null)
+        {
+            Array.Clear(_hPowers, 0, _hPowers.Length);
         }
 #endif
     }

--- a/src/Security/Cryptography/Cipher/Gcm/GcmCore.cs
+++ b/src/Security/Cryptography/Cipher/Gcm/GcmCore.cs
@@ -649,8 +649,14 @@ internal struct GcmCore
     /// Multiplies two elements in GF(2^128).
     /// </summary>
     /// <param name="x">First operand (16 bytes).</param>
-    /// <param name="y">Second operand (16 bytes).</param>
+    /// <param name="y">Second operand (16 bytes) - callers pass the secret hash subkey H here.</param>
     /// <param name="result">Result buffer (16 bytes, can be same as x).</param>
+    /// <remarks>
+    /// Branch-free by construction: every conditional XOR is done via an all-ones/all-zeros
+    /// mask rather than an <c>if</c>, so execution time does not depend on the bits of
+    /// <paramref name="y"/> (the secret H in every current caller). See <see cref="GfMulUlong"/>
+    /// for the ulong-native equivalent used on the hot GHASH path.
+    /// </remarks>
     [MethodImpl(MethodImplOptionsEx.HotPath)]
     public static void GfMul(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, Span<byte> result)
     {
@@ -662,41 +668,29 @@ internal struct GcmCore
 
         ulong z0 = 0, z1 = 0;
 
-        // Multiply using the "left-to-right" method
+        // Multiply using the "left-to-right" method. Conditional XORs use a constant-time
+        // mask (0 or all-ones) instead of a branch, since y may be secret (see remarks).
         for (int i = 0; i < 64; i++)
         {
-            // If bit i of y0 is set, XOR x into z
-            if (((y0 >> (63 - i)) & 1) == 1)
-            {
-                z0 ^= x0;
-                z1 ^= x1;
-            }
+            ulong mask = 0UL - ((y0 >> (63 - i)) & 1);
+            z0 ^= x0 & mask;
+            z1 ^= x1 & mask;
 
             // Reduce x by the polynomial if needed, then shift right
-            bool lsb = (x1 & 1) == 1;
+            ulong lsbMask = 0UL - (x1 & 1);
             x1 = (x1 >> 1) | (x0 << 63);
-            x0 >>= 1;
-            if (lsb)
-            {
-                x0 ^= R;
-            }
+            x0 = (x0 >> 1) ^ (R & lsbMask);
         }
 
         for (int i = 0; i < 64; i++)
         {
-            if (((y1 >> (63 - i)) & 1) == 1)
-            {
-                z0 ^= x0;
-                z1 ^= x1;
-            }
+            ulong mask = 0UL - ((y1 >> (63 - i)) & 1);
+            z0 ^= x0 & mask;
+            z1 ^= x1 & mask;
 
-            bool lsb = (x1 & 1) == 1;
+            ulong lsbMask = 0UL - (x1 & 1);
             x1 = (x1 >> 1) | (x0 << 63);
-            x0 >>= 1;
-            if (lsb)
-            {
-                x0 ^= R;
-            }
+            x0 = (x0 >> 1) ^ (R & lsbMask);
         }
 
         BinaryPrimitives.WriteUInt64BigEndian(result.Slice(0), z0);
@@ -708,7 +702,10 @@ internal struct GcmCore
     /// </summary>
     /// <remarks>
     /// This avoids repeated byte-to-ulong conversions when H is already stored as ulongs.
-    /// The algorithm is identical to <see cref="GfMul"/>.
+    /// The algorithm is identical to <see cref="GfMul"/>. Branch-free by construction: every
+    /// conditional XOR is done via an all-ones/all-zeros mask rather than an <c>if</c>, so
+    /// execution time does not depend on the secret bits of H. This is the scalar fallback
+    /// used when no CLMUL/PMULL hardware acceleration is available.
     /// </remarks>
     /// <param name="h0">High 64 bits of H.</param>
     /// <param name="h1">Low 64 bits of H.</param>
@@ -722,30 +719,24 @@ internal struct GcmCore
 
         for (int i = 0; i < 64; i++)
         {
-            if (((h0 >> (63 - i)) & 1) == 1)
-            {
-                z0 ^= x0;
-                z1 ^= x1;
-            }
+            ulong mask = 0UL - ((h0 >> (63 - i)) & 1);
+            z0 ^= x0 & mask;
+            z1 ^= x1 & mask;
 
-            bool lsb = (x1 & 1) == 1;
+            ulong lsbMask = 0UL - (x1 & 1);
             x1 = (x1 >> 1) | (x0 << 63);
-            x0 >>= 1;
-            if (lsb) x0 ^= R;
+            x0 = (x0 >> 1) ^ (R & lsbMask);
         }
 
         for (int i = 0; i < 64; i++)
         {
-            if (((h1 >> (63 - i)) & 1) == 1)
-            {
-                z0 ^= x0;
-                z1 ^= x1;
-            }
+            ulong mask = 0UL - ((h1 >> (63 - i)) & 1);
+            z0 ^= x0 & mask;
+            z1 ^= x1 & mask;
 
-            bool lsb = (x1 & 1) == 1;
+            ulong lsbMask = 0UL - (x1 & 1);
             x1 = (x1 >> 1) | (x0 << 63);
-            x0 >>= 1;
-            if (lsb) x0 ^= R;
+            x0 = (x0 >> 1) ^ (R & lsbMask);
         }
 
         y0 = z0;
@@ -768,6 +759,18 @@ internal struct GcmCore
     ///   <item><description>Apply reduction from <see cref="ReductionTable"/></description></item>
     ///   <item><description>XOR with <c>M[nibble]</c> from the Shoup table</description></item>
     /// </list>
+    /// </para>
+    /// <para>
+    /// <b>Timing side channel:</b> unlike <see cref="GfMulUlong"/>, this method is <i>not</i>
+    /// constant-time. <c>table</c> is precomputed from the secret hash subkey H, and both the
+    /// <c>table[2 * nibble]</c> lookups and the <see cref="ReductionTable"/> lookups are indexed
+    /// by data derived from the running GHASH accumulator, which is itself entangled with H after
+    /// the first block. On CPUs without dedicated carry-less multiplication (PCLMULQDQ / PMULL),
+    /// this creates a cache-timing channel comparable to classic AES T-table attacks, and could in
+    /// principle let a co-resident attacker recover information about H (enabling GCM tag forgery
+    /// for that key) given enough timing samples. Prefer running on hardware with CLMUL/PMULL
+    /// support (see <see cref="SimdSupport"/>) wherever GCM operations are exposed to a
+    /// potentially adversarial, shared execution environment (e.g. multi-tenant cloud hosts).
     /// </para>
     /// </remarks>
     /// <param name="table">The precomputed Shoup table (32 ulongs = 16 pairs).</param>

--- a/src/Security/Cryptography/Cipher/SymmetricCipher.cs
+++ b/src/Security/Cryptography/Cipher/SymmetricCipher.cs
@@ -35,6 +35,21 @@ using OS = System.Security.Cryptography;
 /// byte[] ciphertext = encryptor.TransformFinalBlock(plaintext, 0, plaintext.Length);
 /// </code>
 /// </para>
+/// <para>
+/// <b>Security warning - CBC + PKCS#7 is padding-oracle-prone:</b> the default
+/// <see cref="Mode"/>/<see cref="Padding"/> combination (<see cref="CipherMode.CBC"/> with
+/// <see cref="PaddingMode.PKCS7"/>) provides no authentication. Decrypting attacker-controlled
+/// ciphertext and revealing - through any observable channel, including response timing, error
+/// type, or response size - whether the padding was valid lets an attacker decrypt the
+/// ciphertext byte-by-byte (Vaudenay's padding-oracle attack; exploited in practice by
+/// POODLE and Lucky 13). The PKCS#7 check in this library is constant-time with respect to
+/// <i>where</i> the padding is invalid, but that alone does not make an application built on
+/// top of it padding-oracle-safe: a caller that returns a distinguishable error/status for
+/// padding failures reintroduces the oracle at the application layer. For new code, prefer an
+/// AEAD cipher (<see cref="AesGcm"/>, <see cref="ChaCha20Poly1305"/>) which authenticates the
+/// ciphertext before any padding or plaintext is exposed, or pair CBC with a MAC verified
+/// before decryption (encrypt-then-MAC).
+/// </para>
 /// </remarks>
 public abstract class SymmetricCipher : OS.SymmetricAlgorithm
 {

--- a/src/Security/Cryptography/Hash/Blake/Blake2b.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2b.cs
@@ -51,6 +51,7 @@ public sealed class Blake2b : HashAlgorithm
     // Blake2b core state
     private Blake2bState _core;
     private readonly byte[]? _key;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Blake2b"/> class with default output size (64 bytes).
@@ -211,20 +212,26 @@ public sealed class Blake2b : HashAlgorithm
 #endif
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake2b));
         _core.Reset(_key);
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake2b));
         _core.Append(source);
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake2b));
         return _core.TryGetCurrentHash(destination, out bytesWritten);
     }
 
@@ -235,6 +242,7 @@ public sealed class Blake2b : HashAlgorithm
         {
             _core.Dispose();
             ClearBuffer(_key);
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Blake/Blake2s.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake2s.cs
@@ -51,6 +51,7 @@ public sealed class Blake2s : HashAlgorithm
     // Blake2s core state
     private Blake2sState _core;
     private readonly byte[]? _key;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Blake2s"/> class with default output size (32 bytes).
@@ -211,20 +212,26 @@ public sealed class Blake2s : HashAlgorithm
 #endif
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake2s));
         _core.Reset(_key);
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake2s));
         _core.Append(source);
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake2s));
         return _core.TryGetCurrentHash(destination, out bytesWritten);
     }
 
@@ -235,6 +242,7 @@ public sealed class Blake2s : HashAlgorithm
         {
             _core.Dispose();
             ClearBuffer(_key);
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Blake/Blake3.cs
+++ b/src/Security/Cryptography/Hash/Blake/Blake3.cs
@@ -74,6 +74,7 @@ public sealed class Blake3 : HashAlgorithm, IExtendableOutput
     // Blake3 core state
     private Blake3State _core;
     private readonly Blake3Mode _mode;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Blake3"/> class with default output size (32 bytes).
@@ -241,8 +242,10 @@ public sealed class Blake3 : HashAlgorithm, IExtendableOutput
 #endif
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake3));
         _core.Reset(_mode == Blake3Mode.KeyedHash);
     }
 
@@ -263,20 +266,26 @@ public sealed class Blake3 : HashAlgorithm, IExtendableOutput
     /// Finalizes the hash and squeezes output of the specified length.
     /// </summary>
     /// <param name="output">The buffer to receive the output.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Squeeze(Span<byte> output)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake3));
         _core.Squeeze(output);
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake3));
         _core.Append(source);
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Blake3));
         return _core.TryGetCurrentHash(destination, out bytesWritten);
     }
 
@@ -286,6 +295,7 @@ public sealed class Blake3 : HashAlgorithm, IExtendableOutput
         if (disposing)
         {
             _core.Dispose();
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Keccak/CShake128.cs
+++ b/src/Security/Cryptography/Hash/Keccak/CShake128.cs
@@ -172,8 +172,10 @@ public sealed class CShake128 : KeccakCore, IExtendableOutput
     /// Squeezes output bytes from the XOF state.
     /// </summary>
     /// <param name="output">The buffer to receive the output.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Squeeze(Span<byte> output)
     {
+        if (_disposed) throw new ObjectDisposedException(GetType().Name);
         if (!_finalized)
         {
             _buffer[RateBytes - 1] = 0x00;

--- a/src/Security/Cryptography/Hash/Keccak/CShake256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/CShake256.cs
@@ -169,8 +169,10 @@ public sealed class CShake256 : KeccakCore, IExtendableOutput
     /// Squeezes output bytes from the XOF state.
     /// </summary>
     /// <param name="output">The buffer to receive the output.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Squeeze(Span<byte> output)
     {
+        if (_disposed) throw new ObjectDisposedException(GetType().Name);
         if (!_finalized)
         {
             _buffer[RateBytes - 1] = 0x00;

--- a/src/Security/Cryptography/Hash/Keccak/KT128.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KT128.cs
@@ -66,6 +66,7 @@ public sealed class KT128 : HashAlgorithm, IExtendableOutput
     private byte[] _buffer;
     private int _bufferLength;
     private bool _finalized;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KT128"/> class with default output size.
@@ -195,8 +196,11 @@ public sealed class KT128 : HashAlgorithm, IExtendableOutput
         => HashAlgorithmPool<KT128>.HashData(source);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(KT128));
+
         _bufferLength = 0;
         _finalized = false;
     }
@@ -214,8 +218,10 @@ public sealed class KT128 : HashAlgorithm, IExtendableOutput
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(KT128));
         if (_finalized)
         {
             throw new InvalidOperationException("Cannot add data after finalization.");
@@ -244,8 +250,10 @@ public sealed class KT128 : HashAlgorithm, IExtendableOutput
     /// Squeezes output bytes from the KT128 state.
     /// </summary>
     /// <param name="output">The buffer to receive the output.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Squeeze(Span<byte> output)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(KT128));
         if (!_finalized)
         {
             FinalizeInternal(output);
@@ -422,6 +430,8 @@ public sealed class KT128 : HashAlgorithm, IExtendableOutput
                 ArrayPool<byte>.Shared.Return(_buffer, clearArray: true);
                 _buffer = null!;
             }
+
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Keccak/KT256.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KT256.cs
@@ -66,6 +66,7 @@ public sealed class KT256 : HashAlgorithm, IExtendableOutput
     private byte[] _buffer;
     private int _bufferLength;
     private bool _finalized;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KT256"/> class with default output size.
@@ -195,8 +196,11 @@ public sealed class KT256 : HashAlgorithm, IExtendableOutput
         => HashAlgorithmPool<KT256>.HashData(source);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(KT256));
+
         _bufferLength = 0;
         _finalized = false;
     }
@@ -214,8 +218,10 @@ public sealed class KT256 : HashAlgorithm, IExtendableOutput
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(KT256));
         if (_finalized)
         {
             throw new InvalidOperationException("Cannot add data after finalization.");
@@ -244,8 +250,10 @@ public sealed class KT256 : HashAlgorithm, IExtendableOutput
     /// Squeezes output bytes from the KT256 state.
     /// </summary>
     /// <param name="output">The buffer to receive the output.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Squeeze(Span<byte> output)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(KT256));
         if (!_finalized)
         {
             FinalizeInternal(output);
@@ -417,6 +425,8 @@ public sealed class KT256 : HashAlgorithm, IExtendableOutput
                 ArrayPool<byte>.Shared.Return(_buffer, clearArray: true);
                 _buffer = null!;
             }
+
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Keccak/KeccakCore.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakCore.cs
@@ -27,6 +27,7 @@ public abstract class KeccakCore : HashAlgorithm
     private protected readonly byte[] _buffer;
     private protected readonly int _rateBytes;
     private protected int _bufferLength;
+    private protected bool _disposed;
 
     internal KeccakCore(int rateBytes, SimdSupport simdSupport = SimdSupport.KeccakDefault)
         : this(rateBytes, 0, simdSupport)
@@ -41,8 +42,11 @@ public abstract class KeccakCore : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(GetType().Name);
+
         _keccakCore.Reset();
         ClearBuffer(_buffer);
         _bufferLength = 0;
@@ -54,8 +58,11 @@ public abstract class KeccakCore : HashAlgorithm
     internal static new SimdSupport SimdSupport => KeccakCoreState.SimdSupport;
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(GetType().Name);
+
         int offset = 0;
 
         // If we have data in buffer, fill it first
@@ -95,6 +102,7 @@ public abstract class KeccakCore : HashAlgorithm
         {
             _keccakCore.Reset();
             ClearBuffer(_buffer);
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Keccak/KeccakHashCore.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakHashCore.cs
@@ -33,8 +33,10 @@ public abstract class KeccakHashCore : KeccakCore
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(GetType().Name);
         if (destination.Length < _outputBytes)
         {
             bytesWritten = 0;

--- a/src/Security/Cryptography/Hash/Keccak/KeccakXofCore.cs
+++ b/src/Security/Cryptography/Hash/Keccak/KeccakXofCore.cs
@@ -87,8 +87,11 @@ public abstract class KeccakXofCore : KeccakCore, IExtendableOutput
     /// Squeezes output bytes from the XOF state.
     /// </summary>
     /// <param name="output">The buffer to receive the output.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Squeeze(Span<byte> output)
     {
+        if (_disposed) throw new ObjectDisposedException(GetType().Name);
+
         // Finalize if not already done
         if (!_finalized)
         {

--- a/src/Security/Cryptography/Hash/Legacy/MD5.cs
+++ b/src/Security/Cryptography/Hash/Legacy/MD5.cs
@@ -84,6 +84,7 @@ public sealed class MD5 : HashAlgorithm
     private readonly byte[] _buffer;
     private int _bufferLength;
     private ulong _totalLength;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MD5"/> class.
@@ -154,8 +155,10 @@ public sealed class MD5 : HashAlgorithm
 #pragma warning restore CS0618
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(MD5));
         _a = A0;
         _b = B0;
         _c = C0;
@@ -166,8 +169,10 @@ public sealed class MD5 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(MD5));
         _totalLength += (ulong)source.Length;
         int offset = 0;
 
@@ -237,6 +242,7 @@ public sealed class MD5 : HashAlgorithm
         {
             ClearBuffer(_buffer);
             _a = _b = _c = _d = 0;
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Legacy/SHA1.cs
+++ b/src/Security/Cryptography/Hash/Legacy/SHA1.cs
@@ -46,6 +46,7 @@ public sealed class SHA1 : HashAlgorithm
     private readonly uint[] _w;
     private long _bytesProcessed;
     private int _bufferLength;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SHA1"/> class.
@@ -96,8 +97,11 @@ public sealed class SHA1 : HashAlgorithm
 #pragma warning restore CS0618
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(SHA1));
+
         // SHA-1 initialization constants
         _state[0] = 0x67452301;
         _state[1] = 0xefcdab89;
@@ -111,8 +115,11 @@ public sealed class SHA1 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(SHA1));
+
         int offset = 0;
 
         if (_bufferLength > 0)
@@ -145,8 +152,10 @@ public sealed class SHA1 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(SHA1));
         if (destination.Length < HashSizeBytes)
         {
             bytesWritten = 0;
@@ -173,6 +182,7 @@ public sealed class SHA1 : HashAlgorithm
             ClearBuffer(_buffer);
             Array.Clear(_state, 0, _state.Length);
             Array.Clear(_w, 0, _w.Length);
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Regional/Kupyna.cs
+++ b/src/Security/Cryptography/Hash/Regional/Kupyna.cs
@@ -196,6 +196,7 @@ public sealed class Kupyna : HashAlgorithm
     private readonly byte[] _buffer;
     private int _bufferLength;
     private ulong _inputBlocks;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Kupyna"/> class with 512-bit output.
@@ -348,8 +349,10 @@ public sealed class Kupyna : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Kupyna));
         Array.Clear(_state, 0, _state.Length);
         _state[0] = (ulong)_blockSize;
 
@@ -358,8 +361,10 @@ public sealed class Kupyna : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Kupyna));
         int offset = 0;
 
         if (_bufferLength > 0)
@@ -393,8 +398,10 @@ public sealed class Kupyna : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Kupyna));
         if (destination.Length < _hashSizeBytes)
         {
             bytesWritten = 0;
@@ -462,6 +469,7 @@ public sealed class Kupyna : HashAlgorithm
             Array.Clear(_tempState2, 0, _tempState2.Length);
             Array.Clear(_scratch, 0, _scratch.Length);
             ClearBuffer(_buffer);
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Regional/Lsh256.cs
+++ b/src/Security/Cryptography/Hash/Regional/Lsh256.cs
@@ -130,6 +130,7 @@ public sealed class Lsh256 : HashAlgorithm
     private readonly uint[] _submsgOR;
     private readonly byte[] _buffer;
     private int _bufferLength;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Lsh256"/> class with 256-bit output.
@@ -270,16 +271,20 @@ public sealed class Lsh256 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Lsh256));
         Array.Copy(_iv, 0, _cvL, 0, NumWords);
         Array.Copy(_iv, NumWords, _cvR, 0, NumWords);
         _bufferLength = 0;
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Lsh256));
         int offset = 0;
 
         if (_bufferLength > 0)
@@ -311,8 +316,10 @@ public sealed class Lsh256 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Lsh256));
         if (destination.Length < _hashSizeBytes)
         {
             bytesWritten = 0;
@@ -357,6 +364,7 @@ public sealed class Lsh256 : HashAlgorithm
             Array.Clear(_submsgOL, 0, _submsgOL.Length);
             Array.Clear(_submsgOR, 0, _submsgOR.Length);
             ClearBuffer(_buffer);
+            _disposed = true;
         }
 
         base.Dispose(disposing);

--- a/src/Security/Cryptography/Hash/Regional/Lsh512.cs
+++ b/src/Security/Cryptography/Hash/Regional/Lsh512.cs
@@ -153,6 +153,7 @@ public sealed class Lsh512 : HashAlgorithm
     private readonly ulong[] _submsgOR;
     private readonly byte[] _buffer;
     private int _bufferLength;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Lsh512"/> class with 512-bit output.
@@ -309,16 +310,20 @@ public sealed class Lsh512 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Lsh512));
         Array.Copy(_iv, 0, _cvL, 0, NumWords);
         Array.Copy(_iv, NumWords, _cvR, 0, NumWords);
         _bufferLength = 0;
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Lsh512));
         int offset = 0;
 
         if (_bufferLength > 0)
@@ -350,8 +355,10 @@ public sealed class Lsh512 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Lsh512));
         if (destination.Length < _hashSizeBytes)
         {
             bytesWritten = 0;
@@ -405,6 +412,7 @@ public sealed class Lsh512 : HashAlgorithm
             Array.Clear(_submsgOL, 0, _submsgOL.Length);
             Array.Clear(_submsgOR, 0, _submsgOR.Length);
             ClearBuffer(_buffer);
+            _disposed = true;
         }
 
         base.Dispose(disposing);

--- a/src/Security/Cryptography/Hash/Regional/SM3.cs
+++ b/src/Security/Cryptography/Hash/Regional/SM3.cs
@@ -58,6 +58,7 @@ public sealed class SM3 : HashAlgorithm
     private readonly byte[] _buffer;
     private int _bufferLength;
     private ulong _totalLength;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SM3"/> class.
@@ -118,8 +119,10 @@ public sealed class SM3 : HashAlgorithm
         => HashAlgorithmPool<SM3>.HashData(source);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(SM3));
         _v0 = IV0;
         _v1 = IV1;
         _v2 = IV2;
@@ -134,8 +137,10 @@ public sealed class SM3 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(SM3));
         _totalLength += (ulong)source.Length;
         int offset = 0;
 
@@ -208,6 +213,7 @@ public sealed class SM3 : HashAlgorithm
         {
             ClearBuffer(_buffer);
             _v0 = _v1 = _v2 = _v3 = _v4 = _v5 = _v6 = _v7 = 0;
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Regional/Streebog.cs
+++ b/src/Security/Cryptography/Hash/Regional/Streebog.cs
@@ -214,6 +214,7 @@ public sealed class Streebog : HashAlgorithm
     private readonly ulong[] _sigma;  // Checksum accumulator (512-bit as 8 ulongs)
     private readonly byte[] _buffer;  // Message block buffer
     private int _bufferLength;
+    private bool _disposed;
 
     /// <summary>
     /// Converts a hex string to a byte array.
@@ -357,8 +358,11 @@ public sealed class Streebog : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Streebog));
+
         // IV is 0x00 for 512-bit, 0x01 for 256-bit (RFC 6986 Section 6.1)
         ulong iv = _hashSizeBytes == 32 ? 0x0101010101010101UL : 0UL;
 
@@ -372,8 +376,10 @@ public sealed class Streebog : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Streebog));
         int offset = 0;
 
         // Fill buffer if partially full
@@ -427,9 +433,11 @@ public sealed class Streebog : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Streebog));
         if (destination.Length < _hashSizeBytes)
         {
             bytesWritten = 0;
@@ -748,6 +756,7 @@ public sealed class Streebog : HashAlgorithm
             Array.Clear(_n, 0, BlockSizeWords);
             Array.Clear(_sigma, 0, BlockSizeWords);
             ClearBuffer(_buffer);
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Regional/Whirlpool.cs
+++ b/src/Security/Cryptography/Hash/Regional/Whirlpool.cs
@@ -146,6 +146,7 @@ public sealed class Whirlpool : HashAlgorithm
     private readonly byte[] _buffer;
     private int _bufferLength;
     private ulong _totalBits;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Whirlpool"/> class.
@@ -207,8 +208,10 @@ public sealed class Whirlpool : HashAlgorithm
         => HashAlgorithmPool<Whirlpool>.HashData(source);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Whirlpool));
         Array.Clear(_hash, 0, _hash.Length);
         ClearBuffer(_buffer);
         _bufferLength = 0;
@@ -216,8 +219,10 @@ public sealed class Whirlpool : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Whirlpool));
         unchecked
         {
             _totalBits += (ulong)source.Length * 8;
@@ -252,8 +257,10 @@ public sealed class Whirlpool : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Whirlpool));
         if (destination.Length < HashSizeBytes)
         {
             bytesWritten = 0;
@@ -308,6 +315,7 @@ public sealed class Whirlpool : HashAlgorithm
         {
             Array.Clear(_hash, 0, _hash.Length);
             ClearBuffer(_buffer);
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Ripemd/Ripemd160.cs
+++ b/src/Security/Cryptography/Hash/Ripemd/Ripemd160.cs
@@ -95,6 +95,7 @@ public sealed class Ripemd160 : HashAlgorithm
     private readonly byte[] _buffer;
     private int _bufferLength;
     private ulong _totalLength;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Ripemd160"/> class.
@@ -155,8 +156,10 @@ public sealed class Ripemd160 : HashAlgorithm
         => HashAlgorithmPool<Ripemd160>.HashData(source);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public override void Initialize()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Ripemd160));
         _h0 = H0;
         _h1 = H1;
         _h2 = H2;
@@ -168,8 +171,10 @@ public sealed class Ripemd160 : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Ripemd160));
         _totalLength += (ulong)source.Length;
         int offset = 0;
 
@@ -239,6 +244,7 @@ public sealed class Ripemd160 : HashAlgorithm
         {
             ClearBuffer(_buffer);
             _h0 = _h1 = _h2 = _h3 = _h4 = 0;
+            _disposed = true;
         }
         base.Dispose(disposing);
     }

--- a/src/Security/Cryptography/Hash/Sha2/Sha2HashAlgorithm{T}.cs
+++ b/src/Security/Cryptography/Hash/Sha2/Sha2HashAlgorithm{T}.cs
@@ -55,8 +55,11 @@ public abstract class Sha2HashAlgorithm<T> : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public sealed override void Initialize()
     {
+        if (!_allocated) throw new ObjectDisposedException(GetType().Name);
+
         InitializeState();
         _bytesProcessed = 0;
         _bufferLength = 0;
@@ -92,8 +95,11 @@ public abstract class Sha2HashAlgorithm<T> : HashAlgorithm
     protected abstract void OutputHash(Span<byte> destination, T[] state);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected sealed override void HashCore(ReadOnlySpan<byte> source)
     {
+        if (!_allocated) throw new ObjectDisposedException(GetType().Name);
+
         int offset = 0;
 
         // If we have leftover data in the buffer, fill it first
@@ -129,8 +135,10 @@ public abstract class Sha2HashAlgorithm<T> : HashAlgorithm
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     protected sealed override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
     {
+        if (!_allocated) throw new ObjectDisposedException(GetType().Name);
         if (destination.Length < OutputSizeBytes)
         {
             bytesWritten = 0;

--- a/src/Security/Cryptography/Kdf/Pbkdf2.cs
+++ b/src/Security/Cryptography/Kdf/Pbkdf2.cs
@@ -79,7 +79,8 @@ public static class Pbkdf2
         if (output.IsEmpty) throw new ArgumentException("Output buffer must not be empty.", nameof(output));
         if (iterations < 1) throw new ArgumentOutOfRangeException(nameof(iterations), "Iteration count must be at least 1.");
 
-        using var prf = hmacFactory(password.ToArray());
+        byte[] passwordCopy = password.ToArray();
+        using var prf = hmacFactory(passwordCopy);
         int hLen = prf.MacSize;
 
         // RFC 8018 §5.2: DK = T_1 ‖ T_2 ‖ ... ‖ T_dkLen/hLen
@@ -127,6 +128,7 @@ public static class Pbkdf2
         {
             Array.Clear(u, 0, u.Length);
             Array.Clear(t, 0, t.Length);
+            Array.Clear(passwordCopy, 0, passwordCopy.Length);
         }
     }
 

--- a/src/Security/Cryptography/Mac/Cmac/AesCmac.cs
+++ b/src/Security/Cryptography/Mac/Cmac/AesCmac.cs
@@ -129,8 +129,10 @@ public sealed class AesCmac : IMac
     public static AesCmac Create(ReadOnlySpan<byte> key) => new(key);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Update(ReadOnlySpan<byte> input)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(AesCmac));
         if (_finalized) throw new InvalidOperationException("Cannot update after finalization. Call Reset() first.");
 
         int offset = 0;
@@ -175,8 +177,10 @@ public sealed class AesCmac : IMac
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Finalize(Span<byte> destination)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(AesCmac));
         if (destination.Length < BlockSize) throw new ArgumentException("Destination buffer is too small.", nameof(destination));
         if (_finalized) throw new InvalidOperationException("Already finalized. Call Reset() first.");
 

--- a/src/Security/Cryptography/Mac/Gmac/AesGmac.cs
+++ b/src/Security/Cryptography/Mac/Gmac/AesGmac.cs
@@ -111,8 +111,11 @@ public sealed class AesGmac : IDisposable
     /// <exception cref="ArgumentException">
     /// <paramref name="nonce"/> is not 12 bytes, or <paramref name="tag"/> is too small.
     /// </exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void ComputeTag(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> associatedData, Span<byte> tag)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(AesGmac));
         if (tag.Length < TagSizeBytes)
             throw new ArgumentException($"Tag buffer must be at least {TagSizeBytes} bytes.", nameof(tag));
 

--- a/src/Security/Cryptography/Mac/Hmac/HmacCore.cs
+++ b/src/Security/Cryptography/Mac/Hmac/HmacCore.cs
@@ -74,9 +74,9 @@ public class HmacCore : IMac
         if (_disposed) throw new ObjectDisposedException(nameof(HmacCore));
         if (_finalized) throw new InvalidOperationException("Cannot update after finalization. Call Reset() first.");
 
-        // Feed through the inner hash via TransformBlock
-        byte[] temp = input.ToArray();
-        _innerHash.TransformBlock(temp, 0, temp.Length, null, 0);
+        // Zero-allocation append; avoids copying (potentially secret) input to the heap
+        // and avoids reallocating per call.
+        _innerHash.AppendData(input);
     }
 
     /// <inheritdoc/>
@@ -88,15 +88,16 @@ public class HmacCore : IMac
         if (_finalized) throw new InvalidOperationException("Already finalized. Call Reset() first.");
 
         // Complete inner hash: H((K' ⊕ ipad) ‖ m)
-        _innerHash.TransformFinalBlock([], 0, 0);
-        byte[] innerResult = _innerHash.Hash!;
+        Span<byte> innerResult = stackalloc byte[_macSize];
+        _innerHash.TryGetHashAndReset(innerResult, out _);
 
         // Complete outer hash: H((K' ⊕ opad) ‖ innerResult)
         // The opad key block was already fed in InitializeInner()
-        _outerHash.TransformFinalBlock(innerResult, 0, innerResult.Length);
-        byte[] outerResult = _outerHash.Hash!;
+        _outerHash.AppendData(innerResult);
+        Span<byte> outerResult = stackalloc byte[_macSize];
+        _outerHash.TryGetHashAndReset(outerResult, out _);
 
-        outerResult.AsSpan(0, _macSize).CopyTo(destination);
+        outerResult.CopyTo(destination);
         _finalized = true;
     }
 
@@ -162,10 +163,12 @@ public class HmacCore : IMac
 
         if (key.Length > blockSize)
         {
-            // Key longer than block size: hash it first
-            byte[] hashedKey = _innerHash.ComputeHash(key.ToArray());
-            _innerHash.Initialize();
-            hashedKey.AsSpan().CopyTo(keyBlock);
+            // Key longer than block size: hash it first. Zero-allocation and self-clearing
+            // since hashedKey is stack-allocated rather than a heap array left uncleared.
+            _innerHash.AppendData(key);
+            Span<byte> hashedKey = stackalloc byte[_macSize];
+            _innerHash.TryGetHashAndReset(hashedKey, out _);
+            hashedKey.CopyTo(keyBlock);
         }
         else
         {
@@ -185,10 +188,10 @@ public class HmacCore : IMac
     {
         // Start inner hash with ipad key block
         _innerHash.Initialize();
-        _innerHash.TransformBlock(_ipadKey, 0, _ipadKey.Length, null, 0);
+        _innerHash.AppendData(_ipadKey);
 
         // Pre-feed outer hash with opad key block
         _outerHash.Initialize();
-        _outerHash.TransformBlock(_opadKey, 0, _opadKey.Length, null, 0);
+        _outerHash.AppendData(_opadKey);
     }
 }

--- a/src/Security/Cryptography/Mac/Hmac/HmacCore.cs
+++ b/src/Security/Cryptography/Mac/Hmac/HmacCore.cs
@@ -68,8 +68,10 @@ public class HmacCore : IMac
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Update(ReadOnlySpan<byte> input)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(HmacCore));
         if (_finalized) throw new InvalidOperationException("Cannot update after finalization. Call Reset() first.");
 
         // Feed through the inner hash via TransformBlock
@@ -78,8 +80,10 @@ public class HmacCore : IMac
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Finalize(Span<byte> destination)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(HmacCore));
         if (destination.Length < _macSize) throw new ArgumentException("Destination buffer is too small.", nameof(destination));
         if (_finalized) throw new InvalidOperationException("Already finalized. Call Reset() first.");
 

--- a/src/Security/Cryptography/Mac/Kmac/KeccakKMacCore.cs
+++ b/src/Security/Cryptography/Mac/Kmac/KeccakKMacCore.cs
@@ -134,8 +134,10 @@ public abstract class KeccakKMacCore : KeccakCore, IExtendableOutput
     /// Finalizes the MAC computation and squeezes output bytes.
     /// </summary>
     /// <param name="output">The buffer to receive the output.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Squeeze(Span<byte> output)
     {
+        if (_disposed) throw new ObjectDisposedException(GetType().Name);
         if (!_finalized)
         {
             Span<byte> rightEncodedL = stackalloc byte[CShake128.EncodeBufferLength];

--- a/src/Security/Cryptography/Mac/Poly1305/Poly1305Mac.cs
+++ b/src/Security/Cryptography/Mac/Poly1305/Poly1305Mac.cs
@@ -122,8 +122,10 @@ public sealed class Poly1305Mac : IMac
     public static Poly1305Mac Create(ReadOnlySpan<byte> key) => new(key);
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Update(ReadOnlySpan<byte> input)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Poly1305Mac));
         if (_finalized) throw new InvalidOperationException("Cannot update after finalization. Call Reset() first.");
 
         int offset = 0;
@@ -162,8 +164,10 @@ public sealed class Poly1305Mac : IMac
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Finalize(Span<byte> destination)
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(Poly1305Mac));
         if (destination.Length < TagSizeBytes) throw new ArgumentException("Destination buffer is too small.", nameof(destination));
         if (_finalized) throw new InvalidOperationException("Already finalized. Call Reset() first.");
 

--- a/src/Security/Cryptography/README.md
+++ b/src/Security/Cryptography/README.md
@@ -50,8 +50,8 @@ dotnet add package CryptoHives.Foundation.Security.Cryptography
 | BLAKE | BLAKE2b, BLAKE2s (SIMD-accelerated), BLAKE3 |
 | Ascon | Ascon-Hash256, Ascon-XOF128 (NIST SP 800-232 lightweight) |
 | Regional hash | SM3, Streebog, Kupyna, LSH, Whirlpool, RIPEMD-160 |
-| Legacy | SHA-1, MD5 (backward compatibility only) |
-| MAC | HMAC-SHA-256/384/512, HMAC-SHA3-256, AES-CMAC, AES-GMAC, Poly1305, KMAC128/256, BLAKE2/3 keyed |
+| Legacy | SHA-1, MD5, HMAC-SHA-1, HMAC-MD5 (backward compatibility only) |
+| MAC | HMAC-SHA-256/384/512, HMAC-SHA3-256/384/512, AES-CMAC, AES-GMAC, Poly1305, KMAC128/256, BLAKE2/3 keyed |
 | Cipher (AEAD) | AES-GCM (128/192/256), AES-CCM (128/192/256), ChaCha20-Poly1305, XChaCha20-Poly1305, Ascon-AEAD128 |
 | Cipher (block/stream) | AES-128/192/256 (ECB/CBC/CTR), ChaCha20 |
 | Cipher (regional) | SM4, ARIA, Camellia, Kuznyechik, Kalyna, SEED |
@@ -108,9 +108,13 @@ Span<byte> ciphertext = new byte[plaintext.Length];
 Span<byte> tag        = stackalloc byte[16];
 aesGcm.Encrypt(nonce, plaintext, ciphertext, tag, associatedData);
 
-// Decrypt — throws if tag verification fails
+// Decrypt — returns false (and clears `recovered`) if tag verification fails;
+// it does not throw. Always check the result before trusting the output.
 Span<byte> recovered = new byte[ciphertext.Length];
-aesGcm.Decrypt(nonce, ciphertext, tag, recovered, associatedData);
+if (!aesGcm.Decrypt(nonce, ciphertext, tag, recovered, associatedData))
+{
+    throw new CryptographicException("Authentication failed.");
+}
 ```
 
 ### cSHAKE — Domain-Separated XOF

--- a/src/Security/Cryptography/Rng/RandomNumberGenerator.cs
+++ b/src/Security/Cryptography/Rng/RandomNumberGenerator.cs
@@ -78,7 +78,7 @@ public class RandomNumberGenerator : IDisposable
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(temp);
+            ArrayPool<byte>.Shared.Return(temp, clearArray: true);
         }
 #endif
     }

--- a/tests/Security/Cryptography/Cipher/Aes/AesTests.cs
+++ b/tests/Security/Cryptography/Cipher/Aes/AesTests.cs
@@ -302,6 +302,48 @@ public class AesTests
         Assert.That(decrypted, Is.EqualTo(plaintext));
     }
 
+    /// <summary>
+    /// PKCS#7 padding must be rejected regardless of which byte in the pad is corrupted,
+    /// covering the constant-time rewrite of <c>IsPkcs7PaddingValid</c> - a naive
+    /// early-exit implementation would still throw in every case here, but with a timing
+    /// signature that differs by corruption position (the classical padding-oracle side
+    /// channel this rewrite closes).
+    /// </summary>
+    /// <remarks>
+    /// Uses a full 16-byte plaintext block so PKCS#7 adds a full padding block (all bytes
+    /// = 0x10). In CBC, P_2[i] = D(C_2)[i] XOR C_1[i], so flipping a single byte of the
+    /// first ciphertext block corrupts exactly the corresponding byte of the decrypted
+    /// padding block, leaving the rest - including the pad-length byte at index 15 for
+    /// non-final positions - untouched. This is the same ciphertext malleability real
+    /// padding-oracle attacks exploit.
+    /// </remarks>
+    [Test]
+    [TestCase(0, Description = "First byte of the pad block corrupted")]
+    [TestCase(7, Description = "Middle byte of the pad block corrupted")]
+    [TestCase(14, Description = "Second-to-last byte of the pad block corrupted")]
+    [TestCase(15, Description = "Pad-length byte itself corrupted")]
+    public void Aes_Decrypt_CorruptedPadding_AnyPosition_Throws(int corruptIndexInPadBlock)
+    {
+        byte[] plaintext = new byte[16]; // exactly one block -> PKCS7 adds a full padding block
+        byte[] key = new byte[16];
+        byte[] iv = new byte[16];
+
+        using var aes = CreateAes(16);
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.PKCS7;
+        aes.Key = key;
+        aes.IV = iv;
+
+        byte[] ciphertext = aes.Encrypt(plaintext);
+        Assert.That(ciphertext, Has.Length.EqualTo(32), "Expected two ciphertext blocks (data + full pad block).");
+
+        // Flip a bit in C_1 to corrupt exactly one byte of the decrypted padding block.
+        ciphertext[corruptIndexInPadBlock] ^= 0xFF;
+
+        aes.IV = iv;
+        Assert.Throws<System.Security.Cryptography.CryptographicException>(() => aes.Decrypt(ciphertext));
+    }
+
     // ========================================================================
     // Multi-block Tests
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/Aes/AesTests.cs
+++ b/tests/Security/Cryptography/Cipher/Aes/AesTests.cs
@@ -365,6 +365,30 @@ public class AesTests
     }
 
     // ========================================================================
+    // Dispose Tests
+    // ========================================================================
+
+    [Test]
+    public void AesCipherTransform_DisposedInstance_Throws()
+    {
+        using var aes = Aes128.Create();
+        aes.Mode = CipherMode.ECB;
+        aes.Padding = PaddingMode.None;
+        aes.Key = new byte[16];
+        aes.IV = new byte[16];
+
+        var encryptor = aes.CreateEncryptor();
+        byte[] block = new byte[16];
+        byte[] output = new byte[16];
+        encryptor.TransformBlock(block, output);
+
+        encryptor.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => encryptor.TransformBlock(block, output));
+        Assert.Throws<ObjectDisposedException>(() => encryptor.TransformFinalBlock(block, output));
+    }
+
+    // ========================================================================
     // Helper Methods
     // ========================================================================
 

--- a/tests/Security/Cryptography/Cipher/Ccm/AesCcmTests.cs
+++ b/tests/Security/Cryptography/Cipher/Ccm/AesCcmTests.cs
@@ -263,6 +263,25 @@ public class AesCcmTests
         Assert.Throws<ArgumentException>(() => ccm.Encrypt(shortNonce, plaintext, ciphertext, tag));
     }
 
+    [Test]
+    public void AesCcm_DisposedInstance_Throws()
+    {
+        byte[] key = new byte[16];
+        byte[] nonce = new byte[12];
+        byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("Test");
+
+        var ccm = AesCcm128.Create(key);
+        byte[] ciphertext = new byte[plaintext.Length];
+        byte[] tag = new byte[16];
+        ccm.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        ccm.Dispose();
+
+        byte[] decrypted = new byte[plaintext.Length];
+        Assert.Throws<ObjectDisposedException>(() => ccm.Encrypt(nonce, plaintext, ciphertext, tag));
+        Assert.Throws<ObjectDisposedException>(() => ccm.Decrypt(nonce, ciphertext, tag, decrypted));
+    }
+
     // ========================================================================
     // Helper Methods
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/ChaCha/ChaCha20Poly1305Tests.cs
+++ b/tests/Security/Cryptography/Cipher/ChaCha/ChaCha20Poly1305Tests.cs
@@ -350,6 +350,27 @@ public class ChaCha20Poly1305Tests
             Throws.InstanceOf<ArgumentException>().Or.InstanceOf<CryptographicException>());
     }
 
+    [Test]
+    public void ChaCha20Poly1305_DisposedInstance_Throws()
+    {
+        if (_implementation.Source != Source.Managed && _implementation.Source != Source.Simd)
+            Assert.Ignore("Dispose behavior is implementation-specific.");
+
+        byte[] key = new byte[32];
+        byte[] nonce = new byte[12];
+        byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("Test");
+
+        var aead = (IAeadCipher)_implementation.Create(key);
+        aead.Dispose();
+
+        byte[] ciphertext = new byte[plaintext.Length];
+        byte[] tag = new byte[16];
+        byte[] decrypted = new byte[plaintext.Length];
+
+        Assert.Throws<ObjectDisposedException>(() => aead.Encrypt(nonce, plaintext, ciphertext, tag));
+        Assert.Throws<ObjectDisposedException>(() => aead.Decrypt(nonce, ciphertext, tag, decrypted));
+    }
+
     // ========================================================================
     // Helper Methods
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/ChaCha/ChaCha20Tests.cs
+++ b/tests/Security/Cryptography/Cipher/ChaCha/ChaCha20Tests.cs
@@ -401,6 +401,27 @@ public class ChaCha20Tests
         Assert.That(chacha.IV!.Length, Is.EqualTo(12));
     }
 
+    [Test]
+    public void ChaCha20CipherTransform_DisposedInstance_Throws()
+    {
+        if (_implementation.Source != Source.Managed && _implementation.Source != Source.Simd)
+            Assert.Ignore("Dispose behavior is implementation-specific.");
+
+        using var chacha = (SymmetricCipher)_implementation.Create();
+        chacha.Key = new byte[32];
+        chacha.IV = new byte[12];
+
+        var encryptor = chacha.CreateEncryptor();
+        byte[] block = new byte[16];
+        byte[] output = new byte[16];
+        encryptor.TransformBlock(block, output);
+
+        encryptor.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => encryptor.TransformBlock(block, output));
+        Assert.Throws<ObjectDisposedException>(() => encryptor.TransformFinalBlock(block, output));
+    }
+
     // ========================================================================
     // Helper Methods
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/ChaCha/XChaCha20Poly1305Tests.cs
+++ b/tests/Security/Cryptography/Cipher/ChaCha/XChaCha20Poly1305Tests.cs
@@ -353,6 +353,25 @@ public class XChaCha20Poly1305Tests
         Assert.Throws<ArgumentException>(() => aead.Encrypt(shortNonce, plaintext));
     }
 
+    [Test]
+    public void XChaCha20Poly1305_DisposedInstance_Throws()
+    {
+        byte[] key = new byte[32];
+        byte[] nonce = new byte[24];
+        byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("Test");
+
+        var aead = XChaCha20Poly1305.Create(key);
+        byte[] ciphertext = new byte[plaintext.Length];
+        byte[] tag = new byte[16];
+        aead.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        aead.Dispose();
+
+        byte[] decrypted = new byte[plaintext.Length];
+        Assert.Throws<ObjectDisposedException>(() => aead.Encrypt(nonce, plaintext, ciphertext, tag));
+        Assert.Throws<ObjectDisposedException>(() => aead.Decrypt(nonce, ciphertext, tag, decrypted));
+    }
+
     // ========================================================================
     // Helper Methods
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/Gcm/AesGcmTests.cs
+++ b/tests/Security/Cryptography/Cipher/Gcm/AesGcmTests.cs
@@ -286,6 +286,25 @@ public class AesGcmTests
         Assert.That(oversizedTag[20], Is.EqualTo(0xAB), "Bytes beyond TagSizeBytes must be left untouched.");
     }
 
+    [Test]
+    public void AesGcm_DisposedInstance_Throws()
+    {
+        byte[] key = new byte[16];
+        byte[] nonce = new byte[12];
+        byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("Test");
+
+        var aesGcm = AesGcm128.Create(key);
+        byte[] ciphertext = new byte[plaintext.Length];
+        byte[] tag = new byte[16];
+        aesGcm.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        aesGcm.Dispose();
+
+        byte[] decrypted = new byte[plaintext.Length];
+        Assert.Throws<ObjectDisposedException>(() => aesGcm.Encrypt(nonce, plaintext, ciphertext, tag));
+        Assert.Throws<ObjectDisposedException>(() => aesGcm.Decrypt(nonce, ciphertext, tag, decrypted));
+    }
+
     // ========================================================================
     // AES-256-GCM Specific Tests
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/Gcm/AesGcmTests.cs
+++ b/tests/Security/Cryptography/Cipher/Gcm/AesGcmTests.cs
@@ -264,6 +264,28 @@ public class AesGcmTests
         Assert.Throws<CryptographicException>(() => aesGcm.Decrypt(wrongNonce, ciphertextWithTag));
     }
 
+    [Test]
+    public void AesGcm_Encrypt_TagBufferLargerThanTagSize_WritesTagWithoutThrowing()
+    {
+        byte[] key = new byte[16];
+        byte[] nonce = new byte[12];
+        byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("Secret message");
+
+        using var aesGcm = AesGcm128.Create(key);
+
+        byte[] ciphertext = new byte[plaintext.Length];
+        byte[] expectedTag = new byte[16];
+        aesGcm.Encrypt(nonce, plaintext, ciphertext, expectedTag);
+
+        // Oversized tag buffer: only the first TagSizeBytes must be written, the rest untouched.
+        byte[] oversizedTag = new byte[32];
+        oversizedTag[20] = 0xAB;
+
+        Assert.DoesNotThrow(() => aesGcm.Encrypt(nonce, plaintext, ciphertext, oversizedTag));
+        Assert.That(oversizedTag.AsSpan(0, 16).ToArray(), Is.EqualTo(expectedTag));
+        Assert.That(oversizedTag[20], Is.EqualTo(0xAB), "Bytes beyond TagSizeBytes must be left untouched.");
+    }
+
     // ========================================================================
     // AES-256-GCM Specific Tests
     // ========================================================================

--- a/tests/Security/Cryptography/Cipher/Gcm/AesGcmTests.cs
+++ b/tests/Security/Cryptography/Cipher/Gcm/AesGcmTests.cs
@@ -305,6 +305,37 @@ public class AesGcmTests
         Assert.Throws<ObjectDisposedException>(() => aesGcm.Decrypt(nonce, ciphertext, tag, decrypted));
     }
 
+    /// <summary>
+    /// Verifies that Dispose zeroes the round keys and GHASH subkey material inside
+    /// the internal GcmCore rather than just dropping the reference and leaving the
+    /// key-derived bytes to linger in memory until GC.
+    /// </summary>
+    [Test]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only reflection over a known concrete type.")]
+#endif
+    public void AesGcm_Dispose_ZeroesKeyMaterial()
+    {
+        byte[] key = System.Text.Encoding.UTF8.GetBytes("0123456789ABCDEF");
+        var aesGcm = AesGcm128.Create(key);
+
+        var gcmCoreField = typeof(CryptoHives.Foundation.Security.Cryptography.Cipher.AesGcm).GetField("_gcmCore",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        aesGcm.Dispose();
+
+        object gcmCore = gcmCoreField.GetValue(aesGcm)!;
+        Type gcmCoreType = gcmCore.GetType();
+
+        byte[] encRoundKeysBytes = ToByteArray(GetFieldValue<uint[]>(gcmCore, gcmCoreType, "_encRoundKeys"));
+        byte[] hashSubkey = GetFieldValue<byte[]>(gcmCore, gcmCoreType, "_h");
+        ulong[] shoupTable = GetFieldValue<ulong[]>(gcmCore, gcmCoreType, "_shoupTable");
+
+        Assert.That(encRoundKeysBytes, Is.All.EqualTo((byte)0), "Round keys were not zeroed on Dispose.");
+        Assert.That(hashSubkey, Is.All.EqualTo((byte)0), "GHASH subkey H was not zeroed on Dispose.");
+        Assert.That(shoupTable, Is.All.EqualTo(0UL), "Precomputed Shoup table was not zeroed on Dispose.");
+    }
+
     // ========================================================================
     // AES-256-GCM Specific Tests
     // ========================================================================
@@ -350,6 +381,22 @@ public class AesGcmTests
         {
             bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
         }
+        return bytes;
+    }
+
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only reflection over a known concrete type.")]
+#endif
+    private static T GetFieldValue<T>(object instance, Type type, string fieldName)
+    {
+        var field = type.GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (T)field.GetValue(instance)!;
+    }
+
+    private static byte[] ToByteArray(uint[] words)
+    {
+        byte[] bytes = new byte[words.Length * sizeof(uint)];
+        Buffer.BlockCopy(words, 0, bytes, 0, bytes.Length);
         return bytes;
     }
 }

--- a/tests/Security/Cryptography/Cipher/Sm4/Sm4Tests.cs
+++ b/tests/Security/Cryptography/Cipher/Sm4/Sm4Tests.cs
@@ -219,6 +219,30 @@ public class Sm4Tests
             () => sm4.Key = new byte[32]);
     }
 
+    /// <summary>
+    /// Verifies that a disposed transform throws instead of silently transforming
+    /// with cleared (zeroed) round-key state.
+    /// </summary>
+    [Test]
+    public void BlockCipherTransform_DisposedInstance_Throws()
+    {
+        using var sm4 = Sm4.Create();
+        sm4.Mode = CipherMode.ECB;
+        sm4.Padding = PaddingMode.None;
+        sm4.Key = FromHex("0123456789ABCDEFFEDCBA9876543210");
+        sm4.IV = new byte[16];
+
+        var encryptor = sm4.CreateEncryptor();
+        byte[] block = new byte[16];
+        byte[] output = new byte[16];
+        encryptor.TransformBlock(block, output);
+
+        encryptor.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => encryptor.TransformBlock(block, output));
+        Assert.Throws<ObjectDisposedException>(() => encryptor.TransformFinalBlock(block, output));
+    }
+
     private static byte[] FromHex(string hex)
     {
         byte[] bytes = new byte[hex.Length / 2];

--- a/tests/Security/Cryptography/Cipher/Sm4/Sm4Tests.cs
+++ b/tests/Security/Cryptography/Cipher/Sm4/Sm4Tests.cs
@@ -158,6 +158,44 @@ public class Sm4Tests
     }
 
     /// <summary>
+    /// PKCS#7 padding must be rejected regardless of which byte in the pad is corrupted -
+    /// covers the constant-time padding check in the shared <c>BlockCipherTransform</c> base
+    /// (used by SM4, ARIA, Camellia, Kalyna, Kuznyechik, SEED). Uses a full block of
+    /// plaintext so PKCS#7 adds a full padding block; flipping a byte of the first
+    /// ciphertext block corrupts exactly the corresponding byte of the decrypted padding
+    /// block via CBC's XOR chaining, without touching the rest - the same ciphertext
+    /// malleability real padding-oracle attacks exploit.
+    /// </summary>
+    [Test]
+    [TestCase(0, Description = "First byte of the pad block corrupted")]
+    [TestCase(8, Description = "Middle byte of the pad block corrupted")]
+    [TestCase(15, Description = "Pad-length byte itself corrupted")]
+    public void Sm4CbcCorruptedPadding_AnyPosition_Throws(int corruptIndexInPadBlock)
+    {
+        byte[] key = FromHex("0123456789ABCDEFFEDCBA9876543210");
+        byte[] iv = FromHex("00112233445566778899AABBCCDDEEFF");
+        byte[] plaintext = new byte[16]; // exactly one block -> PKCS7 adds a full padding block
+
+        using var enc = Sm4.Create();
+        enc.Mode = CipherMode.CBC;
+        enc.Padding = PaddingMode.PKCS7;
+        enc.Key = key;
+        enc.IV = iv;
+        byte[] ciphertext = enc.Encrypt(plaintext);
+        Assert.That(ciphertext, Has.Length.EqualTo(32), "Expected two ciphertext blocks (data + full pad block).");
+
+        ciphertext[corruptIndexInPadBlock] ^= 0xFF;
+
+        using var dec = Sm4.Create();
+        dec.Mode = CipherMode.CBC;
+        dec.Padding = PaddingMode.PKCS7;
+        dec.Key = key;
+        dec.IV = iv;
+
+        Assert.Throws<System.Security.Cryptography.CryptographicException>(() => dec.Decrypt(ciphertext));
+    }
+
+    /// <summary>
     /// Verifies CTR mode round-trip with non-block-aligned data.
     /// </summary>
     [Test]

--- a/tests/Security/Cryptography/Hash/HashAlgorithmFactoryTests.cs
+++ b/tests/Security/Cryptography/Hash/HashAlgorithmFactoryTests.cs
@@ -39,6 +39,21 @@ public class HashAlgorithmFactoryTests
 #pragma warning restore CS0618
 
     /// <summary>
+    /// Verifies that a disposed instance throws instead of silently hashing with cleared state.
+    /// </summary>
+    /// <param name="factory">The hash algorithm factory.</param>
+    [Test]
+    [TestCaseSource(typeof(CryptoHivesManagedImplementations), nameof(CryptoHivesManagedImplementations.All))]
+    public void DisposedInstanceThrows(HashAlgorithmFactory factory)
+    {
+        var hash = factory.Create();
+        hash.ComputeHash(TestData);
+        hash.Dispose();
+
+        Assert.Throws<System.ObjectDisposedException>(() => hash.ComputeHash(TestData));
+    }
+
+    /// <summary>
     /// Verifies that XOF algorithms support custom output length.
     /// </summary>
     [Test]

--- a/tests/Security/Cryptography/Mac/Cmac/CmacTests.cs
+++ b/tests/Security/Cryptography/Mac/Cmac/CmacTests.cs
@@ -300,5 +300,21 @@ public class CmacTests
         Assert.That(hash1, Is.EqualTo(hash2));
     }
 
+    /// <summary>
+    /// A disposed instance throws instead of silently authenticating with cleared key material.
+    /// </summary>
+    [Test]
+    public void DisposedInstanceThrows()
+    {
+        byte[] key = new byte[16];
+        var cmac = AesCmac.Create(key);
+        cmac.ComputeHash(Encoding.UTF8.GetBytes("test"));
+
+        cmac.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => cmac.Update(Encoding.UTF8.GetBytes("test")));
+        Assert.Throws<ObjectDisposedException>(() => cmac.Finalize(new byte[16]));
+    }
+
     #endregion
 }

--- a/tests/Security/Cryptography/Mac/Gmac/GmacTests.cs
+++ b/tests/Security/Cryptography/Mac/Gmac/GmacTests.cs
@@ -242,5 +242,23 @@ public class GmacTests
         Assert.That(gmac.ComputeTag(nonce1, aad), Is.Not.EqualTo(gmac.ComputeTag(nonce2, aad)));
     }
 
+    /// <summary>
+    /// A disposed instance throws instead of silently authenticating with cleared key material.
+    /// </summary>
+    [Test]
+    public void DisposedInstanceThrows()
+    {
+        byte[] key = new byte[16];
+        byte[] nonce = new byte[12];
+        byte[] aad = Encoding.UTF8.GetBytes("test");
+
+        var gmac = AesGmac.Create(key);
+        gmac.ComputeTag(nonce, aad);
+
+        gmac.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => gmac.ComputeTag(nonce, aad));
+    }
+
     #endregion
 }

--- a/tests/Security/Cryptography/Mac/Hmac/HmacTests.cs
+++ b/tests/Security/Cryptography/Mac/Hmac/HmacTests.cs
@@ -601,6 +601,43 @@ public class HmacTests
         Assert.Throws<ObjectDisposedException>(() => hmac.Finalize(new byte[32]));
     }
 
+#if !NETFRAMEWORK
+    /// <summary>
+    /// Repeated <see cref="HmacCore.Update"/> calls must not allocate. Regression test for a bug
+    /// where every call copied the input span to a new heap array via ToArray() - both a hygiene
+    /// issue (secret intermediate values, e.g. PBKDF2's U_j, left uncleared on the heap) and a
+    /// performance issue (a fresh allocation per PBKDF2 iteration).
+    /// </summary>
+    [Test]
+    [NonParallelizable]
+    public void UpdateDoesNotAllocate()
+    {
+        byte[] key = new byte[32];
+        byte[] block = new byte[32];
+        using var hmac = HmacSha256.Create(key);
+
+        // Warm up: JIT, and let HmacSha256.Create's own allocations settle.
+        for (int i = 0; i < 5; i++)
+        {
+            hmac.Update(block);
+        }
+        hmac.Reset();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 1000; i++)
+        {
+            hmac.Update(block);
+        }
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.That(after - before, Is.Zero, "HmacCore.Update allocated heap memory.");
+    }
+#endif
+
     #endregion
 
     #region Helper Methods

--- a/tests/Security/Cryptography/Mac/Hmac/HmacTests.cs
+++ b/tests/Security/Cryptography/Mac/Hmac/HmacTests.cs
@@ -585,6 +585,22 @@ public class HmacTests
         Assert.That(sha3_512.MacSize, Is.EqualTo(64));
     }
 
+    /// <summary>
+    /// A disposed instance throws instead of silently authenticating with disposed inner hashes.
+    /// </summary>
+    [Test]
+    public void DisposedInstanceThrows()
+    {
+        byte[] key = new byte[32];
+        var hmac = HmacSha256.Create(key);
+        hmac.ComputeHash(Encoding.UTF8.GetBytes("test"));
+
+        hmac.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => hmac.Update(Encoding.UTF8.GetBytes("test")));
+        Assert.Throws<ObjectDisposedException>(() => hmac.Finalize(new byte[32]));
+    }
+
     #endregion
 
     #region Helper Methods

--- a/tests/Security/Cryptography/Mac/Kmac/KmacTests.cs
+++ b/tests/Security/Cryptography/Mac/Kmac/KmacTests.cs
@@ -586,6 +586,21 @@ public class KMacTests
         Assert.That(hash1, Is.Not.EqualTo(hash2));
     }
 
+    /// <summary>
+    /// A disposed instance throws instead of silently authenticating with cleared state.
+    /// </summary>
+    [Test]
+    public void DisposedInstanceThrows()
+    {
+        byte[] key = Encoding.UTF8.GetBytes("test-key-12345678");
+        var kmac = KMac128.Create(key, 32, "");
+        kmac.ComputeHash(Encoding.UTF8.GetBytes("test"));
+
+        kmac.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => kmac.ComputeHash(Encoding.UTF8.GetBytes("test")));
+    }
+
     #endregion
 
     #region Helper Methods

--- a/tests/Security/Cryptography/Mac/Poly1305/Poly1305MacTests.cs
+++ b/tests/Security/Cryptography/Mac/Poly1305/Poly1305MacTests.cs
@@ -396,4 +396,23 @@ public class Poly1305MacTests
     }
 
     #endregion
+
+    #region Dispose
+
+    /// <summary>
+    /// A disposed instance throws instead of silently authenticating with cleared state.
+    /// </summary>
+    [Test]
+    public void DisposedInstanceThrows()
+    {
+        var mac = Poly1305Mac.Create(new byte[32]);
+        mac.Update(Encoding.ASCII.GetBytes("test"));
+
+        mac.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => mac.Update(Encoding.ASCII.GetBytes("more")));
+        Assert.Throws<ObjectDisposedException>(() => mac.Finalize(new byte[16]));
+    }
+
+    #endregion
 }

--- a/tests/Security/Cryptography/Rng/RandomNumberGeneratorTests.cs
+++ b/tests/Security/Cryptography/Rng/RandomNumberGeneratorTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace Cryptography.Tests.Rng;

--- a/tests/Security/Cryptography/Rng/RandomNumberGeneratorTests.cs
+++ b/tests/Security/Cryptography/Rng/RandomNumberGeneratorTests.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace Cryptography.Tests.Rng;
+
+using CryptoHives.Foundation.Security.Cryptography.Rng;
+using NUnit.Framework;
+using System;
+using System.Buffers;
+
+/// <summary>
+/// Tests for the <see cref="RandomNumberGenerator"/> polyfill.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class RandomNumberGeneratorTests
+{
+    [Test]
+    public void GetBytes_FillsRequestedLength()
+    {
+        Span<byte> buffer = stackalloc byte[32];
+        using var rng = RandomNumberGenerator.Create();
+
+        rng.GetBytes(buffer);
+
+        Assert.That(buffer.ToArray(), Is.Not.EqualTo(new byte[32]));
+    }
+
+#if !NET6_0_OR_GREATER
+    /// <summary>
+    /// On frameworks without a span-based OS API, <see cref="RandomNumberGenerator.GetBytes(Span{byte})"/>
+    /// rents a scratch buffer from <see cref="ArrayPool{T}.Shared"/> to fill it, then must return the
+    /// buffer cleared - otherwise the random bytes it just generated remain in the pooled array and
+    /// leak to whichever unrelated caller rents that array next.
+    /// </summary>
+    [Test]
+    public void GetBytes_DoesNotLeakRandomBytesIntoSharedArrayPool()
+    {
+        const int size = 4096; // Unusual size to avoid collisions with other pool users.
+
+        // Seed the pool bucket with a dirty, sentinel-filled array so we can tell whether
+        // it comes back cleared after GetBytes uses and returns it.
+        byte[] seed = ArrayPool<byte>.Shared.Rent(size);
+        for (int i = 0; i < seed.Length; i++)
+        {
+            seed[i] = 0xAA;
+        }
+        ArrayPool<byte>.Shared.Return(seed, clearArray: false);
+
+        Span<byte> buffer = new byte[size];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(buffer);
+
+        // Rent from the same bucket; the default ArrayPool reuses the most recently
+        // returned array for a given size class on this thread (LIFO), so this is
+        // very likely the same backing array GetBytes just rented and returned.
+        byte[] reclaimed = ArrayPool<byte>.Shared.Rent(size);
+        try
+        {
+            Assert.That(reclaimed, Has.None.EqualTo((byte)0xAA), "Sentinel byte survived: array was not cleared on return.");
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(reclaimed);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
This pull request introduces important security and robustness improvements to the cryptographic cipher implementations, focusing on constant-time PKCS#7 padding validation to prevent timing side-channel attacks, consistent object disposal checks, and minor documentation and code quality updates.

**Security and Padding Validation:**
- Replaces the previous PKCS#7 padding validation logic in both `BlockCipherTransform` and `AesCipherTransform` with a constant-time implementation to mitigate CBC padding oracle attacks. The new method scans all bytes in the block without early exit, ensuring execution time does not leak information about padding validity.

**Object Disposal Robustness:**
- Adds explicit checks for object disposal (`_disposed`) at the start of all cryptographic transform and AEAD methods (`TransformBlock`, `TransformFinalBlock`, `Encrypt`, `Decrypt`) across AES, ChaCha20, GCM, CCM, and XChaCha20Poly1305 classes, throwing `ObjectDisposedException` if used after disposal. 

**GCM and AEAD Improvements:**
- Updates GCM (`AesGcm`) disposal to securely clear internal state using a new `Clear` method on `GcmCore`, and makes `GcmCore` a mutable struct to support this. 

