### PR TITLE
Fix Nuget dependencies for analyzer on .NET Framework

### DIFF
--- a/.azurepipelines/get-version.ps1
+++ b/.azurepipelines/get-version.ps1
@@ -10,7 +10,7 @@
 try {
     # Try install tool
     # Note: Keep Version in sync with project settings
-    & dotnet @("tool", "install", "--tool-path", "./tools", "--version", "3.10.85", "--framework", "net80", "nbgv") 2>&1 
+    & dotnet @("tool", "install", "--tool-path", "./tools", "--version", "3.10.91", "--framework", "net80", "nbgv") 2>&1 
 
     $props = (& ./tools/nbgv  @("get-version", "-f", "json")) | ConvertFrom-Json
     if ($LastExitCode -ne 0) {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,11 +33,12 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="18.7.23" />
     <PackageVersion Include="NaCl.Core" Version="2.2.0" />
     <PackageVersion Include="NeoSmart.AsyncLock" Version="3.3.0-preview1" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.85" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageVersion Include="Nuget.Packaging" Version="7.6.0" />
     <PackageVersion Include="Nuget.Protocol" Version="7.6.0" />
+    <PackageVersion Include="Nuget.Resolver" Version="7.6.0" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
     <PackageVersion Include="NUnit.Console" Version="3.22.0" />

--- a/src/Memory/Buffers/AllocatedSegment{T}.cs
+++ b/src/Memory/Buffers/AllocatedSegment{T}.cs
@@ -1,6 +1,8 @@
 ﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
+#pragma warning disable CA1000 // Do not declare static members on generic types
+
 namespace CryptoHives.Foundation.Memory.Buffers;
 
 using System;

--- a/src/Memory/Buffers/EmptySegment{T}.cs
+++ b/src/Memory/Buffers/EmptySegment{T}.cs
@@ -1,6 +1,8 @@
 ﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
+#pragma warning disable CA1000 // Do not declare static members on generic types
+
 namespace CryptoHives.Foundation.Memory.Buffers;
 
 using System;

--- a/src/Memory/Buffers/PooledSegment{T}.cs
+++ b/src/Memory/Buffers/PooledSegment{T}.cs
@@ -1,6 +1,8 @@
 ﻿// SPDX-FileCopyrightText: 2025 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
+#pragma warning disable CA1000 // Do not declare static members on generic types
+
 namespace CryptoHives.Foundation.Memory.Buffers;
 
 using System;

--- a/tests/Threading.Analyzers/Threading.Analyzers.Tests.csproj
+++ b/tests/Threading.Analyzers/Threading.Analyzers.Tests.csproj
@@ -9,6 +9,8 @@
     <RootNamespace>CryptoHives.Foundation.Threading.Analyzers.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +20,21 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
-  <!-- Bump Nuget on .NET Framework due to vulnerable transitive dependency -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <!-- Bump NuGet to avoid vulnerable/mismatched transitive dependencies -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
+    <PackageReference Include="Nuget.Resolver" />
     <PackageReference Include="Nuget.Packaging" />
     <PackageReference Include="Nuget.Protocol" />
+  </ItemGroup>
+
+  <!-- 
+    NuGet client libraries 7.x dropped net462 support (net472 minimum); 
+    pin the last version that still targets net462 
+  -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="Nuget.Resolver" VersionOverride="6.3.4" />
+    <PackageReference Include="Nuget.Packaging" VersionOverride="6.3.4" />
+    <PackageReference Include="Nuget.Protocol" VersionOverride="6.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

- Fix Nuget dependencies for analyzer on .NET Framework, 7.x versions stopped support for 4.6.2
- Bump versioning Nuget

## Type of change

<!-- Check all that apply. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [x] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [x] CryptoHives.Foundation.Threading.Analyzers
- [x] Build / CI / NuGet packaging / docs

