### PR TITLE
ci: auto-label PRs based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,33 @@
+# Configuration for actions/labeler — auto-applies labels to PRs based on changed files.
+# https://github.com/actions/labeler
+
+memory:
+  - changed-files:
+    - any-glob-to-any-file: 'src/Memory/**'
+
+threading:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/Threading/**'
+      - 'src/Threading.Analyzers/**'
+
+cryptography:
+  - changed-files:
+    - any-glob-to-any-file: 'src/Security/Cryptography/**'
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docfx/**'
+      - '**/*.md'
+
+actions:
+  - changed-files:
+    - any-glob-to-any-file: '.github/workflows/**'
+
+nuget:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.csproj'
+      - 'Directory.Packages.props'
+      - 'Directory.Build.props'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+# SPDX-License-Identifier: MIT
+
+# PR Labeler
+# Automatically labels pull requests based on which files they change (see .github/labeler.yml).
+# Uses pull_request_target (not pull_request) so labels can be applied on PRs from forks;
+# this is safe here because the action only reads .github/labeler.yml from the base branch
+# and the file list of the PR — it never checks out or executes PR code.
+
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
## Summary

Adds [`actions/labeler`](https://github.com/actions/labeler) to auto-apply labels to PRs based on which files they touch, using labels already in the repo.

`.github/labeler.yml`:

| Label | Paths |
|---|---|
| `memory` | `src/Memory/**` |
| `threading` | `src/Threading/**`, `src/Threading.Analyzers/**` |
| `cryptography` | `src/Security/Cryptography/**` |
| `documentation` | `docfx/**`, `**/*.md` |
| `actions` | `.github/workflows/**` |
| `nuget` | `**/*.csproj`, `Directory.Packages.props`, `Directory.Build.props` |

## Why `pull_request_target`

The workflow uses `pull_request_target` instead of `pull_request` so labeling also works on PRs opened from forks (which don't get write-token access under `pull_request`). This is the pattern GitHub documents as safe for `actions/labeler`: the job never checks out or executes PR code — it only reads `.github/labeler.yml` from the base branch and the PR's changed-file list via the API.

## Notes

- Both files validated to parse; label config matches names already present in the repo (`memory`, `threading`, `cryptography`, `documentation`, `actions`, `nuget`) — no new labels created.
- `sync-labels` left at its default (`false`), so the action only adds labels; it won't remove a label a maintainer added by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)