### PR TITLE
Add `ISegmentOwner<T>` segment ownership primitives to Memory package

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ Pooled buffer management for transformation pipelines and high-frequency I/O:
 - `ArrayPoolMemoryStream` — drop-in `MemoryStream` replacement backed by `ArrayPool<byte>`, with `ReadOnlySequence` handoff support
 - `ReadOnlySequenceMemoryStream` — reads a `ReadOnlySequence<byte>` as a `MemoryStream` without copying
 - `ArrayPoolBufferWriter<T>` — `IBufferWriter<T>` over pooled arrays, e.g. for `Utf8JsonWriter`
-- Ownership primitives for zero-copy handoff of pooled buffers
+- `ISegmentOwner<T>` — ownership contract for `ArraySegment<T>` with three built-in strategies:
+  - `PooledSegment<T>` — rents from `ArrayPool<T>.Shared`, returns on dispose
+  - `AllocatedSegment<T>` — wraps a GC-managed `T[]`, no pool lifecycle
+  - `EmptySegment<T>` — zero-allocation null-object sentinel
 
 ### 🚀 Concurrency Tools (Threading)
 Async-compatible synchronization primitives built on `ObjectPool` and `ValueTask<T>`, designed to keep `Task` / `TaskCompletionSource<T>` allocations off the hot path.
@@ -120,10 +123,10 @@ Measured with BenchmarkDotNet across a range of payload sizes, comparing our man
 │    BufferWriter<T> │   │ AsyncManualResetEvent │   │  TurboSHAKE · KT128/256    │
 │ ReadOnlySequence-  │   │ AsyncReaderWriterLock │   │  ParallelHash (SP 800-185) │
 │    MemoryStream    │   │ AsyncBarrier          │   │  KMAC128 · KMAC256         │
-│ Ownership          │   │ AsyncCountdownEvent   │   │  Keccak · BLAKE2 · BLAKE3  │
-│    Primitives      │   │                       │   │  Ascon · Regional · Legacy │
-│                    │   │ IValueTaskSource<T>   │   │                            │
-│                    │   │    backed by          │   │ MAC                        │
+│ ISegmentOwner<T>   │   │ AsyncCountdownEvent   │   │  Keccak · BLAKE2 · BLAKE3  │
+│  PooledSegment     │   │                       │   │  Ascon · Regional · Legacy │
+│  AllocatedSegment  │   │ IValueTaskSource<T>   │   │                            │
+│  EmptySegment      │   │    backed by          │   │ MAC                        │
 │                    │   │   ObjectPool<T>       │   │  HMAC · KMAC               │
 │                    │   │                       │   │  AES-CMAC · AES-GMAC       │
 │                    │   │                       │   │  Poly1305 · BLAKE2/3       │
@@ -296,3 +299,4 @@ Issues and pull requests are welcome. Please read the [Contributing Guide](https
 ---
 
 © 2026 The Keepers of the CryptoHives
+

--- a/docfx/packages/memory/allocatedsegment.md
+++ b/docfx/packages/memory/allocatedsegment.md
@@ -1,0 +1,122 @@
+﻿# AllocatedSegment&lt;T&gt; Class
+
+An [`ISegmentOwner<T>`](isegmentowner.md) that wraps a GC-managed `T[]` in an
+`ArraySegment<T>`. The underlying array is collected by the garbage collector;
+`Dispose` only clears the segment wrapper.
+
+## Namespace
+
+```csharp
+CryptoHives.Foundation.Memory.Buffers
+```
+
+## Inheritance
+
+`Object` → **`AllocatedSegment<T>`**
+
+## Implements
+
+- [`ISegmentOwner<T>`](isegmentowner.md)
+- `IDisposable`
+
+## Syntax
+
+```csharp
+public sealed class AllocatedSegment<T> : ISegmentOwner<T>
+```
+
+## Overview
+
+Use `AllocatedSegment<T>` when you already have a heap-allocated array and want to hand it
+to code that expects `ISegmentOwner<T>`, or when a short-lived buffer is needed and pool
+lifecycle management would add unnecessary complexity.
+
+Unlike `PooledSegment<T>`, the array is not returned to any pool on dispose — it is
+eligible for GC as soon as there are no more live references to it.
+
+## Factory Method
+
+```csharp
+public static ISegmentOwner<T> Create(T[] buffer)
+```
+
+Wraps `buffer` in an `AllocatedSegment<T>` as a full-array segment (offset 0, length equal
+to `buffer.Length`).
+
+| Parameter | Description |
+|-----------|-------------|
+| `buffer` | The array to wrap. The full array is exposed as the initial segment. |
+
+**Returns** — An owner whose `Segment.Array` is the same reference as `buffer`.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Segment` | `ArraySegment<T>` | Current segment view; updated by `TrySetSegment` calls |
+
+## Methods
+
+| Method | Description |
+|--------|-------------|
+| `bool TrySetSegment(int offset, int length)` | Repositions the segment view; returns `false` if `offset + length > array.Length` |
+| `void Dispose()` | Clears `Segment` to `default`; the underlying array is unaffected |
+
+## Usage Examples
+
+### Wrapping an Existing Array
+
+```csharp
+using CryptoHives.Foundation.Memory.Buffers;
+
+byte[] data = File.ReadAllBytes(path);
+using ISegmentOwner<byte> segment = AllocatedSegment<byte>.Create(data);
+
+Process(segment);
+// Array is GC-eligible once `segment` and `data` go out of scope
+```
+
+### Narrowing the View with TrySetSegment
+
+```csharp
+byte[] raw = new byte[128];
+using ISegmentOwner<byte> segment = AllocatedSegment<byte>.Create(raw);
+
+// Focus on bytes 8..39 (offset=8, length=32)
+if (segment.TrySetSegment(8, 32))
+{
+    Span<byte> slice = segment.Segment.AsSpan();
+    ReadHeader(slice);
+}
+```
+
+### Indexed Access
+
+```csharp
+using ISegmentOwner<byte> segment = AllocatedSegment<byte>.Create(new byte[4]);
+segment[0] = 0xDE;
+segment[1] = 0xAD;
+segment[2] = 0xBE;
+segment[3] = 0xEF;
+```
+
+## Remarks
+
+- `Create` does **not** copy the array; the `Segment.Array` reference is the same object
+  passed in.
+- Writes via the indexer are immediately visible through the original array reference.
+- Calling `Dispose` more than once is safe.
+- After `Dispose`, `Segment.Array` is `null`, but the array itself is unchanged.
+
+## See Also
+
+- [`ISegmentOwner<T>`](isegmentowner.md)
+- [`PooledSegment<T>`](pooledsegment.md)
+- [`EmptySegment<T>`](emptysegment.md)
+- [Memory Package Overview](index.md)
+
+---
+
+© 2026 The Keepers of the CryptoHives
+
+

--- a/docfx/packages/memory/emptysegment.md
+++ b/docfx/packages/memory/emptysegment.md
@@ -1,0 +1,114 @@
+﻿# EmptySegment&lt;T&gt; Class
+
+An [`ISegmentOwner<T>`](isegmentowner.md) that represents an empty, zero-allocation segment
+backed by `Array.Empty<T>()`. Useful as a null-object sentinel that avoids `null` checks.
+
+## Namespace
+
+```csharp
+CryptoHives.Foundation.Memory.Buffers
+```
+
+## Inheritance
+
+`Object` → **`EmptySegment<T>`**
+
+## Implements
+
+- [`ISegmentOwner<T>`](isegmentowner.md)
+- `IDisposable`
+
+## Syntax
+
+```csharp
+public sealed class EmptySegment<T> : ISegmentOwner<T>
+```
+
+## Overview
+
+`EmptySegment<T>` follows the null-object pattern: it satisfies the `ISegmentOwner<T>`
+contract without allocating any array. All index access throws, `TrySetSegment` always
+returns `false`, and `Dispose` is a no-op.
+
+The singleton `Instance` property returns the single shared instance — no allocation is
+ever needed.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Instance` | `ISegmentOwner<T>` | The shared empty segment singleton |
+| `Segment` | `ArraySegment<T>` | Always an empty segment (`Count == 0`, `Offset == 0`) |
+
+## Methods
+
+| Method | Description |
+|--------|-------------|
+| `bool TrySetSegment(int offset, int length)` | Always returns `false`; an empty segment cannot be resized |
+| `void Dispose()` | No-op; safe to call any number of times |
+
+## Usage Examples
+
+### Default / Uninitialized State
+
+```csharp
+using CryptoHives.Foundation.Memory.Buffers;
+
+public class Pipeline
+{
+    private ISegmentOwner<byte> _segment = EmptySegment<byte>.Instance;
+
+    public void Setsegment(ISegmentOwner<byte> segment)
+    {
+        _segment = segment;
+    }
+
+    public void Run()
+    {
+        // No null check needed — EmptySegment.Segment.Count == 0
+        if (_segment.Segment.Count == 0)
+            return;
+
+        Span<byte> data = _segment.Segment.AsSpan();
+        // ...
+    }
+}
+```
+
+### Guard Against Null segment Parameters
+
+```csharp
+void Process(ISegmentOwner<byte> segment)
+{
+    // Accept EmptySegment as a valid "nothing to do" signal
+    if (segment.Segment.Count == 0)
+        return;
+
+    // ...
+}
+
+// Call with an explicit empty segment — no null reference risk
+Process(EmptySegment<byte>.Instance);
+```
+
+## Remarks
+
+- Accessing the indexer (`this[int]`) always throws `ArgumentOutOfRangeException`; the
+  segment is empty and has no elements.
+- `TrySetSegment` always returns `false` regardless of arguments; the empty segment
+  intentionally cannot be resized.
+- The singleton `Instance` is created once and reused — use it freely without allocation
+  concern.
+
+## See Also
+
+- [`ISegmentOwner<T>`](isegmentowner.md)
+- [`PooledSegment<T>`](pooledsegment.md)
+- [`AllocatedSegment<T>`](allocatedsegment.md)
+- [Memory Package Overview](index.md)
+
+---
+
+© 2026 The Keepers of the CryptoHives
+
+

--- a/docfx/packages/memory/index.md
+++ b/docfx/packages/memory/index.md
@@ -1,4 +1,4 @@
-# CryptoHives.Foundation.Memory Package
+﻿# CryptoHives.Foundation.Memory Package
 
 Buffer management utilities for .NET, built on `ArrayPool<T>` and the modern .NET memory APIs to keep allocations and GC pressure out of high-throughput code.
 
@@ -24,6 +24,15 @@ using CryptoHives.Foundation.Memory.Pools;
 | [ArrayPoolMemoryStream](arraypoolmemorystream.md) | Memory stream using pooled buffers | [Details](arraypoolmemorystream.md) |
 | [ArrayPoolBufferWriter&lt;T&gt;](arraypoolbufferwriter.md) | IBufferWriter implementation with pooled chunks | [Details](arraypoolbufferwriter.md) |
 | [ReadOnlySequenceMemoryStream](readonlysequencememorystream.md) | Stream wrapper for ReadOnlySequence | [Details](readonlysequencememorystream.md) |
+
+### segment Ownership
+
+| Class | Description | Documentation |
+|-------|-------------|---------------|
+| [ISegmentOwner&lt;T&gt;](isegmentowner.md) | Ownership interface for an `ArraySegment<T>` | [Details](isegmentowner.md) |
+| [PooledSegment&lt;T&gt;](pooledsegment.md) | Rents from `ArrayPool<T>.Shared`; returns on dispose | [Details](pooledsegment.md) |
+| [AllocatedSegment&lt;T&gt;](allocatedsegment.md) | Wraps a GC-managed `T[]`; no pool return | [Details](allocatedsegment.md) |
+| [EmptySegment&lt;T&gt;](emptysegment.md) | Zero-allocation null-object sentinel | [Details](emptysegment.md) |
 
 ### Object Pool Utilities
 
@@ -87,6 +96,25 @@ MyClass obj = owner.Object;
 // Automatically returned to the pool when owner is disposed
 ```
 
+### segment Ownership
+
+```csharp
+using CryptoHives.Foundation.Memory.Buffers;
+
+// Pool-backed buffer — returned to ArrayPool on dispose
+using ISegmentOwner<byte> pooled = PooledSegment<byte>.Rent(256);
+Span<byte> span = pooled.Segment.AsSpan();
+// fill span ...
+
+// Wrap an existing array with no pool lifecycle
+byte[] existing = new byte[256];
+using ISegmentOwner<byte> alloc = AllocatedSegment<byte>.Create(existing);
+
+// Empty sentinel — avoids null checks
+ISegmentOwner<byte> none = EmptySegment<byte>.Instance;
+if (none.Segment.Count == 0) { /* nothing to process */ }
+```
+
 ## Why Pooled Buffers
 
 Renting from `ArrayPool<T>.Shared` instead of allocating avoids resize-copy churn and keeps large buffers off the Large Object Heap, which matters once you're pushing enough throughput that allocations start showing up in GC pauses. `ReadOnlySequence<T>` then lets you hand that pooled data to a consumer without copying it at all.
@@ -109,3 +137,5 @@ Renting from `ArrayPool<T>.Shared` instead of allocating avoids resize-copy chur
 ---
 
 © 2026 The Keepers of the CryptoHives
+
+

--- a/docfx/packages/memory/index.md
+++ b/docfx/packages/memory/index.md
@@ -1,4 +1,4 @@
-﻿# CryptoHives.Foundation.Memory Package
+# CryptoHives.Foundation.Memory Package
 
 Buffer management utilities for .NET, built on `ArrayPool<T>` and the modern .NET memory APIs to keep allocations and GC pressure out of high-throughput code.
 
@@ -25,7 +25,7 @@ using CryptoHives.Foundation.Memory.Pools;
 | [ArrayPoolBufferWriter&lt;T&gt;](arraypoolbufferwriter.md) | IBufferWriter implementation with pooled chunks | [Details](arraypoolbufferwriter.md) |
 | [ReadOnlySequenceMemoryStream](readonlysequencememorystream.md) | Stream wrapper for ReadOnlySequence | [Details](readonlysequencememorystream.md) |
 
-### segment Ownership
+### Segment Ownership
 
 | Class | Description | Documentation |
 |-------|-------------|---------------|
@@ -96,7 +96,7 @@ MyClass obj = owner.Object;
 // Automatically returned to the pool when owner is disposed
 ```
 
-### segment Ownership
+### Segment Ownership
 
 ```csharp
 using CryptoHives.Foundation.Memory.Buffers;

--- a/docfx/packages/memory/isegmentowner.md
+++ b/docfx/packages/memory/isegmentowner.md
@@ -1,0 +1,133 @@
+# ISegmentOwner&lt;T&gt; Interface
+
+`ISegmentOwner<T>` complements `IMemoryOwner<T>` with a unified ownership contract for an
+`ArraySegment<T>` that controls the lifetime of its underlying memory. 
+Implementors decide how to acquire and release that memory (pool return,
+GC collection, or no-op), while callers use a single consistent API.
+In conjunction with `ArrayPool<T>`, an allocated `ArraySegment<T>` has the advantage 
+that the underlying buffer is adjustable in terms of the offset and the size of the segment without 
+losing the ownership of the underlying pooled buffer. 
+Due to the simple conversion to `Span<T>` and `Memory<T>`, 
+it is easy to use in the hot path of the code.
+
+## Namespace
+
+```csharp
+CryptoHives.Foundation.Memory.Buffers
+```
+
+## Inheritance
+
+`IDisposable` → **`ISegmentOwner<T>`**
+
+## Syntax
+
+```csharp
+public interface ISegmentOwner<T> : IDisposable
+```
+
+## Type Parameters
+
+**`T`** — The element type of the segment.
+
+## Overview
+
+`ISegmentOwner<T>` bundles three concerns:
+
+| Concern | Member |
+|---------|--------|
+| Data access | `Segment` property and `this[int]` indexer |
+| Slice adjustment | `TrySetSegment(offset, length)` |
+| Lifetime management | `Dispose()` (from `IDisposable`) |
+
+Three built-in implementations cover the most common ownership strategies:
+
+| Class | Memory source | Dispose behaviour |
+|-------|--------------|-------------------|
+| [`PooledSegment<T>`](pooledsegment.md) | `ArrayPool<T>.Shared` | Returns array to pool |
+| [`AllocatedSegment<T>`](allocatedsegment.md) | `new T[]` (GC heap) | Clears the segment wrapper |
+| [`EmptySegment<T>`](emptysegment.md) | `Array.Empty<T>()` | No-op |
+
+## Members
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Segment` | `ArraySegment<T>` | The current segment view of the underlying array |
+
+### Indexer
+
+```csharp
+T this[int i] { get; set; }
+```
+
+Gets or sets element `i` relative to `Segment.Offset` inside `Segment.Array`.
+
+### Methods
+
+```csharp
+bool TrySetSegment(int offset, int length);
+```
+
+Narrows or repositions the segment view. Returns `true` on success; `false` when the
+underlying array is `null` or too small to satisfy `offset + length`.
+
+```csharp
+void Dispose();
+```
+
+Releases ownership of the underlying memory according to the concrete implementation.
+
+## Usage
+
+### Consuming code
+
+Write consumer code against `ISegmentOwner<T>` and let the caller decide the ownership
+strategy via the concrete factory:
+
+```csharp
+void Process(ISegmentOwner<byte> owner)
+{
+    Span<byte> span = owner.Segment.AsSpan();
+    // ... work with span ...
+}
+
+// Caller chooses ArrayPool (cheap in hot path)
+using ISegmentOwner<byte> pooled = PooledSegment<byte>.Rent(1024);
+Process(pooled);
+
+// Or GC-managed array (simple, no pool lifecycle to track)
+using ISegmentOwner<byte> alloc = AllocatedSegment<byte>.Create(new byte[1024]);
+Process(alloc);
+```
+
+### Slicing after rent
+
+```csharp
+using ISegmentOwner<byte> segment = PooledSegment<byte>.Rent(256);
+
+if (segment.TrySetSegment(offset: 16, length: 64))
+{
+    // Segment is now [16..80) inside the rented array
+    Span<byte> slice = segment.Segment.AsSpan();
+    DecryptPayload(slice);
+}
+```
+
+## Thread Safety
+
+Instances are **not thread-safe**. The intended pattern is single-owner, short-lived, scoped with `using`.
+
+## See Also
+
+- [PooledSegment&lt;T&gt;](pooledsegment.md)
+- [AllocatedSegment&lt;T&gt;](allocatedsegment.md)
+- [EmptySegment&lt;T&gt;](emptysegment.md)
+- [Memory Package Overview](index.md)
+
+---
+
+© 2026 The Keepers of the CryptoHives
+
+

--- a/docfx/packages/memory/pooledsegment.md
+++ b/docfx/packages/memory/pooledsegment.md
@@ -1,0 +1,126 @@
+﻿# PooledSegment&lt;T&gt; Class
+
+An [`ISegmentOwner<T>`](isegmentowner.md) that rents a buffer from `ArrayPool<T>.Shared`
+and returns it automatically on dispose.
+
+## Namespace
+
+```csharp
+CryptoHives.Foundation.Memory.Buffers
+```
+
+## Inheritance
+
+`Object` → **`PooledSegment<T>`**
+
+## Implements
+
+- [`ISegmentOwner<T>`](isegmentowner.md)
+- `IDisposable`
+
+## Syntax
+
+```csharp
+public sealed class PooledSegment<T> : ISegmentOwner<T>
+```
+
+## Overview
+
+`PooledSegment<T>` is the right choice whenever you need a temporary, right-sized buffer
+that should go back to the pool once work is done. It wraps the rented array in an
+`ArraySegment<T>` so the actual rented length (which `ArrayPool<T>` may round up) is hidden
+behind a clean `Count == minimumLength` view.
+
+Implemented as a `sealed class` so the backing array can never be disposed more than once
+by an unintended struct copy.
+
+## Factory Method
+
+```csharp
+public static ISegmentOwner<T> Rent(int minimumLength)
+```
+
+Rents a buffer with at least `minimumLength` elements from `ArrayPool<T>.Shared` and
+returns it wrapped in an `PooledSegment<T>`.
+
+| Parameter | Description |
+|-----------|-------------|
+| `minimumLength` | The minimum number of elements required |
+
+**Returns** — An owner whose `Segment.Count` equals `minimumLength`.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Segment` | `ArraySegment<T>` | Current segment view (offset and length track `TrySetSegment` calls) |
+
+## Methods
+
+| Method | Description |
+|--------|-------------|
+| `bool TrySetSegment(int offset, int length)` | Repositions the segment view; returns `false` if `offset + length > array.Length` |
+| `void Dispose()` | Returns the rented array to `ArrayPool<T>.Shared` and resets `Segment` to `default` |
+
+## Usage Examples
+
+### Basic Rent and Use
+
+```csharp
+using CryptoHives.Foundation.Memory.Buffers;
+
+using ISegmentOwner<byte> segment = PooledSegment<byte>.Rent(1024);
+
+Span<byte> buffer = segment.Segment.AsSpan();
+int written = encoder.GetBytes(text, buffer);
+
+// Use only the filled portion
+ProcessData(buffer[..written]);
+
+// Rented array is returned to the pool when segment is disposed
+```
+
+### Narrowing the View with TrySetSegment
+
+```csharp
+using ISegmentOwner<byte> segment = PooledSegment<byte>.Rent(256);
+
+// Skip a 4-byte header and work on 64 data bytes
+if (segment.TrySetSegment(offset: 4, length: 64))
+{
+    Span<byte> data = segment.Segment.AsSpan();
+    FillData(data);
+}
+```
+
+### Indexed Access
+
+```csharp
+using ISegmentOwner<byte> segment = PooledSegment<byte>.Rent(4);
+segment[0] = 0x01;
+segment[1] = 0x02;
+segment[2] = 0x03;
+segment[3] = 0x04;
+```
+
+## Remarks
+
+- The backing array rented from `ArrayPool<T>.Shared` may be larger than `minimumLength`;
+  `Segment.Count` always reflects the requested length.
+- In `DEBUG` builds the array is cleared on return (aids leak detection). Release builds
+  skip the clear for performance.
+- Calling `Dispose` more than once is safe; subsequent calls are no-ops.
+- After `Dispose`, `Segment.Array` is `null`.
+
+## See Also
+
+- [`ISegmentOwner<T>`](isegmentowner.md)
+- [`AllocatedSegment<T>`](allocatedsegment.md)
+- [`EmptySegment<T>`](emptysegment.md)
+- [Memory Package Overview](index.md)
+
+---
+
+© 2026 The Keepers of the CryptoHives
+
+

--- a/docfx/packages/memory/toc.yml
+++ b/docfx/packages/memory/toc.yml
@@ -1,4 +1,4 @@
-- name: Memory Package
+﻿- name: Memory Package
   href: index.md
 - name: Classes
   items:
@@ -12,3 +12,14 @@
       href: objectowner.md
     - name: ObjectPools
       href: objectpools.md
+- name: Segment Ownership
+  items:
+    - name: ISegmentOwner<T>
+      href: isegmentowner.md
+    - name: PooledSegment<T>
+      href: pooledsegment.md
+    - name: AllocatedSegment<T>
+      href: allocatedsegment.md
+    - name: EmptySegment<T>
+      href: emptysegment.md
+

--- a/docfx/porting-to-cryptohives.md
+++ b/docfx/porting-to-cryptohives.md
@@ -228,6 +228,77 @@ Critical rules:
 - Whatever you got from `PooledObject` must not be used after the `using` scope ends (it has
   been returned to the pool).
 
+### 3.5 `ISegmentOwner<T>` — segment ownership primitives
+
+`using CryptoHives.Foundation.Memory.Buffers;`
+
+`ISegmentOwner<T>` is the `ArraySegment<T>` counterpart to the BCL's `IMemoryOwner<T>`.
+Use it when code passes a fixed-size, directly-addressable buffer and the caller needs to
+control whether the backing memory comes from a pool, the GC heap, or is simply empty.
+
+#### Replacement table
+
+| Existing pattern | Replace with |
+|---|---|
+| `ArrayPool<T>.Shared.Rent(n)` + manual `Return` | `PooledSegment<T>.Rent(n)` |
+| `new T[n]` handed across an ownership boundary | `AllocatedSegment<T>.Create(buffer)` |
+| `null` or zero-length array as "no data" sentinel | `EmptySegment<T>.Instance` |
+| `IMemoryOwner<T>` where `ArraySegment<T>` is preferred | `ISegmentOwner<T>` |
+
+#### Choosing the right implementation
+
+| Class | Memory source | When to use |
+|---|---|---|
+| `PooledSegment<T>` | `ArrayPool<T>.Shared` | Hot-path, short-lived, fixed-size buffers where you want pool reuse. |
+| `AllocatedSegment<T>` | `new T[]` (GC heap) | You already have an array and just need a uniform ownership wrapper. |
+| `EmptySegment<T>` | `Array.Empty<T>()` singleton | Default/uninitialized state; avoids `null` checks in consumers. |
+
+#### Patterns
+
+```csharp
+using CryptoHives.Foundation.Memory.Buffers;
+
+// PooledSegment<T> — pool-backed, Segment.Count == minimumLength
+using ISegmentOwner<byte> seg = PooledSegment<byte>.Rent(256);
+Span<byte> span = seg.Segment.AsSpan();
+FillData(span);
+// narrow the view without reallocating (returns false if out-of-range):
+if (seg.TrySetSegment(offset: 16, length: 64))
+    Send(seg.Segment.AsSpan());
+// rented array is returned to ArrayPool on dispose
+
+// AllocatedSegment<T> — wraps an existing GC-managed array, no pool
+byte[] raw = new byte[256];
+using ISegmentOwner<byte> alloc = AllocatedSegment<byte>.Create(raw);
+Process(alloc.Segment.AsSpan());
+// only the wrapper is cleared on Dispose; the array itself is unchanged
+
+// EmptySegment<T> — null-object sentinel
+ISegmentOwner<byte> none = EmptySegment<byte>.Instance;
+
+void Process(ISegmentOwner<byte> owner)
+{
+    if (owner.Segment.Count == 0) return;   // handles EmptySegment cleanly
+    Span<byte> data = owner.Segment.AsSpan();
+    // …
+}
+```
+
+#### Critical rules
+
+- **`PooledSegment<T>` must be `using`-scoped** — the rented array is returned to
+  `ArrayPool<T>.Shared` on dispose. Never let one escape its scope or use the segment after
+  disposal (`Segment.Array` becomes `null`).
+- **`TrySetSegment` does not resize.** It only repositions the view within the existing
+  backing array. It returns `false` when `offset + length > array.Length`; the segment is
+  unchanged. Never use it as a grow/resize operation.
+- **`EmptySegment<T>.Instance` is a permanent singleton.** Calling `Dispose` on it is a
+  no-op by design; treat it as an immutable sentinel value, not as a resource to manage.
+- **Indexer `this[int i]` is offset-aware.** `owner[i]` accesses `Segment.Array[i + Segment.Offset]`.
+  After `TrySetSegment(offset, length)`, index 0 is element `offset` in the original array.
+- For sensitive data, prefer `PooledSegment<T>` (which clears the array on return in DEBUG
+  builds) or ensure you zero the span manually before disposing.
+
 ---
 
 ## 4. Hashing (`CryptoHives.Foundation.Security.Cryptography`)
@@ -325,9 +396,11 @@ Verification checklist:
 - [ ] All existing tests pass. For hashing, add/keep a test asserting the new digest equals
       a known-answer vector or the pre-port output for representative inputs.
 - [ ] No `ValueTask` stored in a field, awaited twice, `.Result`-ed, or `WhenAll`-ed.
-- [ ] Every `ArrayPoolBufferWriter<T>`, `ArrayPoolMemoryStream`, and `ObjectOwner<T>` is in
-      a `using` scope; no pooled buffer or `ReadOnlySequence` escapes it.
+- [ ] Every `ArrayPoolBufferWriter<T>`, `ArrayPoolMemoryStream`, `PooledSegment<T>`, and
+      `ObjectOwner<T>` is in a `using` scope; no pooled buffer or `ReadOnlySequence` escapes it.
 - [ ] No `AsyncLock` used re-entrantly.
+- [ ] No code uses a `PooledSegment<T>` segment or its backing array after `Dispose`.
+- [ ] `TrySetSegment` return value is checked; it is not used as a resize/grow operation.
 
 ## 6. Report
 

--- a/src/Memory/Buffers/AllocatedSegment{T}.cs
+++ b/src/Memory/Buffers/AllocatedSegment{T}.cs
@@ -1,0 +1,63 @@
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Memory.Buffers;
+
+using System;
+
+/// <summary>
+/// An <see cref="ISegmentOwner{T}"/> that wraps a GC-managed <typeparamref name="T"/> array
+/// in an <see cref="ArraySegment{T}"/>. The underlying array is eligible for garbage collection;
+/// <see cref="Dispose"/> only clears the segment wrapper.
+/// </summary>
+public sealed class AllocatedSegment<T> : ISegmentOwner<T>
+{
+    private AllocatedSegment(ArraySegment<T> segment)
+    {
+        Segment = segment;
+    }
+
+    /// <inheritdoc/>
+    public ArraySegment<T> Segment { get; private set; }
+
+    /// <inheritdoc/>
+    public T this[int i]
+    {
+        get => Segment.Array![i + Segment.Offset];
+        set => Segment.Array![i + Segment.Offset] = value;
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="buffer"/> in an <see cref="AllocatedSegment{T}"/> covering the
+    /// full array (offset 0, length equal to the array length). No copy is made.
+    /// </summary>
+    /// <param name="buffer">The array to wrap.</param>
+    /// <returns>
+    /// An <see cref="ISegmentOwner{T}"/> whose <see cref="ISegmentOwner{T}.Segment"/> references
+    /// the same array as <paramref name="buffer"/>. The segment wrapper is cleared on dispose;
+    /// the array itself is unaffected and remains eligible for GC.
+    /// </returns>
+    public static ISegmentOwner<T> Create(T[] buffer)
+    {
+        return new AllocatedSegment<T>(new ArraySegment<T>(buffer));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Segment = default;
+    }
+
+    /// <inheritdoc/>
+    public bool TrySetSegment(int offset, int length)
+    {
+        var array = Segment.Array;
+        if (array?.Length >= offset + length)
+        {
+            Segment = new ArraySegment<T>(array, offset, length);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Memory/Buffers/EmptySegment{T}.cs
+++ b/src/Memory/Buffers/EmptySegment{T}.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Memory.Buffers;
+
+using System;
+
+/// <summary>
+/// An <see cref="ISegmentOwner{T}"/> that represents an empty, zero-allocation segment
+/// backed by <see cref="Array.Empty{T}"/>. Follows the null-object pattern to avoid
+/// <see langword="null"/> checks in consumers.
+/// </summary>
+public sealed class EmptySegment<T> : ISegmentOwner<T>
+{
+    private EmptySegment(ArraySegment<T> segment)
+    {
+        Segment = segment;
+    }
+
+    /// <summary>
+    /// Gets the shared empty segment singleton. No allocation is ever needed.
+    /// </summary>
+    public static ISegmentOwner<T> Instance { get; } = new EmptySegment<T>(new ArraySegment<T>(Array.Empty<T>()));
+
+    /// <inheritdoc/>
+    public ArraySegment<T> Segment { get; private set; }
+
+    /// <inheritdoc/>
+    public T this[int i]
+    {
+        get => throw new ArgumentOutOfRangeException(nameof(i), "Empty segment has no elements.");
+        set => throw new ArgumentOutOfRangeException(nameof(i), "Empty segment has no elements.");
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+
+    /// <inheritdoc/>
+    public bool TrySetSegment(int offset, int length)
+    {
+        return false;
+    }
+}

--- a/src/Memory/Buffers/ISegmentOwner{T}.cs
+++ b/src/Memory/Buffers/ISegmentOwner{T}.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Memory.Buffers;
+
+using System;
+
+/// <summary>
+/// Owner of an <see cref="ArraySegment{T}"/> that controls the lifetime of its
+/// underlying memory. Implementors decide the acquisition and release strategy
+/// (pool return, GC collection, or no-op) while callers use a single consistent API.
+/// </summary>
+/// <remarks>
+/// Three built-in implementations cover the most common ownership strategies:
+/// <list type="bullet">
+///   <item><description><see cref="PooledSegment{T}"/> — rents from <see cref="System.Buffers.ArrayPool{T}"/> and returns on dispose.</description></item>
+///   <item><description><see cref="AllocatedSegment{T}"/> — wraps a GC-managed array; only the segment wrapper is cleared on dispose.</description></item>
+///   <item><description><see cref="EmptySegment{T}"/> — a zero-allocation null-object sentinel.</description></item>
+/// </list>
+/// </remarks>
+public interface ISegmentOwner<T> : IDisposable
+{
+    /// <summary>
+    /// Gets the current <see cref="ArraySegment{T}"/> view of the underlying array.
+    /// </summary>
+    ArraySegment<T> Segment { get; }
+
+    /// <summary>
+    /// Gets or sets element <paramref name="i"/> relative to <see cref="ArraySegment{T}.Offset"/>
+    /// inside <see cref="ArraySegment{T}.Array"/>.
+    /// </summary>
+    /// <param name="i">Zero-based index within the current segment.</param>
+    T this[int i] { get; set; }
+
+    /// <summary>
+    /// Sets the offset and the length of the <see cref="ArraySegment{T}"/>.
+    /// </summary>
+    /// <param name="offset">The new zero-based offset into the underlying array.</param>
+    /// <param name="length">The number of elements to expose starting at <paramref name="offset"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if the segment was updated; <see langword="false"/> if the underlying
+    /// array is <see langword="null"/> or too small to satisfy the requested range.
+    /// </returns>
+    bool TrySetSegment(int offset, int length);
+}

--- a/src/Memory/Buffers/PooledSegment{T}.cs
+++ b/src/Memory/Buffers/PooledSegment{T}.cs
@@ -1,0 +1,79 @@
+﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace CryptoHives.Foundation.Memory.Buffers;
+
+using System;
+using System.Buffers;
+
+/// <summary>
+/// An <see cref="ISegmentOwner{T}"/> that rents a buffer from <see cref="ArrayPool{T}.Shared"/>
+/// and returns it automatically on dispose.
+/// </summary>
+/// <remarks>
+/// Implemented as a sealed class so the backing array can never be disposed more than once
+/// by an unintended struct copy.
+/// </remarks>
+public sealed class PooledSegment<T> : ISegmentOwner<T>
+{
+#if DEBUG
+    // for testing clear buffers when returned
+    private const bool ClearArray = true;
+#else
+    private const bool ClearArray = false;
+#endif
+
+    private PooledSegment(ArraySegment<T> segment)
+    {
+        Segment = segment;
+    }
+
+    /// <inheritdoc/>
+    public ArraySegment<T> Segment { get; private set; }
+
+    /// <inheritdoc/>
+    public T this[int i]
+    {
+        get => Segment.Array![i + Segment.Offset];
+        set => Segment.Array![i + Segment.Offset] = value;
+    }
+
+    /// <summary>
+    /// Rents a buffer with at least <paramref name="minimumLength"/> elements from
+    /// <see cref="ArrayPool{T}.Shared"/> and returns it wrapped in a <see cref="PooledSegment{T}"/>.
+    /// </summary>
+    /// <param name="minimumLength">The minimum number of elements required.</param>
+    /// <returns>
+    /// An <see cref="ISegmentOwner{T}"/> whose <see cref="ISegmentOwner{T}.Segment"/> has
+    /// <see cref="ArraySegment{T}.Count"/> equal to <paramref name="minimumLength"/>.
+    /// </returns>
+    public static ISegmentOwner<T> Rent(int minimumLength)
+    {
+        var segment = new ArraySegment<T>(ArrayPool<T>.Shared.Rent(minimumLength), 0, minimumLength);
+        return new PooledSegment<T>(segment);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        var array = Segment.Array;
+        if (array != null)
+        {
+            ArrayPool<T>.Shared.Return(array, ClearArray);
+            Segment = default;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool TrySetSegment(int offset, int length)
+    {
+        var array = Segment.Array;
+        if (array?.Length >= offset + length)
+        {
+            Segment = new ArraySegment<T>(array, offset, length);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Memory/PORTING.md
+++ b/src/Memory/PORTING.md
@@ -19,6 +19,9 @@ against the shipped source. Do not invent members. Human-oriented docs live in `
 | `new MemoryStream()` as a scratch/accumulation buffer | `ArrayPoolMemoryStream` (drop-in `MemoryStream` subclass) |
 | Copying a `ReadOnlySequence<byte>` into `byte[]` just to `new MemoryStream(bytes)` | `new ReadOnlySequenceMemoryStream(sequence)` |
 | Manual `ObjectPool<T>.Get()`/`Return()` pairs; `StringBuilder` churn | `ObjectOwner<T>` / `ObjectPools.GetStringBuilder()` |
+| `ArrayPool<T>.Shared.Rent(n)` with manual return; caller owns a fixed-size `T[]` slice | `PooledSegment<T>.Rent(n)` — same pool, no manual return |
+| `new T[n]` handed to a method that needs to signal "no data" via `null` or length 0 | `AllocatedSegment<T>.Create(buffer)` / `EmptySegment<T>.Instance` |
+| `IMemoryOwner<T>` patterns where `ArraySegment<T>` is preferred over `Memory<T>` | `ISegmentOwner<T>` |
 
 ---
 
@@ -41,6 +44,35 @@ sealed class ArrayPoolBufferWriter<T> : IBufferWriter<T>, IDisposable {
 sealed class ArrayPoolMemoryStream : MemoryStream { … }           // pooled MemoryStream; Dispose returns segments
 sealed class ReadOnlySequenceMemoryStream : MemoryStream {         // read-only Stream over an existing sequence
     ReadOnlySequenceMemoryStream(ReadOnlySequence<byte> sequence);
+}
+
+// ── Segment ownership ────────────────────────────────────────────────────────
+// ISegmentOwner<T> mirrors IMemoryOwner<T> but exposes ArraySegment<T> instead of Memory<T>.
+// Three implementations cover all ownership strategies; choose by memory source.
+
+interface ISegmentOwner<T> : IDisposable {
+    ArraySegment<T> Segment { get; }
+    T    this[int i] { get; set; }               // element access relative to Segment.Offset
+    bool TrySetSegment(int offset, int length);   // narrows/repositions the view; false if out-of-range
+}
+
+sealed class PooledSegment<T> : ISegmentOwner<T> {
+    // Rents from ArrayPool<T>.Shared; Segment.Count == minimumLength; array may be larger.
+    static ISegmentOwner<T> Rent(int minimumLength);
+    // Dispose returns the rented array to the pool and resets Segment to default.
+}
+
+sealed class AllocatedSegment<T> : ISegmentOwner<T> {
+    // Wraps an existing GC-managed T[]; no pool involved.
+    // Segment.Array is the same reference as the passed-in buffer (no copy).
+    static ISegmentOwner<T> Create(T[] buffer);
+    // Dispose clears Segment to default; the underlying array is unaffected.
+}
+
+sealed class EmptySegment<T> : ISegmentOwner<T> {
+    // Null-object singleton. Segment.Count == 0. TrySetSegment always returns false.
+    // Dispose and indexer access are no-ops / throw ArgumentOutOfRangeException.
+    static ISegmentOwner<T> Instance { get; }
 }
 
 namespace CryptoHives.Foundation.Memory.Pools;
@@ -70,6 +102,31 @@ writer.Advance(bytesWritten);
 ReadOnlySequence<byte> seq = writer.GetReadOnlySequence();   // consume before the using scope ends
 Consume(seq);
 
+// ── PooledSegment<T> — ArrayPool-backed, fixed-size ──────────────────────────
+using ISegmentOwner<byte> seg = PooledSegment<byte>.Rent(256);
+Span<byte> data = seg.Segment.AsSpan();   // Segment.Count == 256
+FillData(data);
+// narrow the view without reallocating:
+if (seg.TrySetSegment(offset: 16, length: 64))
+    Send(seg.Segment.AsSpan());
+// array returned to pool when seg is disposed
+
+// ── AllocatedSegment<T> — wrap an existing GC-managed array ─────────────────
+byte[] existing = File.ReadAllBytes(path);
+using ISegmentOwner<byte> alloc = AllocatedSegment<byte>.Create(existing);
+Process(alloc);
+// only the wrapper is cleared on Dispose; array itself is GC-eligible as usual
+
+// ── EmptySegment<T> — null-object sentinel ───────────────────────────────────
+void Process(ISegmentOwner<byte> owner)
+{
+    if (owner.Segment.Count == 0) return;   // handles EmptySegment gracefully
+    Span<byte> span = owner.Segment.AsSpan();
+    // …
+}
+ISegmentOwner<byte> none = EmptySegment<byte>.Instance;   // never null, never allocates
+Process(none);
+
 using CryptoHives.Foundation.Memory.Pools;
 
 using var owner = ObjectPools.GetStringBuilder();
@@ -82,18 +139,25 @@ StringBuilder sb = owner.PooledObject;
 ## Hard rules
 
 1. **Everything here is scope-bound. Always `using`.** `ArrayPoolBufferWriter<T>`,
-   `ArrayPoolMemoryStream`, and `ObjectOwner<T>` all return pooled memory on `Dispose`.
-   Never let one escape its scope.
+   `ArrayPoolMemoryStream`, `PooledSegment<T>`, and `ObjectOwner<T>` all return pooled
+   memory on `Dispose`. Never let one escape its scope.
 2. **The `ReadOnlySequence<T>` from `GetReadOnlySequence()` is only valid until the next
    write or `Dispose()`.** Fully consume or copy it before disposing; never return it to a
    caller that outlives the `using`.
 3. **`ObjectOwner<T>` is a `readonly struct` — never cast it to `IDisposable` and never box
    it** (double-return / boxing hazard). Use only `using var`; do not copy it.
 4. **Do not use a pooled object after its owner is disposed** — it has been returned and may
-   be handed to another caller.
+   be handed to another caller. This applies equally to `PooledSegment<T>` (array is back in
+   the pool) and `ObjectOwner<T>` (object is back in the pool).
 5. For sensitive data, construct `new ArrayPoolBufferWriter<byte>(clearArray: true, …)` so
-   buffers are zeroed on return.
-6. The pooled `PooledObject` accessor is named **`PooledObject`** (not `Object`).
+   buffers are zeroed on return. `PooledSegment<T>` clears in DEBUG builds automatically.
+6. The `ObjectOwner<T>` accessor is named **`PooledObject`** (not `Object`).
+7. **`TrySetSegment` does not reallocate.** It only repositions the view within the existing
+   backing array. If the requested range does not fit (`offset + length > array.Length`),
+   it returns `false` and the segment is unchanged. Never use it as a resize operation.
+8. **`EmptySegment<T>.Instance` is a singleton — never `Dispose` it** (the call is a no-op
+   by design, but relying on that would indicate confusion about ownership). Treat it as an
+   immutable sentinel value.
 
 ---
 

--- a/src/Memory/README.md
+++ b/src/Memory/README.md
@@ -28,6 +28,7 @@ dotnet add package CryptoHives.Foundation.Memory
 - **`IBufferWriter<T>` support** — `ArrayPoolBufferWriter<T>` works directly with `Utf8JsonWriter`, `PipeWriter`, or any other `IBufferWriter` consumer
 - **Read-only sequence streaming** — wrap an existing `ReadOnlySequence<byte>` as a `Stream` without copying
 - **RAII ownership** — `ObjectOwner<T>` returns pooled objects automatically on dispose
+- **Segment ownership primitives** — `ISegmentOwner<T>` unifies three strategies: `PooledSegment<T>` rents from `ArrayPool<T>`, `AllocatedSegment<T>` wraps GC-managed arrays, and `EmptySegment<T>` is a zero-allocation null-object sentinel
 
 ---
 
@@ -98,6 +99,31 @@ MyExpensiveObject obj = owner.Object;
 // Automatically returned to the pool when owner is disposed — even on exception
 ```
 
+### segment ownership
+
+```csharp
+using CryptoHives.Foundation.Memory.Buffers;
+
+// Pool-backed: rented from ArrayPool<byte>, returned on dispose
+using ISegmentOwner<byte> pooled = PooledSegment<byte>.Rent(256);
+Span<byte> span = pooled.Segment.AsSpan();
+FillData(span);
+
+// Slice the view without copying
+if (pooled.TrySetSegment(offset: 16, length: 64))
+{
+    Span<byte> payload = pooled.Segment.AsSpan();
+    SendPayload(payload);
+}
+
+// GC-managed: wrap an existing array, no pool lifecycle needed
+byte[] buffer = new byte[256];
+using ISegmentOwner<byte> alloc = AllocatedSegment<byte>.Create(buffer);
+
+// Empty sentinel: null-object that avoids null checks
+ISegmentOwner<byte> none = EmptySegment<byte>.Instance;
+```
+
 ---
 
 ## Documentation
@@ -119,3 +145,4 @@ If you discover a vulnerability, please don't open a public issue — follow the
 ## License
 
 MIT — © 2026 The Keepers of the CryptoHives
+

--- a/src/Memory/README.md
+++ b/src/Memory/README.md
@@ -99,7 +99,7 @@ MyExpensiveObject obj = owner.Object;
 // Automatically returned to the pool when owner is disposed — even on exception
 ```
 
-### segment ownership
+### Segment Ownership
 
 ```csharp
 using CryptoHives.Foundation.Memory.Buffers;

--- a/tests/Memory/Buffers/SegmentOwnerTests.cs
+++ b/tests/Memory/Buffers/SegmentOwnerTests.cs
@@ -95,8 +95,7 @@ public class SegmentOwnerTests
     public void EmptyPayloadDisposeMultipleTimesDoesNotThrow()
     {
         ISegmentOwner<byte> payload = EmptySegment<byte>.Instance;
-        Assert.DoesNotThrow(() =>
-        {
+        Assert.DoesNotThrow(() => {
             payload.Dispose();
             payload.Dispose();
             payload.Dispose();
@@ -284,8 +283,7 @@ public class SegmentOwnerTests
     public void ArrayPoolPayloadDisposeMultipleTimesDoesNotThrow()
     {
         ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(64);
-        Assert.DoesNotThrow(() =>
-        {
+        Assert.DoesNotThrow(() => {
             payload.Dispose();
             payload.Dispose();
         });
@@ -463,8 +461,7 @@ public class SegmentOwnerTests
     public void AllocatedPayloadDisposeMultipleTimesDoesNotThrow()
     {
         ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(new byte[8]);
-        Assert.DoesNotThrow(() =>
-        {
+        Assert.DoesNotThrow(() => {
             payload.Dispose();
             payload.Dispose();
         });

--- a/tests/Memory/Buffers/SegmentOwnerTests.cs
+++ b/tests/Memory/Buffers/SegmentOwnerTests.cs
@@ -1,0 +1,475 @@
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+#pragma warning disable CA2000 // Dispose called explicitly inside lambda bodies; false positive
+
+namespace Memory.Tests.Buffers;
+
+using CryptoHives.Foundation.Memory.Buffers;
+using NUnit.Framework;
+using System;
+
+/// <summary>
+/// Tests for <see cref="ISegmentOwner{T}"/> implementations:
+/// <see cref="EmptySegment{T}"/>, <see cref="PooledSegment{T}"/>,
+/// and <see cref="AllocatedSegment{T}"/>.
+/// </summary>
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class SegmentOwnerTests
+{
+    #region EmptySegment<T>
+
+    /// <summary>
+    /// The singleton <see cref="EmptyPayload{T}.Instance"/> must not be <see langword="null"/>.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadInstanceIsNotNull()
+    {
+        Assert.That(EmptySegment<byte>.Instance, Is.Not.Null);
+    }
+
+    /// <summary>
+    /// Repeated access to <see cref="EmptyPayload{T}.Instance"/> must return the same object.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadInstanceIsSingleton()
+    {
+        var first = EmptySegment<byte>.Instance;
+        var second = EmptySegment<byte>.Instance;
+        Assert.That(first, Is.SameAs(second));
+    }
+
+    /// <summary>
+    /// <see cref="EmptyPayload{T}.Segment"/> must be an empty segment backed by <see cref="Array.Empty{T}"/>.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadSegmentIsEmpty()
+    {
+        ISegmentOwner<byte> payload = EmptySegment<byte>.Instance;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload.Segment.Count, Is.Zero);
+            Assert.That(payload.Segment.Offset, Is.Zero);
+            Assert.That(payload.Segment.Array, Is.Not.Null);
+            Assert.That(payload.Segment.Array!.Length, Is.Zero);
+        }
+    }
+
+    /// <summary>
+    /// Reading from the indexer on an empty payload must throw <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadIndexerGetThrows()
+    {
+        ISegmentOwner<byte> payload = EmptySegment<byte>.Instance;
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = payload[0]);
+    }
+
+    /// <summary>
+    /// Writing to the indexer on an empty payload must throw <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadIndexerSetThrows()
+    {
+        ISegmentOwner<byte> payload = EmptySegment<byte>.Instance;
+        Assert.Throws<ArgumentOutOfRangeException>(() => payload[0] = 0);
+    }
+
+    /// <summary>
+    /// <see cref="EmptyPayload{T}.Dispose"/> is a no-op and must never throw.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadDisposeDoesNotThrow()
+    {
+        ISegmentOwner<byte> payload = EmptySegment<byte>.Instance;
+        Assert.DoesNotThrow(() => payload.Dispose());
+    }
+
+    /// <summary>
+    /// Calling <see cref="EmptyPayload{T}.Dispose"/> more than once must not throw.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadDisposeMultipleTimesDoesNotThrow()
+    {
+        ISegmentOwner<byte> payload = EmptySegment<byte>.Instance;
+        Assert.DoesNotThrow(() =>
+        {
+            payload.Dispose();
+            payload.Dispose();
+            payload.Dispose();
+        });
+    }
+
+    /// <summary>
+    /// <see cref="EmptyPayload{T}.TrySetSegment"/> must always return <see langword="false"/>.
+    /// </summary>
+    [Test]
+    public void EmptyPayloadTrySetSegmentAlwaysReturnsFalse()
+    {
+        ISegmentOwner<byte> payload = EmptySegment<byte>.Instance;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload.TrySetSegment(0, 0), Is.False);
+            Assert.That(payload.TrySetSegment(0, 1), Is.False);
+            Assert.That(payload.TrySetSegment(4, 8), Is.False);
+        }
+    }
+
+    #endregion
+
+    #region PooledSegment<T>
+
+    /// <summary>
+    /// <see cref="ArrayPoolPayload{T}.Rent"/> must return a non-null owner.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadRentReturnsNonNullOwner()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(16);
+        Assert.That(payload, Is.Not.Null);
+    }
+
+    /// <summary>
+    /// The segment length must equal the requested <c>minimumLength</c>.
+    /// </summary>
+    [Theory]
+    public void ArrayPoolPayloadRentSegmentLengthEqualsRequestedLength(
+        [Values(1, 16, 64, 128, 1024, 4096)] int length)
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(length);
+        Assert.That(payload.Segment.Count, Is.EqualTo(length));
+    }
+
+    /// <summary>
+    /// The segment offset must be zero after <see cref="ArrayPoolPayload{T}.Rent"/>.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadRentSegmentOffsetIsZero()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(64);
+        Assert.That(payload.Segment.Offset, Is.Zero);
+    }
+
+    /// <summary>
+    /// The backing array must be at least as large as the requested length.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadBackingArrayIsAtLeastRequestedLength()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(64);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload.Segment.Array, Is.Not.Null);
+            Assert.That(payload.Segment.Array!.Length, Is.GreaterThanOrEqualTo(64));
+        }
+    }
+
+    /// <summary>
+    /// The indexer must allow round-trip get/set within the segment.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadIndexerGetSetRoundtrips()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(4);
+        payload[0] = 0xAA;
+        payload[1] = 0xBB;
+        payload[2] = 0xCC;
+        payload[3] = 0xDD;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload[0], Is.EqualTo(0xAA));
+            Assert.That(payload[1], Is.EqualTo(0xBB));
+            Assert.That(payload[2], Is.EqualTo(0xCC));
+            Assert.That(payload[3], Is.EqualTo(0xDD));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> with a valid range must return
+    /// <see langword="true"/> and update the segment.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadTrySetSegmentWithValidRangeReturnsTrueAndUpdatesSegment()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(64);
+        bool result = payload.TrySetSegment(4, 32);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.True);
+            Assert.That(payload.Segment.Offset, Is.EqualTo(4));
+            Assert.That(payload.Segment.Count, Is.EqualTo(32));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> where length exceeds the array must
+    /// return <see langword="false"/> and leave the segment unchanged.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadTrySetSegmentWithLengthExceedingArrayReturnsFalse()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(8);
+        int arrayLength = payload.Segment.Array!.Length;
+        int originalCount = payload.Segment.Count;
+
+        bool result = payload.TrySetSegment(0, arrayLength + 1);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.False);
+            Assert.That(payload.Segment.Count, Is.EqualTo(originalCount));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> where offset + length exceeds the array
+    /// must return <see langword="false"/>.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadTrySetSegmentWithOffsetPlusLengthExceedingArrayReturnsFalse()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(16);
+        int arrayLength = payload.Segment.Array!.Length;
+
+        // offset=8, length=arrayLength-4  →  8 + (arrayLength-4) = arrayLength+4 > arrayLength
+        bool result = payload.TrySetSegment(8, arrayLength - 4);
+        Assert.That(result, Is.False);
+    }
+
+    /// <summary>
+    /// The indexer must respect the updated offset after a successful
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> call.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadIndexerRespectsUpdatedSegmentOffset()
+    {
+        using ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(32);
+
+        // Write sentinel values directly into the backing array.
+        byte[] array = payload.Segment.Array!;
+        for (int i = 0; i < array.Length; i++)
+            array[i] = (byte)i;
+
+        bool moved = payload.TrySetSegment(8, 16);
+        Assert.That(moved, Is.True);
+
+        // payload[i] == array[i + offset]
+        for (int i = 0; i < 16; i++)
+            Assert.That(payload[i], Is.EqualTo((byte)(i + 8)));
+    }
+
+    /// <summary>
+    /// After <see cref="IPayloadOwner{T}.Dispose"/> the segment must be invalidated
+    /// (backing array is <see langword="null"/>).
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadDisposeInvalidatesSegment()
+    {
+        ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(64);
+        payload.Dispose();
+        Assert.That(payload.Segment.Array, Is.Null);
+    }
+
+    /// <summary>
+    /// Calling <see cref="IPayloadOwner{T}.Dispose"/> more than once must not throw.
+    /// </summary>
+    [Test]
+    public void ArrayPoolPayloadDisposeMultipleTimesDoesNotThrow()
+    {
+        ISegmentOwner<byte> payload = PooledSegment<byte>.Rent(64);
+        Assert.DoesNotThrow(() =>
+        {
+            payload.Dispose();
+            payload.Dispose();
+        });
+    }
+
+    #endregion
+
+    #region AllocatedSegment<T>
+
+    /// <summary>
+    /// <see cref="AllocatedPayload{T}.Create"/> must wrap the provided array without copying.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadCreateWrapsBufferWithoutCopying()
+    {
+        byte[] buffer = new byte[8];
+        using ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(buffer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload.Segment.Array, Is.SameAs(buffer));
+            Assert.That(payload.Segment.Offset, Is.Zero);
+            Assert.That(payload.Segment.Count, Is.EqualTo(buffer.Length));
+        }
+    }
+
+    /// <summary>
+    /// The indexer must allow round-trip get/set for all element types.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadIndexerGetSetRoundtrips()
+    {
+        int[] buffer = new int[4];
+        using ISegmentOwner<int> payload = AllocatedSegment<int>.Create(buffer);
+        payload[0] = 10;
+        payload[1] = 20;
+        payload[2] = 30;
+        payload[3] = 40;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload[0], Is.EqualTo(10));
+            Assert.That(payload[1], Is.EqualTo(20));
+            Assert.That(payload[2], Is.EqualTo(30));
+            Assert.That(payload[3], Is.EqualTo(40));
+        }
+    }
+
+    /// <summary>
+    /// Writes via the indexer must be visible through the original array reference.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadIndexerWritesThroughToUnderlyingArray()
+    {
+        byte[] buffer = new byte[3];
+        using ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(buffer);
+        payload[0] = 0xAA;
+        payload[1] = 0xBB;
+        payload[2] = 0xCC;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(buffer[0], Is.EqualTo(0xAA));
+            Assert.That(buffer[1], Is.EqualTo(0xBB));
+            Assert.That(buffer[2], Is.EqualTo(0xCC));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> with a valid range must return
+    /// <see langword="true"/> and update the segment without changing the underlying array.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadTrySetSegmentWithValidRangeReturnsTrueAndUpdatesSegment()
+    {
+        byte[] buffer = new byte[16];
+        using ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(buffer);
+        bool result = payload.TrySetSegment(4, 8);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.True);
+            Assert.That(payload.Segment.Offset, Is.EqualTo(4));
+            Assert.That(payload.Segment.Count, Is.EqualTo(8));
+            Assert.That(payload.Segment.Array, Is.SameAs(buffer));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> where length exceeds the buffer must
+    /// return <see langword="false"/>.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadTrySetSegmentWithLengthExceedingBufferReturnsFalse()
+    {
+        byte[] buffer = new byte[8];
+        using ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(buffer);
+        bool result = payload.TrySetSegment(0, 9);
+        Assert.That(result, Is.False);
+    }
+
+    /// <summary>
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> where offset + length exceeds the buffer
+    /// must return <see langword="false"/>.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadTrySetSegmentWithOffsetPlusLengthExceedingBufferReturnsFalse()
+    {
+        byte[] buffer = new byte[8];
+        using ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(buffer);
+
+        // offset=4, length=8 → 4+8=12 > 8
+        bool result = payload.TrySetSegment(4, 8);
+        Assert.That(result, Is.False);
+    }
+
+    /// <summary>
+    /// The indexer must reflect the offset after a successful
+    /// <see cref="IPayloadOwner{T}.TrySetSegment"/> call.
+    /// </summary>
+    [Theory]
+    public void AllocatedPayloadIndexerRespectsUpdatedSegmentOffset(
+        [Values(0, 2, 4)] int offset,
+        [Values(4, 8)] int length)
+    {
+        byte[] buffer = new byte[16];
+        for (int i = 0; i < buffer.Length; i++)
+            buffer[i] = (byte)i;
+
+        using ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(buffer);
+        bool moved = payload.TrySetSegment(offset, length);
+        Assert.That(moved, Is.True);
+
+        // payload[i] must equal buffer[i + offset]
+        for (int i = 0; i < length; i++)
+            Assert.That(payload[i], Is.EqualTo((byte)(i + offset)));
+    }
+
+    /// <summary>
+    /// After <see cref="IPayloadOwner{T}.Dispose"/> the segment must be invalidated
+    /// (<see cref="ArraySegment{T}.Array"/> is <see langword="null"/>).
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadDisposeInvalidatesSegment()
+    {
+        ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(new byte[8]);
+        payload.Dispose();
+        Assert.That(payload.Segment.Array, Is.Null);
+    }
+
+    /// <summary>
+    /// The underlying GC-managed array must not be affected by <see cref="IPayloadOwner{T}.Dispose"/>.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadDisposeDoesNotClearUnderlyingArray()
+    {
+        byte[] buffer = [1, 2, 3, 4];
+        ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(buffer);
+        payload.Dispose();
+
+        // The wrapper is cleared, but the GC-managed array is untouched.
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(buffer[0], Is.EqualTo(1));
+            Assert.That(buffer[1], Is.EqualTo(2));
+            Assert.That(buffer[2], Is.EqualTo(3));
+            Assert.That(buffer[3], Is.EqualTo(4));
+        }
+    }
+
+    /// <summary>
+    /// Calling <see cref="IPayloadOwner{T}.Dispose"/> more than once must not throw.
+    /// </summary>
+    [Test]
+    public void AllocatedPayloadDisposeMultipleTimesDoesNotThrow()
+    {
+        ISegmentOwner<byte> payload = AllocatedSegment<byte>.Create(new byte[8]);
+        Assert.DoesNotThrow(() =>
+        {
+            payload.Dispose();
+            payload.Dispose();
+        });
+    }
+
+    #endregion
+}
+

--- a/tests/Memory/Pools/ObjectPoolsTests.cs
+++ b/tests/Memory/Pools/ObjectPoolsTests.cs
@@ -7,6 +7,7 @@ using CryptoHives.Foundation.Memory.Pools;
 using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Threading;
@@ -49,6 +50,8 @@ public class ObjectPoolsTests
     }
 
     [Test]
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Test needs to capture all exceptions to verify thread safety")]
     public void GetStringBuilderCanBeUsedConcurrently()
     {
         const int concurrency = 32;


### PR DESCRIPTION
## Add `ISegmentOwner<T>` segment ownership primitives to Memory package

Introduces a family of `ArraySegment<T>`-backed ownership types to `CryptoHives.Foundation.Memory`, following the same mental model as `IMemoryOwner<T>` from `System.Buffers`. The naming mirrors BCL conventions and makes the memory strategy immediately readable at the call site.

---

### New public API

**`CryptoHives.Foundation.Memory.Buffers`**

| Type | Description |
|------|-------------|
| `ISegmentOwner<T>` | Interface: owns an `ArraySegment<T>` and controls its lifetime. Exposes `Segment`, an offset-aware indexer, and `TrySetSegment`. |
| `PooledSegment<T>` | Rents from `ArrayPool<T>.Shared` via `Rent(minimumLength)`; returns the array on `Dispose`. |
| `AllocatedSegment<T>` | Wraps a GC-managed `T[]` via `Create(buffer)` with no copy; clears the wrapper on `Dispose`, leaving the array intact. |
| `EmptySegment<T>` | Zero-allocation null-object sentinel (`Instance` singleton); `Segment.Count == 0`, `TrySetSegment` always returns `false`, `Dispose` is a no-op. |

---

### Changes

**Source** (`src/Memory/Buffers/`)
- Add `ISegmentOwner{T}.cs`, `PooledSegment{T}.cs`, `AllocatedSegment{T}.cs`, `EmptySegment{T}.cs` implementations.
- Add `SegmentOwnerTests.cs`
- Add docfx and porting guides paragraphs

---

### Design notes

- **`ISegmentOwner<T>` vs `IMemoryOwner<T>`** — `IMemoryOwner<T>` exposes `Memory<T>`, which carries its own length and doesn't support offset repositioning. `ISegmentOwner<T>` exposes `ArraySegment<T>` and adds `TrySetSegment` for zero-copy slicing, which is more natural for code that works with array-indexed buffers.
- **`PooledSegment<T>` is a sealed class**, not a struct, to prevent double-return via struct copy — the same reasoning behind `IMemoryOwner<T>` implementations in the BCL.
- **`EmptySegment<T>.Instance`** follows the null-object pattern, removing the need for null checks in consumers that accept `ISegmentOwner<T>`.

## Type of change

<!-- Check all that apply. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [x] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [ ] Build / CI / NuGet packaging / docs

## Checklist

- [x] The solution builds clean with `TreatWarningsAsErrors=true`.
- [x] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [x] I added or updated tests covering the change.
- [x] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [x] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).



