### PR TITLE
Reduce nuget-artifact pipeline runs and harden its supply chain

### DIFF
--- a/.azurepipelines/nuget.yml
+++ b/.azurepipelines/nuget.yml
@@ -58,7 +58,10 @@ jobs:
     displayName: Install NuGetKeyVaultSignTool
   - task: NuGetToolInstaller@1
     inputs:
-      versionSpec: '>=5.8.x'
+      # Pinned exact version: an open-ended range (was '>=5.8.x') resolves to whatever the
+      # newest matching NuGet.exe is on dist.nuget.org at run time, since Microsoft-hosted
+      # agents start with an empty tool cache - i.e. an unpinned supply-chain dependency.
+      versionSpec: '7.6.0'
   - task: PowerShell@2
     displayName: Versioning
     inputs:
@@ -109,7 +112,6 @@ jobs:
   - task: CmdLine@2
     displayName: Sign Nuget packages
     condition: and(succeeded(), ne( variables['SigningClientSecret'], ''))
-    continueOnError: true
     inputs:
       script: |
         NuGetKeyVaultSignTool sign $(Build.ArtifactStagingDirectory)/**/CryptoHives.*.nupkg --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --timestamp-digest sha256 --azure-key-vault-url "$(SigningVaultURL)" --azure-key-vault-client-id "$(SigningClientId)" --azure-key-vault-tenant-id "$(SigningTenantId)" --azure-key-vault-client-secret "$(SigningClientSecret)" --azure-key-vault-certificate "$(SigningCertName)" 

--- a/azure-pipelines-nuget.yml
+++ b/azure-pipelines-nuget.yml
@@ -4,13 +4,27 @@
 
 pr: none
 
+# NOTE: Azure Pipelines lets a project's pipeline settings UI override this trigger entirely
+# ("... > Triggers > Override the YAML trigger from here"). If this pipeline doesn't seem to
+# react to the changes below, check that setting first - the YAML below is otherwise ignored.
 trigger:
+  batch: 'true'
   branches:
     include:
     - main
   paths:
     include:
+    # Package sources and per-package docs/PORTING.md (packed into the .nupkg, see PackagePath).
     - 'src/'
+    # Anything that affects the built/packed output but lives outside src/.
+    - 'Directory.Build.props'
+    - 'Directory.Packages.props'
+    - 'common.props'
+    - 'targets.props'
+    - 'version.props'
+    - 'azure-pipelines-nuget.yml'
+    - '.azurepipelines/nuget.yml'
+    - '.azurepipelines/set-version.ps1'
 
 parameters:
 - name: debugbuild


### PR DESCRIPTION
## Summary
- **Fewer/more-correct runs**: added `batch: true` so rapid pushes to `main` coalesce into a single packaging run, and widened the `paths` filter beyond `src/` to include the root files that affect the packed output but live outside it (`Directory.Build.props`, `Directory.Packages.props`, `common.props`, `targets.props`, `version.props`) plus the pipeline definitions themselves — previously a dependency/version bump or a template edit wouldn't trigger a validating run at all.
- **Heads-up on Azure DevOps behavior**: the project's pipeline settings UI ("... > Triggers > Override the YAML trigger from here") can override this trigger entirely, making any YAML trigger edit a silent no-op. Left an inline comment; worth a quick check in the UI that this isn't enabled for this pipeline.
- **Supply-chain hardening** in `.azurepipelines/nuget.yml`:
  - Pinned `NuGetToolInstaller` to an exact version (`7.6.0`, current latest stable per `dist.nuget.org`) instead of the open-ended `>=5.8.x` range. Microsoft-hosted agents start with an empty tool cache each run, so the floating range resolved to whatever NuGet.exe was newest at build time — an unpinned dependency in a pipeline that produces signed packages, inconsistent with the exact pins already used for `azuresigntool`/`NuGetKeyVaultSignTool`.
  - Removed `continueOnError: true` from the NuGet package signing step, so a signing failure now fails the build loudly instead of silently publishing unsigned packages to the internal feed under what looks like a "signed" run. (No active signing cert is configured right now, so this step is currently a no-op either way, but it's the right posture for when one is added.)

Not changed: the strong-name key download (identity only, not a security boundary) and `allowPackageConflicts: true` on the feed push (left as-is — internal preview feed, versions are unique per commit via NBGV, and this only matters on same-commit re-runs).

## Test plan
- [x] Both modified YAML files validated with `yaml.safe_load`
- [ ] Confirm in Azure DevOps pipeline settings that "Override the YAML trigger from here" is not enabled for this pipeline
- [ ] Push a change touching only `Directory.Packages.props` and confirm the pipeline now triggers
- [ ] Verify a normal `src/` change still triggers the pipeline as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)