### PR TITLE
Add agent/LLM porting guides for the Foundation packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository.
+
+**The canonical guidance lives in [`CLAUDE.md`](CLAUDE.md).** Read it first — it covers the
+repository overview, build/test commands, multi-targeting strategy, global code constraints
+(C# 14, nullable, `TreatWarningsAsErrors`), project structure, per-package architecture, and
+CI/versioning. Everything there applies to any agent, not just Claude.
+
+## Quick orientation
+
+- **Build:** `dotnet build "CryptoHives .NET Foundation.sln"`
+- **Test:** `dotnet test "CryptoHives .NET Foundation.sln"` (NUnit 4)
+- Code must compile clean under `TreatWarningsAsErrors=true`; match surrounding style.
+
+## Guides for *consumers* of the published packages
+
+Each shipped package embeds a `PORTING.md` at its package root — a machine-readable usage +
+porting guide for agents adopting the library in a **downstream** project (not for editing
+this repo). Sources:
+
+- `src/Threading/PORTING.md` — async synchronization primitives
+- `src/Memory/PORTING.md` — ArrayPool-backed buffers/streams/pools
+- `src/Security/Cryptography/PORTING.md` — managed hashes, MAC, KDF, ciphers
+
+The cross-package version is `docfx/porting-to-cryptohives.md` (published to the docs site at
+<https://cryptohives.github.io/Foundation/porting-to-cryptohives.html>).

--- a/docfx/getting-started.md
+++ b/docfx/getting-started.md
@@ -36,6 +36,13 @@ Roslyn analyzers for `ValueTask` misuse. Install this alongside the Threading pa
 dotnet add package CryptoHives.Foundation.Threading.Analyzers
 ```
 
+## Porting existing code
+
+Moving an existing project onto these packages — replacing BCL async primitives, buffer/pool
+code, and hashing? See the [Porting Guide](porting-to-cryptohives.md), a step-by-step
+playbook (also usable directly by AI coding agents). Each package additionally ships a
+`PORTING.md` at its NuGet package root.
+
 ## Support
 
 - [GitHub Issues](https://github.com/CryptoHives/Foundation/issues)

--- a/docfx/packages/security/cryptography/hash-algorithms.md
+++ b/docfx/packages/security/cryptography/hash-algorithms.md
@@ -420,7 +420,7 @@ ph.Squeeze(output);
 
 ---
 
-
+## TurboSHAKE
 
 High-performance XOFs from RFC 9861 (Reduced-round Keccak).
 

--- a/docfx/porting-to-cryptohives.md
+++ b/docfx/porting-to-cryptohives.md
@@ -1,0 +1,340 @@
+# Porting a C# Project to CryptoHives.Foundation
+
+**Audience:** an LLM performing a mechanical + semantic port of an existing C# codebase onto
+the `CryptoHives.Foundation.*` NuGet packages.
+
+**Goal:** replace BCL async synchronization primitives with the allocation-free CryptoHives
+`ValueTask`-based primitives, replace ad-hoc buffer/stream/pool code with the `Memory`
+ArrayPool-based primitives, and replace hashing with the managed, deterministic
+`Security.Cryptography` hash implementations — **without changing observable behavior**.
+
+Follow these instructions exactly. Do not invent APIs. If a source pattern has no clean
+mapping below, leave it unchanged and record it in the "Unmapped" report at the end.
+
+---
+
+## 0. Ground rules
+
+1. **Behavior-preserving first.** Every replacement must keep the same semantics
+   (fairness, reentrancy expectations, exceptions, timeout/cancellation contract). When a
+   CryptoHives type has a *different* semantic (e.g. `AsyncLock` is **not reentrant**),
+   stop and flag it rather than silently swapping.
+2. **One concern per commit.** Do the packages/`csproj` wiring first, then async, then
+   memory, then hashing. Build and run tests between each phase.
+3. **`ValueTask` is single-consumption.** Every CryptoHives async primitive returns
+   `ValueTask`/`ValueTask<T>`. It may be awaited **exactly once** and must never be stored
+   in a field, awaited twice, `.Result`-ed, or passed to `Task.WhenAll`/`WhenAny`. The
+   `CryptoHives.Foundation.Threading.Analyzers` package enforces this — **add it and treat
+   its diagnostics as the source of truth** (see §2.4).
+4. Match surrounding code style: nullable is enabled, warnings are errors in this repo;
+   any code you add must compile clean under `TreatWarningsAsErrors=true`.
+
+---
+
+## 1. Add package references
+
+Add the packages the port actually uses. Package IDs:
+
+| Need | Package ID |
+|---|---|
+| Async primitives (`AsyncLock`, `AsyncSemaphore`, …) | `CryptoHives.Foundation.Threading` |
+| Analyzer that enforces correct `ValueTask` usage | `CryptoHives.Foundation.Threading.Analyzers` |
+| Buffers / streams / object pools | `CryptoHives.Foundation.Memory` |
+| Managed hashes / MAC / KDF / KEM | `CryptoHives.Foundation.Security.Cryptography` |
+
+In each consuming `.csproj`:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="CryptoHives.Foundation.Threading" />
+  <PackageReference Include="CryptoHives.Foundation.Threading.Analyzers">
+    <PrivateAssets>all</PrivateAssets>
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  </PackageReference>
+  <PackageReference Include="CryptoHives.Foundation.Memory" />
+  <PackageReference Include="CryptoHives.Foundation.Security.Cryptography" />
+</ItemGroup>
+```
+
+If the target project uses Central Package Management (`Directory.Packages.props` with
+`<PackageVersion>` entries), put versions there, not inline. Otherwise add `Version="…"`.
+
+---
+
+## 2. Async primitives (`CryptoHives.Foundation.Threading.Async.Pooled`)
+
+`using CryptoHives.Foundation.Threading.Async.Pooled;`
+
+### 2.1 Mapping table
+
+| Existing (BCL / third-party) | Replace with | Notes |
+|---|---|---|
+| `private readonly object _gate = new();` + `lock (_gate) { … }` guarding **async** work | `AsyncLock` + `using (await _lock.LockAsync())` | Only when you need to `await` inside the critical section. Pure-sync `lock` blocks that never await should stay as `lock`. |
+| `SemaphoreSlim(1, 1)` used as a mutex | `AsyncLock` | Analyzer flags this as **CHT009**. |
+| `SemaphoreSlim(n, …)` used for concurrency limiting | `AsyncSemaphore(n)` | |
+| `ManualResetEventSlim` / TCS-based manual gate awaited async | `AsyncManualResetEvent` | |
+| `AutoResetEvent` semantics, async | `AsyncAutoResetEvent` | |
+| `CountdownEvent` awaited async | `AsyncCountdownEvent` | |
+| `Barrier` awaited async | `AsyncBarrier` | |
+| `ReaderWriterLockSlim` awaited async | `AsyncReaderWriterLock` | |
+| `Nito.AsyncEx.AsyncLock`, `NeoSmart.AsyncLock`, `AsyncKeyedLock` (single-key) | `AsyncLock` | Verify the source did not rely on reentrancy. |
+
+### 2.2 `AsyncLock` — exact usage
+
+```csharp
+private readonly AsyncLock _lock = new();
+
+public async Task DoStuffAsync(CancellationToken ct)
+{
+    using (await _lock.LockAsync(ct))          // ct only observed if not acquired immediately
+    {
+        await SomethingAsync();
+    }
+}
+```
+
+Signatures actually present:
+
+- `ValueTask<Releaser> LockAsync(CancellationToken cancellationToken = default)`
+- `ValueTask<Releaser> LockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)`
+  - `timeout` throws `TimeoutException` if it elapses; `TimeSpan.Zero` throws immediately if
+    the lock is held; `Timeout.InfiniteTimeSpan` waits forever.
+- `bool IsTaken { get; }`
+
+Rules:
+- **`AsyncLock` is NOT recursive.** If the original lock was taken re-entrantly (same call
+  stack re-acquires), do not port it — flag it. Re-entrant acquisition will deadlock.
+- The `Releaser` is a `readonly struct` implementing `IDisposable`/`IAsyncDisposable`.
+  Release **only** by disposing it via `using`. Do not store it in a field.
+- Do not `.GetAwaiter().GetResult()` the `ValueTask<Releaser>` (blocking) — that is CHT002.
+
+### 2.3 `AsyncSemaphore` — exact usage
+
+```csharp
+private readonly AsyncSemaphore _semaphore = new(3);   // 3 concurrent permits
+
+public async Task AccessAsync(CancellationToken ct)
+{
+    await _semaphore.WaitAsync(ct);
+    try
+    {
+        await DoWorkAsync();
+    }
+    finally
+    {
+        _semaphore.Release();
+    }
+}
+```
+
+Signatures actually present:
+- `AsyncSemaphore(int initialCount, bool runContinuationAsynchronously = true, …)`
+- `ValueTask WaitAsync(CancellationToken cancellationToken = default)`
+- `ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default)`
+  (throws `TimeoutException` / `OperationCanceledException`)
+- `void Release()` / `void Release(int releaseCount)`
+- `int CurrentCount { get; }`
+
+Note: there is **no** `SemaphoreSlim`-style bool-returning `WaitAsync(timeout)`. The BCL
+pattern `if (await sem.WaitAsync(timeout)) { … }` must be rewritten to try/catch on
+`TimeoutException`, or use a `CancellationToken`.
+
+### 2.4 Enforce correctness with the analyzer
+
+After porting, build. The analyzer emits (see `CLAUDE.md` for the full table):
+
+| ID | Meaning — fix |
+|---|---|
+| CHT001 (Error) | `ValueTask` awaited multiple times — await once, capture the result. |
+| CHT002 (Warn) | `.GetAwaiter().GetResult()` on `ValueTask` — make the caller async and `await`. |
+| CHT003 (Warn) | `ValueTask` stored in a field — don't; await it locally. |
+| CHT004 (Error) | `AsTask()` called multiple times. |
+| CHT005 (Warn) | `.Result` on a `ValueTask` — `await` instead. |
+| CHT006 (Warn) | `ValueTask` passed to `WhenAll`/`WhenAny` — call `.AsTask()` once first, or restructure. |
+| CHT008 (Warn) | `ValueTask` not awaited/consumed. |
+| CHT009 (Info) | `SemaphoreSlim(1,1)` — switch to `AsyncLock`. |
+| CHT010 (Warn) | `ValueTask` captured in a lambda/closure. |
+
+Resolve every CHT00x before considering the async phase done. Do not suppress them to make
+the build pass unless a human explicitly approves a specific instance.
+
+---
+
+## 3. Memory: buffers, streams, pools (`CryptoHives.Foundation.Memory`)
+
+### 3.1 `ArrayPoolBufferWriter<T>` — pooled `IBufferWriter<T>`
+
+`using CryptoHives.Foundation.Memory.Buffers;`
+
+Replace: hand-rolled growable buffers, `MemoryStream` used only to accumulate bytes then
+read them back, `ArrayBufferWriter<T>` where you want ArrayPool backing, or manual
+`ArrayPool<T>.Shared.Rent`/`Return` accumulation loops.
+
+```csharp
+using var writer = new ArrayPoolBufferWriter<byte>();
+// standard IBufferWriter<T> surface:
+Span<byte> span = writer.GetSpan(sizeHint);   // or GetMemory
+// … write into span …
+writer.Advance(bytesWritten);
+// consume as a ReadOnlySequence (valid until next write or Dispose):
+ReadOnlySequence<byte> result = writer.GetReadOnlySequence();
+```
+
+Critical rules:
+- It is `IDisposable` and rents from `ArrayPool<T>.Shared`. **Always `using`** it so pooled
+  arrays are returned. Never let one escape its scope.
+- The `ReadOnlySequence<T>` from `GetReadOnlySequence()` is **only valid until the next
+  write or `Dispose()`**. Fully consume/copy it before disposing. Do not return it to a
+  caller that outlives the `using`.
+- For sensitive data, construct with `new ArrayPoolBufferWriter<byte>(clearArray: true,
+  defaultChunksize, maxChunkSize)` so buffers are zeroed on return.
+- Chunk sizing: default 256, grows (doubling) to max 65536; override via the ctor.
+
+### 3.2 `ArrayPoolMemoryStream` — pooled `MemoryStream`
+
+Replace `new MemoryStream()` used as a scratch/accumulation buffer where the allocation of
+one large backing array is wasteful. It is a `MemoryStream` subclass backed by pooled
+`ArrayPool<byte>` segments, so it is a drop-in for APIs typed as `MemoryStream`/`Stream`.
+`using` it (it returns segments on `Dispose`).
+
+### 3.3 `ReadOnlySequenceMemoryStream` — read-only `Stream` over an existing sequence
+
+Replace code that copies a `ReadOnlySequence<byte>` into a `byte[]` just to wrap it in a
+`new MemoryStream(bytes)`. Wrap the sequence directly:
+`new ReadOnlySequenceMemoryStream(sequence)`.
+
+### 3.4 `ObjectOwner<T>` + object pools
+
+`using CryptoHives.Foundation.Memory.Pools;`
+
+Replace manual `ObjectPool<T>.Get()/Return()` pairs and `StringBuilder` churn.
+
+```csharp
+using var owner = ObjectPools.GetStringBuilder();
+StringBuilder sb = owner.PooledObject;
+// … use sb …
+```
+
+For your own pools:
+```csharp
+using var owner = new ObjectOwner<MyType>(myObjectPool);
+MyType obj = owner.PooledObject;
+```
+
+Critical rules:
+- `ObjectOwner<T>` is a `readonly struct`. Use it **only** with `using var` in a narrow
+  scope. **Never cast it to `IDisposable`** and never box it — that defeats the purpose and
+  can double-return. Do not copy it around.
+- Whatever you got from `PooledObject` must not be used after the `using` scope ends (it has
+  been returned to the pool).
+
+---
+
+## 4. Hashing (`CryptoHives.Foundation.Security.Cryptography`)
+
+`using CryptoHives.Foundation.Security.Cryptography.Hash;`
+
+These are fully managed, deterministic, cross-platform implementations that **extend
+`System.Security.Cryptography.HashAlgorithm`**, so they are drop-in wherever a
+`HashAlgorithm` is expected. Use them to replace BouncyCastle digests, third-party hash
+libs, or `System.Security.Cryptography` types when you want managed determinism across all
+target frameworks (including legacy TFMs where the BCL lacks e.g. SHA-3).
+
+### 4.1 One-shot hashing (preferred — pooled, allocation-light)
+
+Concrete classes expose static `HashData` / `TryHashData` that pool their instance:
+
+```csharp
+byte[] digest = SHA256.HashData(data);                        // ReadOnlySpan<byte> or ReadOnlySequence<byte>
+bool ok      = SHA256.TryHashData(data, destination, out int written);
+```
+
+Prefer these over `ComputeHash` for one-shot cases — no `IDisposable` bookkeeping and they
+accept `ReadOnlySequence<byte>` directly (pairs well with §3.1's `GetReadOnlySequence()`).
+
+### 4.2 Streaming / incremental hashing
+
+For multi-chunk input, use the instance API (same shape as the BCL base type):
+
+```csharp
+using var sha = SHA256.Create();
+sha.AppendData(chunk1);          // or TransformBlock for the classic pattern
+sha.AppendData(chunk2);
+sha.TryGetHashAndReset(dest, out int written);
+// or: byte[] h = sha.ComputeHash(stream);
+```
+
+Every concrete type has a static `Create()` returning the concrete type, plus the inherited
+`HashAlgorithm` surface (`ComputeHash`, `TransformBlock`/`TransformFinalBlock`, etc.).
+
+### 4.3 Available concrete hash types (use the exact class name)
+
+- **SHA-2:** `SHA224`, `SHA256`, `SHA384`, `SHA512`, `SHA512_224`, `SHA512_256`
+- **SHA-3 (FIPS 202):** `SHA3_224`, `SHA3_256`, `SHA3_384`, `SHA3_512`
+- **Keccak (original padding):** `Keccak256`, `Keccak384`, `Keccak512`
+- **XOF:** `Shake128`, `Shake256`, `CShake128`, `CShake256`, `TurboShake128`,
+  `TurboShake256`, `KT128`, `KT256`
+- **BLAKE:** `Blake2b`, `Blake2s`, `Blake3`
+- **Legacy (deprecated, kept for compat):** `SHA1`, `MD5`, `Ripemd160`
+- **Regional / other:** `SM3`, `Whirlpool`, `Kupyna`, `Streebog`, `Lsh256`, `Lsh512`,
+  `AsconHash256`, `AsconXof128`
+- **Parallel:** `ParallelHash`, `IncrementalParallelHash`
+
+### 4.4 Extendable-output functions (XOF)
+
+XOF types (`Shake*`, `CShake*`, `TurboShake*`, `KT*`, `Blake3`, `AsconXof128`) implement
+`IExtendableOutput`:
+
+```csharp
+void Absorb(ReadOnlySpan<byte> input);   // absorb all input first
+void Squeeze(Span<byte> output);         // then squeeze arbitrary-length output (repeatable)
+void Reset();
+```
+
+After the first `Squeeze`, the state is finalized — no more `Absorb`. Map any
+"digest of arbitrary length" or SHAKE usage to this pattern.
+
+### 4.5 Choosing managed vs. OS implementation
+
+`HashAlgorithm.Create(string hashName, bool osVersion = false)` is available: pass
+`osVersion: true` to get the (often faster) OS implementation for algorithms the BCL
+supports, or the default managed CryptoHives implementation otherwise. For a straight port,
+prefer the concrete-class static `HashData` calls (§4.1) for clarity.
+
+### 4.6 Do NOT touch cryptographic correctness
+
+Do not change algorithm choice, key sizes, IV/nonce handling, digest length, or padding as
+part of this port. Swap the *implementation type* only. If the source uses a broken/weak
+algorithm (MD5/SHA-1), keep it as-is (the equivalent CryptoHives type exists) and note it —
+do not "upgrade" it silently.
+
+---
+
+## 5. Procedure & verification
+
+Work phase by phase; build + test after each:
+
+1. **Wire packages** (§1). Restore/build.
+2. **Async** (§2): swap primitives, add the analyzer, drive CHT00x to zero.
+3. **Memory** (§3): swap buffer/stream/pool patterns; verify every new type is `using`-scoped.
+4. **Hashing** (§4): swap hash implementations; confirm identical digests.
+
+Verification checklist:
+- [ ] Solution builds clean under `TreatWarningsAsErrors=true`.
+- [ ] Zero unresolved `CHT001`–`CHT010` diagnostics.
+- [ ] All existing tests pass. For hashing, add/keep a test asserting the new digest equals
+      a known-answer vector or the pre-port output for representative inputs.
+- [ ] No `ValueTask` stored in a field, awaited twice, `.Result`-ed, or `WhenAll`-ed.
+- [ ] Every `ArrayPoolBufferWriter<T>`, `ArrayPoolMemoryStream`, and `ObjectOwner<T>` is in
+      a `using` scope; no pooled buffer or `ReadOnlySequence` escapes it.
+- [ ] No `AsyncLock` used re-entrantly.
+
+## 6. Report
+
+At the end, produce a short report:
+- **Replaced:** table of `file:line` → old type → new CryptoHives type.
+- **Unmapped / flagged:** patterns you intentionally left alone (re-entrant locks, sync-only
+  `lock` blocks, bool-returning `WaitAsync(timeout)` usages that need human decision, weak
+  hashes retained), each with a one-line reason.
+- **Behavioral risks:** anything where semantics *might* differ (fairness, continuation
+  scheduling, timeout-as-exception vs. bool), for human review.

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -2,6 +2,8 @@
   href: index.md
 - name: Getting Started
   href: getting-started.md
+- name: Porting Guide
+  href: porting-to-cryptohives.md
 - name: Packages
   items:
     - name: Memory

--- a/src/Memory/Memory.csproj
+++ b/src/Memory/Memory.csproj
@@ -65,6 +65,11 @@
     <None Include="../../docfx/packages/memory/*.yml" Link="docfx/%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <!-- LLM/agent usage + porting guide, shipped at the package root -->
+  <ItemGroup>
+    <None Include="PORTING.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <Target Name="GetPackagingOutputs" />
 
 </Project>

--- a/src/Memory/PORTING.md
+++ b/src/Memory/PORTING.md
@@ -1,0 +1,108 @@
+# CryptoHives.Foundation.Memory — Guide for LLM Agents
+
+Machine-readable usage + porting guide for coding assistants. All APIs below are verified
+against the shipped source. Do not invent members. Human-oriented docs live in `README.md`.
+
+- **Package:** `CryptoHives.Foundation.Memory`
+- **Namespaces:** `CryptoHives.Foundation.Memory.Buffers`, `CryptoHives.Foundation.Memory.Pools`
+- **What it is:** `ArrayPool<T>`-backed buffer/stream types and RAII object-pool helpers that
+  keep allocations and LOH/GC pressure out of high-throughput and crypto pipelines.
+
+---
+
+## When to use / what to replace
+
+| Existing code | Replace with |
+|---|---|
+| Hand-rolled growable `byte[]`, or `MemoryStream` used only to accumulate then read back | `ArrayPoolBufferWriter<byte>` → `GetReadOnlySequence()` |
+| `ArrayBufferWriter<T>` where pooled backing is wanted | `ArrayPoolBufferWriter<T>` |
+| `new MemoryStream()` as a scratch/accumulation buffer | `ArrayPoolMemoryStream` (drop-in `MemoryStream` subclass) |
+| Copying a `ReadOnlySequence<byte>` into `byte[]` just to `new MemoryStream(bytes)` | `new ReadOnlySequenceMemoryStream(sequence)` |
+| Manual `ObjectPool<T>.Get()`/`Return()` pairs; `StringBuilder` churn | `ObjectOwner<T>` / `ObjectPools.GetStringBuilder()` |
+
+---
+
+## Verified API surface
+
+```csharp
+namespace CryptoHives.Foundation.Memory.Buffers;
+
+sealed class ArrayPoolBufferWriter<T> : IBufferWriter<T>, IDisposable {
+    ArrayPoolBufferWriter();                                              // default 256 → max 65536 chunks
+    ArrayPoolBufferWriter(int defaultChunkSize, int maxChunkSize);
+    ArrayPoolBufferWriter(bool clearArray, int defaultChunkSize, int maxChunkSize); // clearArray zeroes on return
+    Span<T>   GetSpan(int sizeHint = 0);
+    Memory<T> GetMemory(int sizeHint = 0);
+    void      Advance(int count);
+    ReadOnlySequence<T> GetReadOnlySequence();   // valid only until next write or Dispose()
+    void      Dispose();                          // returns pooled arrays
+}
+
+sealed class ArrayPoolMemoryStream : MemoryStream { … }           // pooled MemoryStream; Dispose returns segments
+sealed class ReadOnlySequenceMemoryStream : MemoryStream {         // read-only Stream over an existing sequence
+    ReadOnlySequenceMemoryStream(ReadOnlySequence<byte> sequence);
+}
+
+namespace CryptoHives.Foundation.Memory.Pools;
+
+readonly struct ObjectOwner<T> : IDisposable where T : class {
+    ObjectOwner(ObjectPool<T> pool);
+    T PooledObject { get; }       // NOTE: the member is PooledObject, not Object
+    void Dispose();               // returns the object to the pool
+}
+
+static class ObjectPools {
+    static ObjectOwner<StringBuilder> GetStringBuilder();
+}
+```
+
+---
+
+## Canonical patterns
+
+```csharp
+using CryptoHives.Foundation.Memory.Buffers;
+
+using var writer = new ArrayPoolBufferWriter<byte>();
+Span<byte> span = writer.GetSpan(sizeHint);
+// … write into span …
+writer.Advance(bytesWritten);
+ReadOnlySequence<byte> seq = writer.GetReadOnlySequence();   // consume before the using scope ends
+Consume(seq);
+
+using CryptoHives.Foundation.Memory.Pools;
+
+using var owner = ObjectPools.GetStringBuilder();
+StringBuilder sb = owner.PooledObject;
+// … use sb; do NOT use it after the using scope …
+```
+
+---
+
+## Hard rules
+
+1. **Everything here is scope-bound. Always `using`.** `ArrayPoolBufferWriter<T>`,
+   `ArrayPoolMemoryStream`, and `ObjectOwner<T>` all return pooled memory on `Dispose`.
+   Never let one escape its scope.
+2. **The `ReadOnlySequence<T>` from `GetReadOnlySequence()` is only valid until the next
+   write or `Dispose()`.** Fully consume or copy it before disposing; never return it to a
+   caller that outlives the `using`.
+3. **`ObjectOwner<T>` is a `readonly struct` — never cast it to `IDisposable` and never box
+   it** (double-return / boxing hazard). Use only `using var`; do not copy it.
+4. **Do not use a pooled object after its owner is disposed** — it has been returned and may
+   be handed to another caller.
+5. For sensitive data, construct `new ArrayPoolBufferWriter<byte>(clearArray: true, …)` so
+   buffers are zeroed on return.
+6. The pooled `PooledObject` accessor is named **`PooledObject`** (not `Object`).
+
+---
+
+## Porting procedure
+
+1. Add `CryptoHives.Foundation.Memory`.
+2. Swap buffer/stream/pool patterns per the table; ensure every new type is `using`-scoped
+   and no pooled buffer or `ReadOnlySequence` escapes its scope.
+3. Build clean; run existing tests.
+4. Report: `file:line` → old type → new type.
+
+Full cross-package porting guide: <https://cryptohives.github.io/Foundation/porting-to-cryptohives.html>

--- a/src/Security/Cryptography/Cryptography.csproj
+++ b/src/Security/Cryptography/Cryptography.csproj
@@ -77,6 +77,11 @@
     <None Include="../../../docfx/packages/security/cryptography/benchmarks/*.md" Link="docfx/benchmarks/%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <!-- LLM/agent usage + porting guide, shipped at the package root -->
+  <ItemGroup>
+    <None Include="PORTING.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <Target Name="GetPackagingOutputs" />
 
 </Project>

--- a/src/Security/Cryptography/PORTING.md
+++ b/src/Security/Cryptography/PORTING.md
@@ -1,0 +1,160 @@
+# CryptoHives.Foundation.Security.Cryptography — Guide for LLM Agents
+
+Machine-readable usage + porting guide for coding assistants. All APIs below are verified
+against the shipped source. Do not invent members. Human-oriented docs live in `README.md`.
+
+- **Package:** `CryptoHives.Foundation.Security.Cryptography` (published as a `-beta`
+  pre-release; API surface may still change)
+- **Root namespace:** `CryptoHives.Foundation.Security.Cryptography` with sub-namespaces
+  `.Hash`, `.Mac`, `.Kdf`, `.Cipher`
+- **What it is:** fully managed, deterministic, cross-platform implementations of hashes,
+  MACs, KDFs, and ciphers. Hash and cipher types **extend the
+  `System.Security.Cryptography` base types**, so they are drop-in where those are expected.
+  Hardware intrinsics (AES-NI, ARM Crypto, AVX2, NEON, SSE/SSSE3) are used for performance
+  where available but are never required for correctness.
+
+Use these to replace BouncyCastle / third-party crypto, or the BCL types, when you need
+managed determinism across all target frameworks (including legacy TFMs where the BCL lacks
+e.g. SHA-3, KMAC, or Ascon).
+
+> **Never change cryptographic parameters during a port.** Swap the *implementation type*
+> only — do not alter algorithm, key size, nonce/IV handling, digest length, or padding. If
+> the source uses a weak algorithm (MD5/SHA-1), keep it (the equivalent type exists) and
+> flag it; do not silently "upgrade".
+
+---
+
+## Hashing — `…Hash`
+
+`using CryptoHives.Foundation.Security.Cryptography.Hash;`
+
+Concrete types extend `System.Security.Cryptography.HashAlgorithm` and add pooled static
+one-shot helpers:
+
+```csharp
+byte[] digest = SHA256.HashData(data);                          // ReadOnlySpan<byte> or ReadOnlySequence<byte>
+bool ok       = SHA256.TryHashData(data, dest, out int written);
+
+using var sha = SHA256.Create();                                // streaming / incremental
+sha.AppendData(chunk1); sha.AppendData(chunk2);
+sha.TryGetHashAndReset(dest, out int n);
+```
+
+Prefer the static `HashData`/`TryHashData` for one-shot cases (allocation-light, accept
+`ReadOnlySequence<byte>` — pairs with `ArrayPoolBufferWriter.GetReadOnlySequence()`).
+
+**Available types (use the exact class name):**
+- SHA-2: `SHA224` `SHA256` `SHA384` `SHA512` `SHA512_224` `SHA512_256`
+- SHA-3 (FIPS 202): `SHA3_224` `SHA3_256` `SHA3_384` `SHA3_512`
+- Keccak (original padding): `Keccak256` `Keccak384` `Keccak512`
+- XOF: `Shake128` `Shake256` `CShake128` `CShake256` `TurboShake128` `TurboShake256` `KT128` `KT256`
+- BLAKE: `Blake2b` `Blake2s` `Blake3`
+- Legacy (kept for compat): `SHA1` `MD5` `Ripemd160`
+- Regional/other: `SM3` `Whirlpool` `Kupyna` `Streebog` `Lsh256` `Lsh512` `AsconHash256` `AsconXof128`
+- Parallel: `ParallelHash` `IncrementalParallelHash`
+
+**XOF (extendable output)** — `Shake*`, `CShake*`, `TurboShake*`, `KT*`, `Blake3`,
+`AsconXof128` implement `IExtendableOutput`:
+```csharp
+void Absorb(ReadOnlySpan<byte> input);   // absorb ALL input first
+void Squeeze(Span<byte> output);         // then squeeze arbitrary length (repeatable)
+void Reset();
+// After the first Squeeze the state is finalized — no more Absorb.
+```
+
+`HashAlgorithm.Create(string hashName, bool osVersion = false)` selects the managed
+implementation (default) or the OS one (`osVersion: true`) for algorithms the BCL supports.
+
+---
+
+## MAC — `…Mac`
+
+`using CryptoHives.Foundation.Security.Cryptography.Mac;`
+
+Common streaming interface:
+```csharp
+interface IMac : IDisposable {
+    string AlgorithmName { get; }
+    int MacSize { get; }
+    void Update(ReadOnlySpan<byte> input);
+    void Finalize(Span<byte> destination);   // destination >= MacSize
+    void Reset();                             // reuse with same key
+}
+```
+
+HMAC types (`HmacSha256`, `HmacSha1`, `HmacMd5`, `HmacSha384`, `HmacSha512`,
+`HmacSha3_256/384/512`) expose:
+```csharp
+static HmacSha256 Create(byte[] key);
+static byte[] Hash(byte[] key, byte[] data);   // one-shot
+```
+
+KMAC: `KMac128` / `KMac256`:
+```csharp
+static KMac128 Create(byte[] key, int outputBytes = 32, string? customization = null);
+```
+Also available: `AesCmac`, `AesGmac`, `Poly1305Mac`.
+
+---
+
+## KDF — `…Kdf`
+
+`using CryptoHives.Foundation.Security.Cryptography.Kdf;`
+
+KDFs are static classes and take an `HmacFactory` delegate
+(`delegate IMac HmacFactory(byte[] key)`), so you choose the underlying PRF explicitly:
+
+```csharp
+using CryptoHives.Foundation.Security.Cryptography.Mac;
+
+byte[] okm = Hkdf.DeriveKey(
+    key => HmacSha256.Create(key), ikm, outputLength: 32, salt: salt, info: info);
+// Also: Hkdf.Extract(factory, ikm, salt) / Hkdf.Expand(factory, prk, outputLength, info)
+
+byte[] dk = Pbkdf2.DeriveKey(
+    key => HmacSha256.Create(key), password, salt, iterations, outputLength /* or Span dest */);
+```
+Also available: `Kbkdf`, `ConcatKdf`.
+
+---
+
+## Cipher — `…Cipher`
+
+`using CryptoHives.Foundation.Security.Cryptography.Cipher;`
+
+**AEAD** implements `IAeadCipher`:
+```csharp
+interface IAeadCipher : IDisposable {
+    int KeySizeBytes, NonceSizeBytes, TagSizeBytes { get; }
+    void   Encrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext, Span<byte> tag, ReadOnlySpan<byte> associatedData = default);
+    bool   Decrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> tag, Span<byte> plaintext, ReadOnlySpan<byte> associatedData = default);
+    byte[] Encrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> associatedData = default);            // tag appended
+    byte[] Decrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> ciphertextWithTag, ReadOnlySpan<byte> associatedData = default);    // throws on auth failure
+}
+```
+AEAD types: `AesGcm128/192/256`, `AesCcm128/192/256`, `ChaCha20Poly1305`,
+`XChaCha20Poly1305`, `AsconAead128`. Construct via `Create(ReadOnlySpan<byte> key)`, e.g.
+`using var gcm = AesGcm256.Create(key);`.
+
+**Block ciphers** extend `SymmetricCipher : System.Security.Cryptography.SymmetricAlgorithm`
+(drop-in: set `Key`/`IV`, use `CreateEncryptor()`/`CreateDecryptor()`, or the type's
+`Encrypt(plaintext)`/`Decrypt(ciphertext)` convenience methods):
+`Aes128/192/256`, `Aria128/192/256`, `Camellia128/192/256`, `Kalyna128/256/512`,
+`Kuznyechik`, `Seed`, `Sm4`. Stream cipher: `ChaCha20`.
+
+**Cipher hard rules:** never reuse a `(key, nonce)` pair for AEAD; a `false`/throwing
+`Decrypt` means tampering or wrong key — discard the output, never use partial plaintext.
+
+---
+
+## Porting procedure
+
+1. Add `CryptoHives.Foundation.Security.Cryptography`.
+2. Swap implementation types only, preserving all crypto parameters (§ note above).
+3. Add/keep a known-answer-vector test asserting the new output equals the pre-port output
+   for representative inputs.
+4. Build clean; run tests.
+5. Report: `file:line` → old type → new type; plus any weak algorithm retained for human
+   review.
+
+Full cross-package porting guide: <https://cryptohives.github.io/Foundation/porting-to-cryptohives.html>

--- a/src/Threading/PORTING.md
+++ b/src/Threading/PORTING.md
@@ -1,0 +1,120 @@
+# CryptoHives.Foundation.Threading — Guide for LLM Agents
+
+Machine-readable usage + porting guide for coding assistants. All APIs below are verified
+against the shipped source. Do not invent members. Human-oriented docs live in `README.md`.
+
+- **Package:** `CryptoHives.Foundation.Threading`
+- **Primitive namespace:** `CryptoHives.Foundation.Threading.Async.Pooled`
+- **Companion analyzer (install separately):** `CryptoHives.Foundation.Threading.Analyzers`
+- **What it is:** allocation-free async synchronization primitives that return
+  `ValueTask`/`ValueTask<T>` instead of `Task`, backed by pooled `IValueTaskSource<T>`.
+
+---
+
+## When to use / what to replace
+
+Use these when an `await` must happen inside a critical section, or to remove
+`Task`/`TaskCompletionSource<T>` allocations from hot paths.
+
+| Existing code | Replace with | Caveat |
+|---|---|---|
+| `lock (obj) { … }` around code that needs to `await` | `AsyncLock` + `using (await l.LockAsync())` | **Not reentrant.** Pure-sync `lock` blocks stay `lock`. |
+| `SemaphoreSlim(1, 1)` as a mutex | `AsyncLock` | Analyzer flags this (CHT009). |
+| `SemaphoreSlim(n, …)` for concurrency limiting | `AsyncSemaphore(n)` | No bool-returning `WaitAsync(timeout)` — see below. |
+| `ManualResetEventSlim` / TCS gate awaited async | `AsyncManualResetEvent` | |
+| `AutoResetEvent` (async) | `AsyncAutoResetEvent` | Releases exactly one waiter per `Set()`. |
+| `CountdownEvent` (async) | `AsyncCountdownEvent` | |
+| `Barrier` (async) | `AsyncBarrier` | |
+| `ReaderWriterLockSlim` (async) | `AsyncReaderWriterLock` | |
+| `Nito.AsyncEx.AsyncLock`, `NeoSmart.AsyncLock`, single-key `AsyncKeyedLock` | `AsyncLock` | Verify no reentrancy. |
+
+---
+
+## Verified API surface
+
+```csharp
+// AsyncLock — NOT reentrant. Release only by disposing the Releaser.
+sealed class AsyncLock {
+    AsyncLock();
+    ValueTask<Releaser> LockAsync(CancellationToken cancellationToken = default);
+    ValueTask<Releaser> LockAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
+    bool IsTaken { get; }
+    readonly struct Releaser : IDisposable, IAsyncDisposable; // Dispose() releases the lock
+}
+
+// AsyncSemaphore
+sealed class AsyncSemaphore {
+    AsyncSemaphore(int initialCount, bool runContinuationAsynchronously = true, …);
+    ValueTask WaitAsync(CancellationToken cancellationToken = default);
+    ValueTask WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
+    void Release();
+    void Release(int releaseCount);
+    int CurrentCount { get; }
+}
+
+// AsyncManualResetEvent / AsyncAutoResetEvent
+new AsyncManualResetEvent(initialState: false);  // Set() releases ALL waiters, stays set until Reset()
+new AsyncAutoResetEvent(initialState: false);    // Set() releases ONE waiter, auto-resets
+//   .Set(); .Reset(); ValueTask WaitAsync(CancellationToken); ValueTask WaitAsync(TimeSpan, CancellationToken);
+
+// AsyncReaderWriterLock — using (await rw.ReaderLockAsync(ct)) / (await rw.WriterLockAsync(ct))
+```
+
+`timeout` overloads throw `TimeoutException` when the time elapses (`TimeSpan.Zero` throws
+immediately if unavailable; `Timeout.InfiniteTimeSpan` waits forever). Cancellation throws
+`OperationCanceledException`. The `CancellationToken` is only observed if the primitive
+cannot complete synchronously.
+
+---
+
+## Canonical patterns
+
+```csharp
+using CryptoHives.Foundation.Threading.Async.Pooled;
+
+private readonly AsyncLock _lock = new();
+public async Task DoWorkAsync(CancellationToken ct)
+{
+    using (await _lock.LockAsync(ct).ConfigureAwait(false))
+        await ModifySharedStateAsync().ConfigureAwait(false);
+}
+
+private readonly AsyncSemaphore _sem = new(4);
+public async Task FetchAsync(CancellationToken ct)
+{
+    await _sem.WaitAsync(ct).ConfigureAwait(false);
+    try { await CallServiceAsync().ConfigureAwait(false); }
+    finally { _sem.Release(); }
+}
+```
+
+---
+
+## Hard rules (the `ValueTask` contract — enforced by the analyzer)
+
+1. **Await each returned `ValueTask` exactly once.** A second `await` or `AsTask()` throws
+   `InvalidOperationException` (CHT001/CHT004).
+2. **Never store a `ValueTask` in a field** (CHT003) or **capture it in a lambda/closure**
+   (CHT010). Await it locally.
+3. **Never block on it**: no `.Result` (CHT005), no `.GetAwaiter().GetResult()` (CHT002).
+4. **Never pass it to `Task.WhenAll`/`WhenAny`** (CHT006) — call `.AsTask()` once first, or
+   restructure.
+5. **Always await or discard** every returned `ValueTask`/`Releaser` (CHT008), otherwise the
+   pooled source never returns to the pool.
+6. **`AsyncLock` is not reentrant** — re-acquiring on the same call stack deadlocks. If the
+   source lock was reentrant, do **not** port it; flag it for human review.
+7. There is **no** `SemaphoreSlim`-style `bool WaitAsync(timeout)`. Rewrite
+   `if (await sem.WaitAsync(timeout))` to try/catch `TimeoutException` or use a token.
+
+---
+
+## Porting procedure
+
+1. Add `CryptoHives.Foundation.Threading` and the `…Threading.Analyzers` package.
+2. Swap primitives per the table above; keep the `using`-based release pattern.
+3. Build and drive every `CHT001`–`CHT010` diagnostic to zero (do not suppress without human
+   approval). Run existing tests.
+4. Report: `file:line` → old type → new type; plus any reentrant locks / bool-timeout waits
+   left unported for human review.
+
+Full cross-package porting guide: <https://cryptohives.github.io/Foundation/porting-to-cryptohives.html>

--- a/src/Threading/Threading.csproj
+++ b/src/Threading/Threading.csproj
@@ -77,6 +77,11 @@
     <Compile Include="../Security/Cryptography/shared/MethodImplOptionsEx.cs" Link="shared/MethodImplOptionsEx.cs" />
   </ItemGroup>
 
+  <!-- LLM/agent usage + porting guide, shipped at the package root -->
+  <ItemGroup>
+    <None Include="PORTING.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <Target Name="GetPackagingOutputs" />
 
 </Project>


### PR DESCRIPTION
## Summary

Adds machine-readable usage + porting guides aimed at LLM coding agents adopting the `CryptoHives.Foundation.*` packages, plus supporting docs wiring.

- **Per-package `PORTING.md`** for Threading, Memory, and Security.Cryptography. Each is a source-verified usage + porting guide (mapping tables, verified API signatures, hard rules/traps) and is **packed at the root of its NuGet package** (`<None Include="PORTING.md" Pack="true" PackagePath="" />`). Verified via `dotnet pack` that the file lands next to `README.md` in the `.nupkg`.
- **Cross-package guide** `docfx/porting-to-cryptohives.md`, published as a docfx site page — added to the site TOC and linked from Getting Started. (Previously lived in a standalone `docs/` folder; moved so it becomes part of the published documentation.)
- **Repo-root `AGENTS.md`** — the standard agent-instructions file — delegating to `CLAUDE.md` and pointing at the guides. (Named the packed guides `PORTING.md` rather than `AGENTS.md` to avoid the "instructions for editing this repo" semantics of the AGENTS.md convention.)
- **Docs fix:** added a `## TurboSHAKE` section heading in `hash-algorithms.md` so the `#turboshake` bookmark link in the crypto index resolves.

## Verification

- `dotnet pack src/Memory` → `PORTING.md` present at nupkg root.
- `docfx build` → **0 errors**; the previously-reported `InvalidBookmark` warning is gone. The only remaining warning is a pre-existing network failure reaching `xref.docs.microsoft.com` (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)