### PR TITLE
Reduce Azure Pipelines runs and add missing cancel-in-progress

### DIFF
--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -13,6 +13,10 @@ on:
       - 'src/**/*.csproj'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,10 @@ on:
     - '**/Directory.Packages.props'
     - '**/packages.lock.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -17,6 +17,10 @@ on:
   schedule:
     - cron: '17 22 * * 2'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: DevSkim

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -15,6 +15,10 @@ on:
     - '**/.editorconfig'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,27 +2,33 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+# CI (push) trigger: full pipeline only for main/release branches. Feature-branch pushes are
+# still fully validated via the pr: trigger below when a PR is open; restricting this trigger
+# avoids running the whole multi-stage pipeline a second time on every push to an open PR's
+# source branch (previously: push trigger + pr trigger both fired for the same commit).
 trigger:
   batch: 'true'
   branches:
     include:
-    - '*'
+    - main
+    - releases/*
   paths:
-    include:
-    - '*' 
     exclude:
-    - 'docs/*' 
-    - 'docfx/*' 
-    - '*.md' 
+    # '**' matches nested folders too, unlike a bare '*' which only matches direct children.
+    - docfx/**
+    - .github/**
+    - '**/*.md'
 
-pr: 
+pr:
   autoCancel: 'true'
   branches:
     include:
     - '*'
   paths:
-    include:
-    - '*' 
+    exclude:
+    - docfx/**
+    - .github/**
+    - '**/*.md'
 
 variables:
   FullBuild: ${{ or(ne(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'False')) }}


### PR DESCRIPTION
## Summary

Two-part CI hygiene pass: reduce redundant Azure Pipelines runs, and audit both CI systems for proper cancel-on-push behavior.

### Azure Pipelines (`azure-pipelines.yml`)

- **CI (push) trigger restricted to `main` and `releases/*`** (was every branch, `'*'`). This was the biggest source of waste: pushing to an open PR's source branch fired the *entire* multi-stage pipeline **twice** — once via the push trigger (full build+test matrix across every TFM/OS, since `Build.Reason != 'PullRequest'`) and once via the `pr:` trigger. Feature branches remain fully covered by the `pr:` trigger, which still targets all branches.
- **Fixed path excludes to actually be recursive.** `docfx/*` and `docs/*` only match direct children in Azure's glob syntax — nested files (e.g. anything under `docfx/packages/**`, which is most of the doc content) were **not** excluded, so most doc-only changes still triggered the full pipeline. Replaced with `docfx/**`, added `.github/**` (GitHub-only files never affect the Azure build) and broadened `*.md` to `**/*.md`. Applied identically to the `pr:` trigger.
- `batch: true` and `pr.autoCancel: true` were already correctly set and are unchanged. Confirmed against current Azure DevOps docs: there is no further "cancel in-progress" mechanism for CI *push* triggers on Azure Pipelines — batching (coalescing pending pushes into one run after the current one finishes) is the platform's only lever there. `pr.autoCancel` is the real cancel-in-progress equivalent, and it's already on.

### GitHub Actions concurrency audit

| Workflow | Before | After |
|---|---|---|
| `buildandtest.yml` | ✅ already had `cancel-in-progress: true` | unchanged |
| `codeql-analysis.yml` | ✅ already had it | unchanged |
| `docfx.yml` | `cancel-in-progress: false` (intentional — Pages deploys shouldn't be interrupted) | unchanged |
| `api-compat.yml` | ❌ no concurrency group | ✅ added |
| `dependency-review.yml` | ❌ none | ✅ added |
| `devskim.yml` | ❌ none | ✅ added |
| `format-check.yml` | ❌ none | ✅ added |
| `labeler.yml` | ❌ none | ✅ added (PR-number-based group; `pull_request_target` has no useful `github.ref`) |
| `copilot-setup-steps.yml` | ❌ none | ✅ added, for consistency |
| `sbom.yml` | none | left as-is — release/dispatch-only, no realistic overlap |
| `stale.yml` | none | left as-is — daily cron only |

Without a concurrency group, repeated pushes to the same PR were piling up redundant concurrent runs instead of cancelling the stale one — same class of waste as the Azure double-trigger issue, just within GitHub Actions.

## Verification

- Confirmed via the GitHub API that no branch ruleset or protection currently requires any of these checks, so tightening triggers carries no risk of a required check getting stuck pending (same due-diligence as the earlier `buildandtest.yml` path-filtering change).
- All edited YAML files (`azure-pipelines.yml` + 6 workflow files) validated to parse correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)