### PR TITLE
ci: scope workflow triggers to relevant changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,14 +4,16 @@ name: "CodeQL"
 on:
   push:
     branches: [ main, release/* ]
+    paths:
+    - '**.cs'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
     paths:
-    - '**.cs'    
+    - '**.cs'
   schedule:
     - cron: '30 6 * * 6'
-  workflow_dispatch:  
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,7 +6,13 @@
 
 name: Dependency Review
 
-on: [pull_request]
+# Only run when the dependency graph can actually change (manifests / lock files).
+on:
+  pull_request:
+    paths:
+    - '**/*.csproj'
+    - '**/Directory.Packages.props'
+    - '**/packages.lock.json'
 
 permissions:
   contents: read

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -8,8 +8,12 @@ name: DevSkim
 on:
   push:
     branches: [ "main" ]
+    paths:
+    - '**.cs'
   pull_request:
     branches: [ "main" ]
+    paths:
+    - '**.cs'
   schedule:
     - cron: '17 22 * * 2'
 

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -2,11 +2,15 @@
 
 name: DocFX Deployment
 
-# Trigger the action on push to main
+# Trigger on push to main, but only when documentation or the API-doc sources change.
+# (API reference is generated from src/**; other churn does not affect the site.)
 on:
   push:
     branches:
       - main
+    paths:
+      - 'docfx/**'
+      - 'src/**'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -8,6 +8,11 @@ name: Code Format Check
 
 on:
   pull_request:
+    branches: [ main ]
+    paths:
+    - '**.cs'
+    - '**.csproj'
+    - '**/.editorconfig'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,9 +6,9 @@
 
 name: Generate SBOM
 
+# The SBOM is only attached to releases, so regenerate it on release (and on demand).
+# Building it on every push to main produced an SBOM that was never uploaded.
 on:
-  push:
-    branches: [main]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Trigger-scoping pass so each workflow only runs when its work is actually needed. No change to what's tested on real code changes; the CodeQL/DevSkim weekly schedules and all vulnerability/license gating are untouched.

| Workflow | Before | After |
|---|---|---|
| **sbom** | push→main + release + dispatch | **release + dispatch** — the SBOM is only uploaded on release, so every main push built one that was thrown away |
| **dependency-review** | every PR | PRs that change **`*.csproj` / `Directory.Packages.props` / `packages.lock.json`** |
| **codeql** | push→main/release (no filter) | push adds a **`**.cs`** path filter (PR side already had one) |
| **devskim** | push→main + PR (no filter) | push & PR add a **`**.cs`** path filter |
| **docfx** | every push→main | push→main touching **`docfx/**` or `src/**`** (API docs come from `src`) |
| **format-check** | every PR | PRs to **main** touching **`**.cs` / `**.csproj` / `.editorconfig`** |

## Notes

- Already well-scoped, left as-is: `copilot-setup-steps` (self-file only), `api-compat` (PR + `src/**`), `buildandtest` (tuned previously), `stale` (cheap daily cron).
- The `dependency-review` change here only touches the `on:` trigger; PR #184 changes its `with:` block (licenses) — non-overlapping, no conflict.
- All six edited workflows were validated to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)