### PR TITLE
Increase spin lock threshold

### DIFF
--- a/CryptoHives .NET Foundation.sln
+++ b/CryptoHives .NET Foundation.sln
@@ -58,7 +58,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{51D53384
 		nuget\logo.jpg = nuget\logo.jpg
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{69C6A38B-5F20-4894-9543-10EFF1AA4203}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{69C6A38B-5F20-4894-9543-10EFF1AA4203}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "devops ci", "devops ci", "{509454EF-E537-4120-81D8-8C2DAA768D31}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Threading/Internal/SpinLock.cs
+++ b/src/Threading/Internal/SpinLock.cs
@@ -10,8 +10,56 @@ using System.Threading;
 /// A lightweight, non reentrant spin lock for
 /// internal use in the threading libraries.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Contention policy:</b> every critical section this lock guards across the library is short,
+/// synchronous and bounded - no <see langword="await"/> ever happens while it is held - so a waiter is
+/// expected to get in after a handful of spins or yields. The waiting strategy is tuned for exactly that
+/// shape.
+/// </para>
+/// <para>
+/// In particular, <see cref="SpinWait.SpinOnce()"/>'s default behaviour is deliberately <em>not</em> used:
+/// it escalates to <see cref="Thread.Sleep(int)"/> with an argument of 1 after about 20 spins, and every
+/// call after that sleeps again. On Windows <c>Thread.Sleep(1)</c> does not sleep one millisecond - it
+/// may round up to the system scheduler quantum, roughly 15.6 ms. For a lock whose critical sections are
+/// measured in nanoseconds that turns contention into a latency cliff rather than a gradual slowdown.
+/// </para>
+/// <para>
+/// Instead the escalation threshold is raised to <see cref="Sleep1Threshold"/>, far beyond what a healthy
+/// contended acquisition of a nanosecond-scale critical section should ever need. Below it the lock
+/// spins and then yields (<c>Thread.Yield</c>/<c>Thread.Sleep(0)</c>), which hands the core to the lock
+/// holder without ever parking the waiter for a whole quantum. The threshold is retained rather than
+/// disabled outright (<c>SpinOnce(-1)</c>) purely as a safety valve: this is a general-purpose library
+/// that may run on a single-core container or with the holder descheduled by a long GC pause, and in
+/// those genuinely pathological cases backing off is better than yielding forever.
+/// </para>
+/// </remarks>
 internal struct SpinLock
 {
+    /// <summary>
+    /// Number of spin iterations before <see cref="Thread.Sleep(int)"/> with an argument of 1 - and with
+    /// it the scheduler-quantum penalty described in the type remarks - is permitted as a last resort.
+    /// The framework default is 20; the critical sections guarded here are orders of magnitude shorter
+    /// than that default is tuned for, so this deliberately sits well above any healthy contention.
+    /// </summary>
+    /// <remarks>
+    /// Internal rather than private so the spin-cost tests can convert this budget into the wall-clock
+    /// window it actually buys, rather than restating the number and drifting from it.
+    /// </remarks>
+    internal const int Sleep1Threshold = 200;
+
+#if !NET5_0_OR_GREATER
+    /// <summary>
+    /// <see cref="SpinWait"/>'s own built-in escalation point - the spin count at which it starts using
+    /// <see cref="Thread.Sleep(int)"/> with an argument of 1 on every subsequent call. Below this the
+    /// framework's tuning is exactly what we want; at and above it we take the backoff over by hand.
+    /// </summary>
+    private const int FrameworkSleep1Threshold = 20;
+
+    /// <summary>How often a yield is replaced by <c>Thread.Sleep(0)</c>, matching SpinWait's own ratio.</summary>
+    private const int Sleep0EveryHowManyYields = 5;
+#endif
+
     private volatile int _state;
 
     public SpinLock()
@@ -33,13 +81,73 @@ internal struct SpinLock
     [MethodImpl(MethodImplOptionsEx.OptimizedLoop)]
     private void EnterCore()
     {
-        // Spin forever
         var spinWait = new SpinWait();
+        int spinCount = 0;
         do
         {
-            // SpinOnce yields based on .NET heuristics 
-            spinWait.SpinOnce();
+            SpinOnce(ref spinWait, ref spinCount);
         } while (!TryEnter());
+    }
+
+    /// <summary>
+    /// One iteration of this lock's backoff curve: the step a waiter takes between two failed attempts
+    /// to acquire.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Extracted from <see cref="EnterCore"/>, and internal rather than private, so the spin-cost tests
+    /// can time exactly the step the lock takes on every target framework instead of a replica of it -
+    /// the two targets take materially different code paths, so a replica would be measuring the wrong
+    /// one half of the time.
+    /// </para>
+    /// <para>
+    /// On targets with the <c>SpinOnce(int)</c> overload this is a straight delegation: the overload
+    /// keeps the runtime's own spin/yield tuning (including its single-processor special case) while
+    /// moving the <c>Thread.Sleep(1)</c> cliff to a value tuned for the Async primitives. Elsewhere the
+    /// overload does not exist, so the framework's own <see cref="SpinWait"/> is driven for as long as
+    /// it is safe to - which is exactly up to the point where it would start sleeping a quantum - and
+    /// only beyond that is the backoff driven by hand. Reusing <see cref="SpinWait"/> below that point
+    /// keeps the runtime's processor-count-aware spin durations and yield/<c>Sleep(0)</c> ratio rather
+    /// than reimplementing them.
+    /// </para>
+    /// </remarks>
+    /// <param name="spinWait">The framework spin state.</param>
+    /// <param name="spinCount">
+    /// Iterations elapsed, counted separately from <see cref="SpinWait.Count"/> because that property
+    /// stops advancing once this stops calling <see cref="SpinWait.SpinOnce()"/>.
+    /// </param>
+    [MethodImpl(MethodImplOptionsEx.HotPath)]
+    internal static void SpinOnce(ref SpinWait spinWait, ref int spinCount)
+    {
+        spinCount++;
+#if NET5_0_OR_GREATER
+        spinWait.SpinOnce(Sleep1Threshold);
+#else
+        if (spinWait.Count < FrameworkSleep1Threshold)
+        {
+            spinWait.SpinOnce();
+            return;
+        }
+
+        // Budget is expressed against the total spin count so this matches the NET5_0_OR_GREATER path,
+        // where SpinOnce(Sleep1Threshold) counts from zero rather than from the handover.
+        if (spinCount >= Sleep1Threshold)
+        {
+            Thread.Sleep(1);
+            spinWait.Reset();
+            spinCount = 0;
+        }
+        else if ((spinCount % Sleep0EveryHowManyYields) == 0)
+        {
+            // Sleep(0) yields to any ready thread of equal priority, including on other cores;
+            // Thread.Yield() only considers the current processor. Alternating covers both.
+            Thread.Sleep(0);
+        }
+        else
+        {
+            Thread.Yield();
+        }
+#endif
     }
 
     [MethodImpl(MethodImplOptionsEx.HotPath)]

--- a/tests/Common/Main.cs
+++ b/tests/Common/Main.cs
@@ -22,6 +22,6 @@ static class Program
             .AddAnalyser(DefaultConfig.Instance.GetAnalysers().ToArray())
             .AddValidator(DefaultConfig.Instance.GetValidators().ToArray())
         ;
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+        _ = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
     }
 }

--- a/tests/Threading/Internal/MeasurementGate.cs
+++ b/tests/Threading/Internal/MeasurementGate.cs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace Threading.Tests.Internal;
+
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+/// <summary>
+/// A machine-wide gate that lets only one timing fixture measure at a time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The spin lock measurements need idle cores: they time nanosecond-scale operations, and
+/// <see cref="SpinLockLatencyTests"/> additionally spins a thread per core so that every waiter is
+/// resident when its round starts. Anything else competing for those cores is measured as lock latency.
+/// </para>
+/// <para>
+/// <see cref="NonParallelizableAttribute"/> is not enough on its own, because it only orders fixtures
+/// <em>within</em> one test assembly. The test projects multi-target, so <c>dotnet test</c> runs a
+/// separate process per target framework and runs those processes concurrently - three copies of the
+/// same measurement, each spinning a thread per core, on one machine. That oversubscription deschedules
+/// waiters for whole scheduler quanta, which is precisely the signal these fixtures assert on, so they
+/// fail while the lock itself is behaving correctly.
+/// </para>
+/// <para>
+/// The gate is an exclusively-opened lock file rather than a named mutex or semaphore: a file handle has
+/// no thread affinity, so NUnit is free to run <c>OneTimeSetUp</c> and <c>OneTimeTearDown</c> on
+/// different threads, and it behaves the same on every supported platform, which named semaphores do not.
+/// A crashed run cannot leave the gate stuck either - the operating system closes the handle with the
+/// process.
+/// </para>
+/// </remarks>
+internal sealed class MeasurementGate : IDisposable
+{
+    /// <summary>
+    /// Shared across target frameworks on purpose: the point is to serialise the per-TFM test processes
+    /// against each other.
+    /// </summary>
+    private const string LockFileName = "cryptohives-threading-measurement.lock";
+
+    /// <summary>
+    /// How long to wait for the gate before giving up and measuring anyway. Sized well above the time
+    /// the whole matrix needs, so reaching it means the gate is not working rather than that the machine
+    /// is busy - in which case running unserialised is more useful than blocking the suite.
+    /// </summary>
+    private static readonly TimeSpan AcquireTimeout = TimeSpan.FromMinutes(15);
+
+    private static readonly TimeSpan RetryInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly FileStream? _stream;
+
+    private MeasurementGate(FileStream? stream)
+        => _stream = stream;
+
+    /// <summary>
+    /// Blocks until no other test process is measuring, and returns the held gate.
+    /// </summary>
+    public static MeasurementGate Acquire()
+    {
+        string path = Path.Combine(Path.GetTempPath(), LockFileName);
+        long deadline = Stopwatch.GetTimestamp() + (long)(AcquireTimeout.TotalSeconds * Stopwatch.Frequency);
+        bool waited = false;
+
+        while (true)
+        {
+            try
+            {
+                var stream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+                if (waited)
+                {
+                    TestContext.Out.WriteLine(
+                        "  Waited for another test process to finish measuring before starting.");
+                }
+
+                return new MeasurementGate(stream);
+            }
+            catch (IOException)
+            {
+                // Held by another target framework's test process. Wait for it.
+                if (Stopwatch.GetTimestamp() >= deadline)
+                {
+                    TestContext.Out.WriteLine(
+                        $"  NOTE: the measurement gate was still held after {AcquireTimeout.TotalMinutes:N0} " +
+                        "minutes. Measuring anyway - results may be affected by concurrent load.");
+                    return new MeasurementGate(null);
+                }
+
+                waited = true;
+                Thread.Sleep(RetryInterval);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // No writable temp directory. Serialisation is an optimisation, not a correctness
+                // requirement, so fall through and measure.
+                TestContext.Out.WriteLine(
+                    "  NOTE: no writable temp directory for the measurement gate. Measuring unserialised.");
+                return new MeasurementGate(null);
+            }
+        }
+    }
+
+    public void Dispose()
+        => _stream?.Dispose();
+}

--- a/tests/Threading/Internal/MeasurementGate.cs
+++ b/tests/Threading/Internal/MeasurementGate.cs
@@ -61,7 +61,7 @@ internal sealed class MeasurementGate : IDisposable
     /// </summary>
     public static MeasurementGate Acquire()
     {
-        string path = Path.Combine(Path.GetTempPath(), LockFileName);
+        string path = Path.Combine(Path.GetTempPath(), Path.GetFileName(LockFileName));
         long deadline = Stopwatch.GetTimestamp() + (long)(AcquireTimeout.TotalSeconds * Stopwatch.Frequency);
         bool waited = false;
 

--- a/tests/Threading/Internal/PlatformTimer.cs
+++ b/tests/Threading/Internal/PlatformTimer.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace Threading.Tests.Internal;
+
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+/// <summary>
+/// Shared timing primitives for the spin lock measurements.
+/// </summary>
+/// <remarks>
+/// The spin lock's contention policy is a claim about two wall-clock quantities - what a park costs and
+/// what a spin costs - so both fixtures that examine it need the same, calibrated, notion of each. They
+/// share this helper rather than a constant so nothing is hard-coded to Windows' 15.6 ms scheduler
+/// quantum: the platform's real numbers are measured at run time.
+/// </remarks>
+internal static class PlatformTimer
+{
+    /// <summary>
+    /// Number of <c>Thread.Sleep(1)</c> samples taken to calibrate the platform's timer granularity.
+    /// The median is used, so a single descheduled sample cannot move the result.
+    /// </summary>
+    public const int QuantumCalibrationSamples = 15;
+
+    /// <summary>High performance counter ticks since <paramref name="start"/>, as a <see cref="TimeSpan"/>.</summary>
+    public static TimeSpan Elapsed(long start)
+        => TimeSpan.FromMilliseconds(ToMilliseconds(Stopwatch.GetTimestamp() - start));
+
+    /// <summary>Converts high performance counter ticks to milliseconds.</summary>
+    public static double ToMilliseconds(double ticks)
+        => ticks * 1_000.0 / Stopwatch.Frequency;
+
+    /// <summary>Converts high performance counter ticks to nanoseconds.</summary>
+    public static double ToNanoseconds(double ticks)
+        => ticks * 1_000_000_000.0 / Stopwatch.Frequency;
+
+    /// <summary>
+    /// Measures the platform's real <c>Thread.Sleep(1)</c> granularity - roughly 15.6 ms on Windows at the
+    /// default timer resolution, closer to 1 ms elsewhere - as the median of several samples.
+    /// </summary>
+    /// <remarks>
+    /// This is the cost the spin lock's contention policy exists to avoid, so every assertion about
+    /// parking is expressed against it rather than against a hard-coded quantum.
+    /// </remarks>
+    public static double MeasureSleep1GranularityMilliseconds()
+    {
+        // Discard the first sleep: it can land anywhere inside the current tick.
+        Thread.Sleep(1);
+
+        double[] samples = new double[QuantumCalibrationSamples];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            Thread.Sleep(1);
+            samples[i] = ToMilliseconds(Stopwatch.GetTimestamp() - start);
+        }
+
+        Array.Sort(samples);
+        return samples[samples.Length / 2];
+    }
+
+    /// <summary>Reports the counter resolution and the measured park cost.</summary>
+    /// <param name="granularityMs">Measured <c>Thread.Sleep(1)</c> granularity.</param>
+    public static void ReportGranularity(double granularityMs)
+    {
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine("Platform timer:");
+        TestContext.Out.WriteLine($"{"  high performance counter",-34} {Stopwatch.Frequency,14:N0} Hz");
+        TestContext.Out.WriteLine($"{"  counter resolution",-34} {ToNanoseconds(1),14:N1} ns per tick");
+        TestContext.Out.WriteLine($"{"  Thread.Sleep(1) granularity",-34} {granularityMs,14:F3} ms (median of {QuantumCalibrationSamples})");
+    }
+
+    /// <summary>
+    /// Reports the build configuration of the measurement, because an unoptimised build inflates every
+    /// number below and a reader comparing two runs has to know which they are looking at.
+    /// </summary>
+    public static void ReportConfiguration()
+    {
+#if DEBUG
+        TestContext.Out.WriteLine(
+            "  NOTE: Debug build - measurements are inflated. Run with -c Release for representative figures.");
+#else
+        TestContext.Out.WriteLine("  Release build.");
+#endif
+    }
+}

--- a/tests/Threading/Internal/SpinLockLatencyTests.cs
+++ b/tests/Threading/Internal/SpinLockLatencyTests.cs
@@ -1,0 +1,634 @@
+// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace Threading.Tests.Internal;
+
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+using SpinLock = CryptoHives.Foundation.Threading.Internal.SpinLock;
+
+/// <summary>
+/// Latency tests proving the contention policy documented on <see cref="SpinLock"/>: a waiter blocked on
+/// the lock is never parked on the scheduler-quantum timer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SpinWait.SpinOnce()"/>'s default backoff escalates to <c>Thread.Sleep(1)</c> after about
+/// twenty spins, and sleeps again on every call after that. On Windows <c>Thread.Sleep(1)</c> does not
+/// sleep one millisecond - it rounds up to the system scheduler quantum, roughly 15.6 ms. For a lock whose
+/// critical sections are measured in nanoseconds that turns contention into a latency cliff: a waiter
+/// stops paying for the critical section it is waiting on and starts paying a whole quantum instead.
+/// </para>
+/// <para>
+/// <b>Method.</b> These tests do not free-run threads against the lock and measure what happens. A
+/// free-running loop measures the wrong thing: the thread that releases the lock still owns its cache line
+/// exclusively and never backs off, so it re-acquires immediately and convoys thousands of uncontended
+/// acquisitions while its peers sit deep in backoff. The resulting distribution is bimodal, dominated by
+/// re-acquisitions by the same thread, and is identical for both backoffs - it says nothing about either.
+/// </para>
+/// <para>
+/// Instead each round is a controlled handoff. One holder thread takes the lock, releases a set of waiter
+/// threads that are already spinning hot on a gate, holds the lock for a known duration, and then releases
+/// it. Every waiter is therefore guaranteed to block, and its acquisition latency has a known expected
+/// value: the holder's critical section, plus a handoff. Latencies are taken with
+/// <see cref="Stopwatch.GetTimestamp"/> - the high performance counter, <c>QueryPerformanceCounter</c> on
+/// Windows - and the assertion is that they track the critical section rather than snapping to the
+/// quantum grid.
+/// </para>
+/// <para>
+/// The quantum is not hard-coded to 15.6 ms: the platform's real <c>Thread.Sleep(1)</c> granularity is
+/// measured first, so the same assertions are meaningful on Linux and macOS, where it is closer to a
+/// millisecond.
+/// </para>
+/// <para>
+/// <b>Envelope.</b> The spin budget is finite by design - see the safety-valve paragraph on
+/// <see cref="SpinLock"/> - so the claim is scoped to critical sections of the length the library actually
+/// produces. <see cref="ReportHandoffLatencyAcrossCriticalSectionLengths"/> maps the whole curve for both
+/// backoffs, including the point where each one runs out of budget and starts parking. That the tuned lock
+/// eventually parks too, at a critical section thousands of times longer than any it guards, is the
+/// designed behaviour and is reported rather than asserted.
+/// </para>
+/// <para>
+/// The fixture is <see cref="NonParallelizableAttribute">non-parallelizable</see> because it measures
+/// wall-clock latency and needs a free core per thread; running it alongside other fixtures would
+/// oversubscribe the machine and inject preemption stalls that have nothing to do with the lock. That
+/// attribute only orders fixtures within one assembly, so a <see cref="MeasurementGate"/> extends the
+/// same exclusion across the per-target-framework test processes that <c>dotnet test</c> runs in
+/// parallel - without it, three copies of this fixture spin a thread per core simultaneously and it
+/// fails on the preemption that causes.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public class SpinLockLatencyTests
+{
+    private MeasurementGate? _gate;
+
+    [OneTimeSetUp]
+    public void AcquireMeasurementGate()
+        => _gate = MeasurementGate.Acquire();
+
+    [OneTimeTearDown]
+    public void ReleaseMeasurementGate()
+        => _gate?.Dispose();
+
+    /// <summary>
+    /// Fraction of the measured <c>Thread.Sleep(1)</c> granularity at which a wait is treated as having
+    /// been parked rather than spun. Half a quantum is not reachable by spinning and yielding, so anything
+    /// at or above it - over and above the critical section actually being waited on - is evidence of a
+    /// sleep.
+    /// </summary>
+    private const double QuantumBandFraction = 0.5;
+
+    /// <summary>
+    /// Floor for the quantum band, in milliseconds. Where the platform's own <c>Sleep(1)</c> granularity
+    /// is already close to one millisecond, half of it is too tight to distinguish from an ordinary
+    /// scheduling hiccup; this keeps the band honest without weakening it on Windows.
+    /// </summary>
+    private const double MinQuantumBandMilliseconds = 2.0;
+
+    /// <summary>
+    /// Fraction of handoffs permitted to land in the quantum band regardless. A waiter can be descheduled
+    /// by the operating system through no fault of the lock, so a hard zero would be a flake.
+    /// </summary>
+    private const double QuantumBandOutlierTolerance = 0.002;
+
+    /// <summary>Absolute floor for the outlier allowance, so short runs are not hair-triggered.</summary>
+    private const int MinQuantumBandOutlierAllowance = 3;
+
+    /// <summary>Handoff rounds per probe. Each round produces one sample per waiter.</summary>
+    private const int Rounds = 400;
+
+    /// <summary>
+    /// Handoff rounds per probe for the diagnostic sweep. Lower than <see cref="Rounds"/> because the
+    /// sweep deliberately includes configurations that park: at a quantum per round those would otherwise
+    /// dominate the runtime of the whole fixture.
+    /// </summary>
+    private const int ReportRounds = 60;
+
+    /// <summary>Rounds run before measurement starts, to get the loop jitted and the threads settled.</summary>
+    private const int WarmupRounds = 50;
+
+    /// <summary>
+    /// Ceiling on the waiter count. The holder needs a core of its own, and every waiter needs one to spin
+    /// on; oversubscribing would measure the scheduler rather than the lock.
+    /// </summary>
+    private const int MaxWaiters = 8;
+
+    /// <summary>
+    /// Critical-section lengths, in microseconds, at which the lock is asserted to hold the line. The
+    /// library's own critical sections are a handful of instructions - tens of nanoseconds - so even the
+    /// longest of these is orders of magnitude beyond what it has to absorb in practice, and all three sit
+    /// well inside the spin budget mapped by
+    /// <see cref="ReportHandoffLatencyAcrossCriticalSectionLengths"/>.
+    /// </summary>
+    private static readonly double[] AssertedHoldMicroseconds = [0.0, 1.0, 10.0];
+
+    /// <summary>
+    /// Critical-section lengths, in microseconds, mapped by
+    /// <see cref="ReportHandoffLatencyAcrossCriticalSectionLengths"/>. The tail entries sit outside the
+    /// envelope on purpose, to show where each backoff runs out of spin budget.
+    /// </summary>
+    private static readonly double[] ReportedHoldMicroseconds = [0.0, 1.0, 10.0, 50.0, 200.0, 1_000.0];
+
+    /// <summary>
+    /// Critical-section length used for the head-to-head against the framework's default backoff. It has
+    /// to be long enough to exhaust the default twenty-spin budget - with a negligible critical section the
+    /// default never escalates and there is no cliff to demonstrate - while staying inside this lock's own
+    /// budget. Ten microseconds is the first measured point where the two separate cleanly;
+    /// <see cref="ReportHandoffLatencyAcrossCriticalSectionLengths"/> shows the margin either side.
+    /// </summary>
+    private const double CliffComparisonHoldMicroseconds = 10.0;
+
+    /// <summary>
+    /// Multiple of the critical section that a handoff is allowed to cost before it is treated as no
+    /// longer tracking the critical section at all. Only applied on top of an absolute floor, since a
+    /// negligible critical section has no meaningful multiple.
+    /// </summary>
+    private const double HandoffOverheadFactor = 4.0;
+
+    /// <summary>
+    /// Absolute headroom, in milliseconds, allowed on top of the critical section before a handoff counts
+    /// as parked. Comfortably above any spin-and-yield handoff and comfortably below half a quantum.
+    /// </summary>
+    private const double HandoffHeadroomMilliseconds = 1.0;
+
+    private static int WaiterCount => Math.Max(2, Math.Min(Environment.ProcessorCount - 1, MaxWaiters));
+
+    /// <summary>
+    /// Asserts that a blocked waiter pays for the critical section it is waiting on, and never for the
+    /// timer quantum.
+    /// </summary>
+    /// <param name="holdMicroseconds">How long the holder keeps the lock, in microseconds.</param>
+    [Test, CancelAfter(120_000)]
+    [TestCaseSource(nameof(AssertedHoldMicroseconds))]
+    public void WaiterLatencyTracksTheCriticalSectionNotTheTimerQuantum(double holdMicroseconds)
+    {
+        RequireEnoughProcessors();
+
+        double granularityMs = MeasureSleep1GranularityMilliseconds();
+        double bandMs = QuantumBandLowerBound(granularityMs);
+
+        var box = new TunedSpinLockBox();
+        HandoffStats stats = RunHandoffProbe("SpinLock", holdMicroseconds, box.Enter, box.Exit, bandMs);
+
+        ReportGranularity(granularityMs, bandMs);
+        Report(stats, bandMs);
+
+        double expectedCeilingMs = ExpectedHandoffCeilingMilliseconds(holdMicroseconds);
+        int allowance = OutlierAllowance(stats.SampleCount);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                stats.ParkedCount,
+                Is.LessThanOrEqualTo(allowance),
+                $"{stats.ParkedCount:N0} of {stats.SampleCount:N0} handoffs of a " +
+                $"{holdMicroseconds:N1} us critical section cost at least {bandMs:F2} ms on top of it, which is " +
+                $"only reachable by parking on the {granularityMs:F2} ms timer.");
+
+            Assert.That(
+                stats.P99Milliseconds,
+                Is.LessThan(expectedCeilingMs),
+                $"99% of handoffs should cost about the {holdMicroseconds:N1} us critical section being waited " +
+                $"on, not {stats.P99Milliseconds * 1000.0:N1} us.");
+        }
+    }
+
+    /// <summary>
+    /// Runs the tuned lock and a control lock using the framework's default <see cref="SpinWait"/> backoff
+    /// through the same handoff probe, and asserts that the tuned lock avoids a cliff the control hits.
+    /// </summary>
+    /// <remarks>
+    /// The comparative assertions are conditional on the control actually demonstrating the cliff on this
+    /// machine, which makes the test self-calibrating rather than platform-specific: where
+    /// <c>Thread.Sleep(1)</c> really costs a quantum the control collapses and the tuned lock must beat it
+    /// by a wide margin; where it does not, there is no cliff to avoid and only the unconditional bound
+    /// applies.
+    /// </remarks>
+    [Test, CancelAfter(120_000)]
+    public void DefaultSpinWaitBackoffParksWhereSpinLockDoesNot()
+    {
+        RequireEnoughProcessors();
+
+        double granularityMs = MeasureSleep1GranularityMilliseconds();
+        double bandMs = QuantumBandLowerBound(granularityMs);
+
+        var control = new DefaultSpinWaitLockBox();
+        HandoffStats controlStats = RunHandoffProbe(
+            "SpinWait default", CliffComparisonHoldMicroseconds, control.Enter, control.Exit, bandMs);
+
+        var tuned = new TunedSpinLockBox();
+        HandoffStats tunedStats = RunHandoffProbe(
+            "SpinLock", CliffComparisonHoldMicroseconds, tuned.Enter, tuned.Exit, bandMs);
+
+        ReportGranularity(granularityMs, bandMs);
+        Report(controlStats, bandMs);
+        Report(tunedStats, bandMs);
+
+        Assert.That(
+            tunedStats.ParkedCount,
+            Is.LessThanOrEqualTo(OutlierAllowance(tunedStats.SampleCount)),
+            $"{tunedStats.ParkedCount:N0} of {tunedStats.SampleCount:N0} handoffs reached the {bandMs:F2} ms band.");
+
+        if (controlStats.ParkedRatio <= QuantumBandOutlierTolerance)
+        {
+            TestContext.Out.WriteLine();
+            TestContext.Out.WriteLine(
+                "  Note: the default SpinWait backoff did not exhibit the quantum cliff on this platform " +
+                $"({controlStats.ParkedRatio:P2} of handoffs parked, Sleep(1) granularity {granularityMs:F2} ms), " +
+                "so only the unconditional bound was asserted.");
+            return;
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                tunedStats.ParkedRatio,
+                Is.LessThan(controlStats.ParkedRatio),
+                $"The default backoff parked on {controlStats.ParkedRatio:P2} of handoffs of the same " +
+                $"{CliffComparisonHoldMicroseconds:N0} us critical section, SpinLock on {tunedStats.ParkedRatio:P2}.");
+
+            Assert.That(
+                tunedStats.P99Milliseconds,
+                Is.LessThan(controlStats.P99Milliseconds),
+                "The tuned backoff should have a lower tail than one that parks on the timer.");
+        }
+    }
+
+    /// <summary>
+    /// Maps handoff latency against critical-section length for both backoffs, documenting where each one
+    /// runs out of spin budget and starts parking.
+    /// </summary>
+    /// <remarks>
+    /// Diagnostic rather than behavioural: the longest entries deliberately sit outside the envelope the
+    /// lock is tuned for. The table is the point - it is what makes the spin budget an observed quantity
+    /// rather than an assumed one.
+    /// </remarks>
+    [Test, CancelAfter(300_000)]
+    public void ReportHandoffLatencyAcrossCriticalSectionLengths()
+    {
+        RequireEnoughProcessors();
+
+        double granularityMs = MeasureSleep1GranularityMilliseconds();
+        double bandMs = QuantumBandLowerBound(granularityMs);
+
+        ReportGranularity(granularityMs, bandMs);
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"Handoff latency vs critical-section length ({WaiterCount} waiters, {ReportRounds} rounds):");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine(
+            $"{"backoff",-18}{"held us",10} {"p50 us",12} {"p99 us",12} {"max us",12} {"parked",10}");
+
+        foreach (double holdMicroseconds in ReportedHoldMicroseconds)
+        {
+            var control = new DefaultSpinWaitLockBox();
+            ReportRow(RunHandoffProbe("SpinWait default", holdMicroseconds, control.Enter, control.Exit, bandMs, ReportRounds));
+
+            var tuned = new TunedSpinLockBox();
+            ReportRow(RunHandoffProbe("SpinLock", holdMicroseconds, tuned.Enter, tuned.Exit, bandMs, ReportRounds));
+        }
+
+        Assert.Pass();
+    }
+
+    /// <summary>
+    /// Reports the platform's real <c>Thread.Sleep(1)</c> granularity, which is the cost the lock's
+    /// contention policy exists to avoid.
+    /// </summary>
+    /// <remarks>
+    /// This is a diagnostic, not a behavioural assertion: it only fails if the high performance counter
+    /// itself is unusable, in which case every other measurement in the fixture would be meaningless.
+    /// </remarks>
+    [Test, CancelAfter(30_000)]
+    public void ReportPlatformTimerGranularity()
+    {
+        double granularityMs = MeasureSleep1GranularityMilliseconds();
+        double bandMs = QuantumBandLowerBound(granularityMs);
+
+        ReportGranularity(granularityMs, bandMs);
+
+        Assert.That(
+            granularityMs,
+            Is.GreaterThan(0.0),
+            "Thread.Sleep(1) measured as instantaneous - the high performance counter is not usable.");
+    }
+
+    /// <summary>
+    /// Runs <see cref="Rounds"/> controlled handoffs and records how long each waiter was blocked.
+    /// </summary>
+    /// <remarks>
+    /// Every round the holder takes the lock <em>before</em> opening the gate, so each waiter is guaranteed
+    /// to find it held and to block. The gate is a plain counter the waiters spin on rather than an event,
+    /// so no waiter is ever asleep in the kernel when its round starts - a wake-up would cost more than the
+    /// handoff being measured.
+    /// </remarks>
+    /// <param name="name">Display name of the lock under test.</param>
+    /// <param name="holdMicroseconds">How long the holder keeps the lock.</param>
+    /// <param name="enter">Acquires the lock.</param>
+    /// <param name="exit">Releases the lock.</param>
+    /// <param name="quantumBandMilliseconds">Excess latency at or above which a handoff counts as parked.</param>
+    /// <param name="rounds">Measured handoff rounds.</param>
+    private static HandoffStats RunHandoffProbe(
+        string name,
+        double holdMicroseconds,
+        Action enter,
+        Action exit,
+        double quantumBandMilliseconds,
+        int rounds = Rounds)
+    {
+        int waiterCount = WaiterCount;
+        int totalRounds = WarmupRounds + rounds;
+        long holdTicks = (long)(holdMicroseconds * Stopwatch.Frequency / 1_000_000.0);
+
+        var state = new HandoffState();
+        long[][] samples = new long[waiterCount][];
+        var waiters = new Thread[waiterCount];
+
+        for (int w = 0; w < waiterCount; w++)
+        {
+            samples[w] = new long[rounds];
+        }
+
+        for (int w = 0; w < waiterCount; w++)
+        {
+            int index = w;
+            waiters[w] = new Thread(() => {
+                long[] local = samples[index];
+
+                for (int round = 1; round <= totalRounds; round++)
+                {
+                    // Spin hot on the gate: an event wait would put this thread in the kernel and the
+                    // wake-up would dwarf the handoff being measured.
+                    while (Volatile.Read(ref state.Round) < round)
+                    {
+                        Thread.SpinWait(1);
+                    }
+
+                    long before = Stopwatch.GetTimestamp();
+                    enter();
+                    long acquired = Stopwatch.GetTimestamp();
+                    exit();
+
+                    if (round > WarmupRounds)
+                    {
+                        local[round - WarmupRounds - 1] = acquired - before;
+                    }
+
+                    Interlocked.Increment(ref state.Completed);
+                }
+            }) {
+                IsBackground = true,
+                Name = $"{name} waiter {index}"
+            };
+            waiters[w].Start();
+        }
+
+        for (int round = 1; round <= totalRounds; round++)
+        {
+            Volatile.Write(ref state.Completed, 0);
+
+            // Take the lock before opening the gate, so every waiter is guaranteed to block on it.
+            enter();
+            Volatile.Write(ref state.Round, round);
+
+            if (holdTicks > 0)
+            {
+                BusyWait(holdTicks);
+            }
+
+            exit();
+
+            // Drain the round. Spinning rather than waiting keeps the waiters hot for the next one.
+            while (Volatile.Read(ref state.Completed) < waiterCount)
+            {
+                Thread.SpinWait(1);
+            }
+        }
+
+        for (int w = 0; w < waiterCount; w++)
+        {
+            waiters[w].Join();
+        }
+
+        return HandoffStats.Create(name, waiterCount, holdMicroseconds, samples, rounds, quantumBandMilliseconds);
+    }
+
+    /// <summary>Busy-waits for the given number of high performance counter ticks without ever sleeping.</summary>
+    private static void BusyWait(long ticks)
+    {
+        long deadline = Stopwatch.GetTimestamp() + ticks;
+        while (Stopwatch.GetTimestamp() < deadline)
+        {
+            Thread.SpinWait(1);
+        }
+    }
+
+    private static double MeasureSleep1GranularityMilliseconds()
+        => PlatformTimer.MeasureSleep1GranularityMilliseconds();
+
+    /// <summary>
+    /// Excess latency, over and above the critical section being waited on, at or above which a handoff can
+    /// only be explained by having been parked on the timer.
+    /// </summary>
+    private static double QuantumBandLowerBound(double granularityMilliseconds)
+        => Math.Max(MinQuantumBandMilliseconds, granularityMilliseconds * QuantumBandFraction);
+
+    /// <summary>
+    /// Latency a healthy handoff of the given critical section should stay under: the critical section
+    /// itself, plus whichever of a fixed headroom or a multiple of it is larger.
+    /// </summary>
+    private static double ExpectedHandoffCeilingMilliseconds(double holdMicroseconds)
+    {
+        double holdMs = holdMicroseconds / 1000.0;
+        return holdMs + Math.Max(HandoffHeadroomMilliseconds, holdMs * HandoffOverheadFactor);
+    }
+
+    private static int OutlierAllowance(int sampleCount)
+        => Math.Max(MinQuantumBandOutlierAllowance, (int)(sampleCount * QuantumBandOutlierTolerance));
+
+    private static void RequireEnoughProcessors()
+    {
+        if (Environment.ProcessorCount < 3)
+        {
+            Assert.Ignore(
+                "A controlled handoff needs a core for the holder and one per waiter. With fewer, a waiter " +
+                "cannot spin without starving the holder, and backing off is the correct behaviour.");
+        }
+    }
+
+    private static double ToMilliseconds(double ticks)
+        => PlatformTimer.ToMilliseconds(ticks);
+
+    private static void ReportGranularity(double granularityMs, double bandMs)
+    {
+        PlatformTimer.ReportGranularity(granularityMs);
+        TestContext.Out.WriteLine($"{"  parked-handoff band",-34} {bandMs,14:F3} ms over the critical section");
+        PlatformTimer.ReportConfiguration();
+    }
+
+    private static void Report(HandoffStats stats, double bandMs)
+    {
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine(
+            $"{stats.Name}: {stats.WaiterCount} waiters blocked on a {stats.HoldMicroseconds:N1} us " +
+            $"critical section, {stats.SampleCount:N0} handoffs");
+        TestContext.Out.WriteLine($"{"  mean",-34} {stats.MeanMilliseconds * 1000.0,14:N2} us");
+        TestContext.Out.WriteLine($"{"  p50",-34} {stats.P50Milliseconds * 1000.0,14:N2} us");
+        TestContext.Out.WriteLine($"{"  p90",-34} {stats.P90Milliseconds * 1000.0,14:N2} us");
+        TestContext.Out.WriteLine($"{"  p99",-34} {stats.P99Milliseconds * 1000.0,14:N2} us");
+        TestContext.Out.WriteLine($"{"  max",-34} {stats.MaxMilliseconds * 1000.0,14:N2} us");
+        TestContext.Out.WriteLine($"{"  parked (>= hold + band)",-34} {stats.ParkedCount,14:N0} ({stats.ParkedRatio:P2})");
+        TestContext.Out.WriteLine($"{"  band",-34} {bandMs * 1000.0,14:N0} us");
+    }
+
+    private static void ReportRow(HandoffStats stats)
+        => TestContext.Out.WriteLine(
+            $"{stats.Name,-18}{stats.HoldMicroseconds,10:N0} {stats.P50Milliseconds * 1000.0,12:N2} " +
+            $"{stats.P99Milliseconds * 1000.0,12:N2} {stats.MaxMilliseconds * 1000.0,12:N1} " +
+            $"{stats.ParkedRatio,10:P2}");
+
+    /// <summary>Shared, mutable state driving the handoff rounds. A class so every thread sees one copy.</summary>
+    private sealed class HandoffState
+    {
+        /// <summary>Round the holder has opened. Waiters spin until this reaches their round number.</summary>
+        public int Round;
+
+        /// <summary>Waiters that have completed the current round.</summary>
+        public int Completed;
+    }
+
+    /// <summary>
+    /// Aggregated result of one handoff probe.
+    /// </summary>
+    /// <remarks>
+    /// A class rather than a <see langword="readonly"/> <see langword="struct"/> only because <c>init</c>
+    /// accessors need an <c>IsExternalInit</c> polyfill on the .NET Framework target, and one probe result
+    /// per configuration is not worth carrying one for.
+    /// </remarks>
+    private sealed class HandoffStats
+    {
+        public string Name { get; set; } = string.Empty;
+        public int WaiterCount { get; set; }
+        public double HoldMicroseconds { get; set; }
+        public int SampleCount { get; set; }
+        public double MeanMilliseconds { get; set; }
+        public double P50Milliseconds { get; set; }
+        public double P90Milliseconds { get; set; }
+        public double P99Milliseconds { get; set; }
+        public double MaxMilliseconds { get; set; }
+        public int ParkedCount { get; set; }
+        public double ParkedRatio { get; set; }
+
+        public static HandoffStats Create(
+            string name,
+            int waiterCount,
+            double holdMicroseconds,
+            long[][] samples,
+            int rounds,
+            double quantumBandMilliseconds)
+        {
+            int total = waiterCount * rounds;
+            long[] all = new long[total];
+            double sum = 0.0;
+
+            for (int w = 0; w < waiterCount; w++)
+            {
+                Array.Copy(samples[w], 0, all, w * rounds, rounds);
+                for (int i = 0; i < rounds; i++)
+                {
+                    sum += samples[w][i];
+                }
+            }
+
+            Array.Sort(all);
+
+            // A handoff counts as parked only if it cost the critical section plus a further half quantum:
+            // the wait for the critical section itself is what the waiter is there for.
+            double parkedThresholdMs = (holdMicroseconds / 1000.0) + quantumBandMilliseconds;
+            long parkedTicks = (long)(parkedThresholdMs * Stopwatch.Frequency / 1000.0);
+            int parked = total - LowerBound(all, parkedTicks);
+
+            return new HandoffStats {
+                Name = name,
+                WaiterCount = waiterCount,
+                HoldMicroseconds = holdMicroseconds,
+                SampleCount = total,
+                MeanMilliseconds = ToMilliseconds(sum / total),
+                P50Milliseconds = Percentile(all, 0.50),
+                P90Milliseconds = Percentile(all, 0.90),
+                P99Milliseconds = Percentile(all, 0.99),
+                MaxMilliseconds = ToMilliseconds(all[total - 1]),
+                ParkedCount = parked,
+                ParkedRatio = (double)parked / total,
+            };
+        }
+
+        private static double Percentile(long[] sorted, double percentile)
+            => ToMilliseconds(sorted[(int)(percentile * (sorted.Length - 1))]);
+
+        /// <summary>Index of the first element of <paramref name="sorted"/> that is at least <paramref name="value"/>.</summary>
+        private static int LowerBound(long[] sorted, long value)
+        {
+            int lo = 0;
+            int hi = sorted.Length;
+            while (lo < hi)
+            {
+                int mid = lo + ((hi - lo) / 2);
+                if (sorted[mid] < value)
+                {
+                    lo = mid + 1;
+                }
+                else
+                {
+                    hi = mid;
+                }
+            }
+
+            return lo;
+        }
+    }
+
+    /// <summary>
+    /// Holds the lock under test in a field so the probe can drive it through delegates. The lock is a
+    /// mutable struct; a class field gives every thread a reference to the same instance.
+    /// </summary>
+    private sealed class TunedSpinLockBox
+    {
+        private SpinLock _spinLock = new();
+
+        public void Enter() => _spinLock.Enter();
+
+        public void Exit() => _spinLock.Exit();
+    }
+
+    /// <summary>
+    /// Control lock: the same test-and-set loop driven by <see cref="SpinWait.SpinOnce()"/>'s default
+    /// backoff, which is exactly what <see cref="SpinLock"/> looked like before the contention policy was
+    /// introduced. It exists to demonstrate, on the machine running the test, that the quantum cliff is
+    /// real rather than assumed.
+    /// </summary>
+    private sealed class DefaultSpinWaitLockBox
+    {
+        private volatile int _state;
+
+        public void Enter()
+        {
+            if (Interlocked.Exchange(ref _state, 1) == 0)
+            {
+                return;
+            }
+
+            var spinWait = new SpinWait();
+            do
+            {
+                spinWait.SpinOnce();
+            } while (Interlocked.Exchange(ref _state, 1) != 0);
+        }
+
+        public void Exit() => _state = 0;
+    }
+}

--- a/tests/Threading/Internal/SpinLockSpinCostTests.cs
+++ b/tests/Threading/Internal/SpinLockSpinCostTests.cs
@@ -1,0 +1,564 @@
+// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+// SPDX-License-Identifier: MIT
+
+namespace Threading.Tests.Internal;
+
+using CryptoHives.Foundation.Threading.Pools;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+using SpinLock = CryptoHives.Foundation.Threading.Internal.SpinLock;
+
+/// <summary>
+/// Measures the two quantities the <see cref="SpinLock"/> contention policy trades off against each
+/// other: what one spin costs, and what the critical sections being spun on cost.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SpinLockLatencyTests"/> shows that a waiter is not parked. This fixture answers the
+/// question that justifies the tuning in the first place: <see cref="SpinLock.Sleep1Threshold"/> is a
+/// count, and a count only means something once it is converted into wall-clock time. Timing a single
+/// spin turns the budget into the window it actually buys, and timing the guarded bodies shows how much
+/// of that window a real acquisition needs.
+/// </para>
+/// <para>
+/// <b>What is timed.</b> <see cref="SpinLock.SpinOnce"/> is the lock's own backoff step, called by
+/// <c>EnterCore</c> between two failed attempts to acquire. It is timed directly rather than
+/// reconstructed, because the two supported target families take materially different code paths -
+/// <c>SpinWait.SpinOnce(int)</c> where it exists, a hand-driven backoff where it does not - and a
+/// reconstruction would silently measure only one of them.
+/// </para>
+/// <para>
+/// <b>Shape of the curve.</b> The cost of a spin is not constant, which is the whole point of measuring
+/// it rather than assuming it. The first iterations are a handful of <c>pause</c> instructions and cost
+/// nanoseconds; the spin duration then doubles on each iteration until the framework's yield threshold,
+/// after which every iteration is a <c>Thread.Yield</c> or <c>Thread.Sleep(0)</c> costing a scheduler
+/// round-trip. So <see cref="ReportSpinCostAcrossTheBackoffCurve"/> reports the marginal cost at points
+/// along the curve, not one average that would describe neither end of it.
+/// </para>
+/// <para>
+/// <b>Caveat on the yield region.</b> These measurements are taken on a thread with no one to yield to.
+/// A yield with a runnable peer on the same core costs whatever that peer does before it comes back,
+/// so the tail of the curve is a floor, not a typical value. That is the correct floor for the question
+/// being asked - it bounds how quickly the budget can be burned through - and the contended case is what
+/// <see cref="SpinLockLatencyTests"/> measures instead.
+/// </para>
+/// <para>
+/// The fixture is <see cref="NonParallelizableAttribute">non-parallelizable</see>: it measures
+/// nanosecond-scale operations on a single thread, and a fixture running beside it would preempt the
+/// measurement loop. A <see cref="MeasurementGate"/> extends that exclusion across the
+/// per-target-framework test processes that <c>dotnet test</c> runs in parallel.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public class SpinLockSpinCostTests
+{
+    private MeasurementGate? _gate;
+
+    [OneTimeSetUp]
+    public void AcquireMeasurementGate()
+        => _gate = MeasurementGate.Acquire();
+
+    [OneTimeTearDown]
+    public void ReleaseMeasurementGate()
+        => _gate?.Dispose();
+
+    /// <summary>
+    /// Measurement batches per data point. The median is reported, so one preempted batch cannot move
+    /// the result.
+    /// </summary>
+    private const int MeasurementRounds = 7;
+
+    /// <summary>
+    /// Ceiling on the auto-calibrated repetition count, so a data point cannot run away if the machine
+    /// is slow enough that batches never reach the resolvable duration.
+    /// </summary>
+    private const int MaxRepetitions = 1 << 24;
+
+    /// <summary>
+    /// Timers created per measured batch. Fixed rather than auto-calibrated because every repetition
+    /// allocates a live timer, and the point of the row is the order of magnitude, not a tight figure.
+    /// </summary>
+    private const int TimerCreationBatch = 1_000;
+
+    /// <summary>
+    /// Ceiling on the cost of a single spin. The first iterations of the backoff are a few <c>pause</c>
+    /// instructions, so this has three orders of magnitude of headroom; it exists to catch a spin step
+    /// that has started doing something it should not, such as sleeping.
+    /// </summary>
+    private const double MaxSingleSpinNanoseconds = 1_000.0;
+
+    /// <summary>
+    /// Ceiling on the guarded body of a critical section. The bodies this lock guards are a few field
+    /// accesses and a linked-list splice, so this is a loose bound whose purpose is to fail if the claim
+    /// on <see cref="SpinLock"/> - that its critical sections are nanosecond-scale - ever stops holding.
+    /// </summary>
+    private const double MaxCriticalSectionNanoseconds = 1_000.0;
+
+    /// <summary>
+    /// How much finer than one park the mean spin has to be, taken over the whole budget. The measured
+    /// ratio is around a thousand; the assertion is set at ten so it states the design property - that
+    /// the backoff escalates in steps far smaller than the cliff it replaces - without being a
+    /// throughput test in disguise.
+    /// </summary>
+    private const double MinParkToSpinRatio = 10.0;
+
+    /// <summary>
+    /// Spin counts at which the backoff curve is sampled. The last entry is one short of
+    /// <see cref="SpinLock.Sleep1Threshold"/>, which is the last iteration before a park is permitted, so
+    /// the reported window is the whole spin budget and nothing else.
+    /// </summary>
+    private static readonly int[] SpinCheckpoints =
+        [1, 2, 4, 8, 10, 16, 20, 32, 64, 128, SpinLock.Sleep1Threshold - 1];
+
+    /// <summary>Spins available before the lock is first permitted to park.</summary>
+    private const int BudgetSpins = SpinLock.Sleep1Threshold - 1;
+
+    /// <summary>Consumes loop results so nothing being measured can be optimised away.</summary>
+    private static volatile int _sink;
+
+    /// <summary>
+    /// Reports what one spin costs at each point along the backoff curve, and the wall-clock window the
+    /// whole spin budget buys.
+    /// </summary>
+    /// <remarks>
+    /// The table is the deliverable. A single number would misrepresent a curve whose ends differ by two
+    /// orders of magnitude, and the cumulative column is what converts
+    /// <see cref="SpinLock.Sleep1Threshold"/> from a count into a duration.
+    /// </remarks>
+    [Test, CancelAfter(120_000)]
+    public void ReportSpinCostAcrossTheBackoffCurve()
+    {
+        double granularityMs = PlatformTimer.MeasureSleep1GranularityMilliseconds();
+        PlatformTimer.ReportGranularity(granularityMs);
+        PlatformTimer.ReportConfiguration();
+
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"{"  Thread.SpinWait(1)",-34} {MeasurePauseNanoseconds(),14:N2} ns");
+
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine(
+            $"Cost of one SpinLock.SpinOnce, uncontended (median of {MeasurementRounds} batches):");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"{"spins",8}{"cumulative us",18}{"marginal ns/spin",20}");
+
+        double previousNanoseconds = 0.0;
+        int previousSpins = 0;
+        double budgetNanoseconds = 0.0;
+
+        foreach (int spins in SpinCheckpoints)
+        {
+            double cumulativeNanoseconds = MeasureSpinBurstNanoseconds(spins);
+            double marginalNanoseconds =
+                (cumulativeNanoseconds - previousNanoseconds) / (spins - previousSpins);
+
+            TestContext.Out.WriteLine(
+                $"{spins,8}{cumulativeNanoseconds / 1_000.0,18:N3}{marginalNanoseconds,20:N1}");
+
+            previousNanoseconds = cumulativeNanoseconds;
+            previousSpins = spins;
+            budgetNanoseconds = cumulativeNanoseconds;
+        }
+
+        double granularityNanoseconds = granularityMs * 1_000_000.0;
+
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine("Spin budget:");
+        TestContext.Out.WriteLine($"{"  budget",-34} {BudgetSpins,14:N0} spins before a park is permitted");
+        TestContext.Out.WriteLine($"{"  window bought",-34} {budgetNanoseconds / 1_000.0,14:N2} us");
+        TestContext.Out.WriteLine($"{"  cost of one park instead",-34} {granularityMs * 1_000.0,14:N2} us");
+        TestContext.Out.WriteLine(
+            $"{"  whole budget vs one park",-34} {granularityNanoseconds / budgetNanoseconds,14:N1} x cheaper");
+
+        Assert.Pass();
+    }
+
+    /// <summary>
+    /// Asserts that one spin costs what a handful of instructions costs.
+    /// </summary>
+    /// <remarks>
+    /// This is the assertion the rest of the contention policy rests on. If a single step of the backoff
+    /// were expensive, raising <see cref="SpinLock.Sleep1Threshold"/> from the framework's twenty to two
+    /// hundred would not be avoiding a latency cliff, it would be building a longer one.
+    /// </remarks>
+    [Test, CancelAfter(60_000)]
+    public void OneSpinCostsNanosecondsNotMicroseconds()
+    {
+        double singleSpinNanoseconds = MeasureSpinBurstNanoseconds(1);
+
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"{"one spin",-34} {singleSpinNanoseconds,14:N2} ns");
+        TestContext.Out.WriteLine($"{"  budget",-34} {MaxSingleSpinNanoseconds,14:N2} ns");
+        PlatformTimer.ReportConfiguration();
+
+        Assert.That(
+            singleSpinNanoseconds,
+            Is.LessThan(MaxSingleSpinNanoseconds),
+            $"One spin measured {singleSpinNanoseconds:N1} ns. The first iterations of the backoff are a " +
+            "few pause instructions; anything near a microsecond means the step is blocking.");
+    }
+
+    /// <summary>
+    /// Asserts that the backoff escalates in steps far finer than the park it exists to replace.
+    /// </summary>
+    /// <remarks>
+    /// Expressed as a ratio against the platform's measured <c>Thread.Sleep(1)</c> granularity rather
+    /// than an absolute bound, so it means the same thing on Windows - where a park is roughly 15.6 ms -
+    /// and on platforms where it is closer to a millisecond.
+    /// </remarks>
+    [Test, CancelAfter(120_000)]
+    public void SpinGranularityIsFinerThanTheParkItReplaces()
+    {
+        double granularityMs = PlatformTimer.MeasureSleep1GranularityMilliseconds();
+        double budgetNanoseconds = MeasureSpinBurstNanoseconds(BudgetSpins);
+        double meanSpinNanoseconds = budgetNanoseconds / BudgetSpins;
+        double parkNanoseconds = granularityMs * 1_000_000.0;
+        double ratio = parkNanoseconds / meanSpinNanoseconds;
+
+        PlatformTimer.ReportGranularity(granularityMs);
+        PlatformTimer.ReportConfiguration();
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"{"mean spin over the budget",-34} {meanSpinNanoseconds,14:N1} ns");
+        TestContext.Out.WriteLine($"{"one park",-34} {parkNanoseconds,14:N1} ns");
+        TestContext.Out.WriteLine($"{"ratio",-34} {ratio,14:N1} x");
+        TestContext.Out.WriteLine($"{"  budget",-34} {MinParkToSpinRatio,14:N1} x");
+
+        Assert.That(
+            ratio,
+            Is.GreaterThan(MinParkToSpinRatio),
+            $"A park costs {parkNanoseconds:N0} ns and the mean spin {meanSpinNanoseconds:N0} ns, a ratio " +
+            $"of only {ratio:N1}. The backoff is supposed to escalate in steps far smaller than the cliff " +
+            "it replaces.");
+    }
+
+    /// <summary>
+    /// Reports how long the lock is actually held, and asserts that the bodies on the primitives' normal
+    /// paths are the nanosecond-scale the contention policy on <see cref="SpinLock"/> claims.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A waiter waits for the guarded body, not for the whole <c>Enter</c>/<c>Exit</c> round trip, so the
+    /// bodies are timed unguarded as well as guarded. Differencing the two alone would not work here: the
+    /// bodies turn out to be smaller than the run-to-run spread on the lock itself, so the difference is
+    /// noise while the direct measurement is not.
+    /// </para>
+    /// <para>
+    /// <b>These are floors, not typical values.</b> A tight loop over one queue node keeps every line in
+    /// L1 and every branch predicted, which a real acquisition does not. The figures bound how short the
+    /// critical sections can be, and that is the direction the contention policy needs: they establish
+    /// that the guarded work is orders of magnitude below one spin, so a waiter that spins is trading a
+    /// nanosecond-scale wait against a nanosecond-scale spin.
+    /// </para>
+    /// <para>
+    /// <b>The timeout path is the outlier, and is deliberately excluded from the assertions.</b> Every
+    /// <c>*Async(TimeSpan, …)</c> overload in the library creates its timeout timer while holding this
+    /// lock. That body allocates and takes the runtime's own timer-queue lock, and measures around two
+    /// orders of magnitude above the others - still comfortably inside the spin budget on an idle
+    /// machine, but it is the one guarded body whose cost is not bounded by this library, since it
+    /// depends on a lock and a data structure shared with every other timer in the process. It is
+    /// reported rather than asserted because it is a property of the callers, not of the lock; the row
+    /// exists so the deviation is visible rather than assumed away.
+    /// </para>
+    /// </remarks>
+    [Test, CancelAfter(120_000)]
+    public void GuardedCriticalSectionIsNanosecondScale()
+    {
+        double lockOnlyNanoseconds = Measure(RunEmptyCriticalSection);
+        double releaseBodyNanoseconds = Measure(RunReleaseBody);
+        double handoffBodyNanoseconds = Measure(RunWaiterHandoffBody);
+        double releaseNanoseconds = Measure(RunReleaseCriticalSection);
+        double handoffNanoseconds = Measure(RunWaiterHandoffCriticalSection);
+        double timerNanoseconds = MeasureTimerCreationNanoseconds();
+
+        PlatformTimer.ReportConfiguration();
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"Time spent inside the lock (median of {MeasurementRounds} batches):");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"{"workload",-38}{"body ns",12}{"with lock ns",14}");
+        TestContext.Out.WriteLine($"{"Enter + Exit, nothing guarded",-38}{0.0,12:N1}{lockOnlyNanoseconds,14:N1}");
+        TestContext.Out.WriteLine($"{"release with no waiters",-38}{releaseBodyNanoseconds,12:N1}{releaseNanoseconds,14:N1}");
+        TestContext.Out.WriteLine($"{"waiter handoff (enqueue + dequeue)",-38}{handoffBodyNanoseconds,12:N1}{handoffNanoseconds,14:N1}");
+        TestContext.Out.WriteLine($"{"timeout timer creation",-38}{timerNanoseconds,12:N1}{"not asserted",14}");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"{"  budget for a body",-38}{MaxCriticalSectionNanoseconds,12:N1}");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                releaseBodyNanoseconds,
+                Is.LessThan(MaxCriticalSectionNanoseconds),
+                "The uncontended release path should be a queue-length check and a store.");
+
+            Assert.That(
+                handoffBodyNanoseconds,
+                Is.LessThan(MaxCriticalSectionNanoseconds),
+                "A waiter handoff should be two splices of an intrusive linked list.");
+        }
+    }
+
+    /// <summary>
+    /// Times <paramref name="spins"/> consecutive spins from a fresh backoff state, as the median of
+    /// several auto-calibrated batches.
+    /// </summary>
+    /// <remarks>
+    /// The state is reset for every burst because the cost of a spin depends on how many have already
+    /// happened; timing spins from a shared, ever-advancing state would measure only the yield region.
+    /// </remarks>
+    private static double MeasureSpinBurstNanoseconds(int spins)
+    {
+        int repetitions = CalibrateRepetitions(spins);
+        double[] rounds = new double[MeasurementRounds];
+
+        for (int i = 0; i < rounds.Length; i++)
+        {
+            rounds[i] = PlatformTimer.ToNanoseconds(RunSpinBurst(spins, repetitions)) / repetitions;
+        }
+
+        Array.Sort(rounds);
+        return rounds[rounds.Length / 2];
+    }
+
+    /// <summary>
+    /// Grows the batch size until one batch spans enough counter ticks to be resolvable, and returns it.
+    /// </summary>
+    /// <remarks>
+    /// The high performance counter ticks at 100 ns on Windows, which is an order of magnitude coarser
+    /// than the operation being timed, so a single spin cannot be measured directly - only a batch large
+    /// enough to dwarf the counter's resolution. Running the calibration first also gets the loop jitted
+    /// and the caches warm before the measured batches start.
+    /// </remarks>
+    private static int CalibrateRepetitions(int spins)
+    {
+        int repetitions = 1;
+        while (repetitions < MaxRepetitions && RunSpinBurst(spins, repetitions) < MinBatchTicks)
+        {
+            repetitions *= 2;
+        }
+
+        return repetitions;
+    }
+
+    /// <summary>Same calibrate-then-median protocol, for the critical-section workloads.</summary>
+    private static double Measure(Func<int, long> workload)
+    {
+        int repetitions = 1;
+        while (repetitions < MaxRepetitions && workload(repetitions) < MinBatchTicks)
+        {
+            repetitions *= 2;
+        }
+
+        double[] rounds = new double[MeasurementRounds];
+        for (int i = 0; i < rounds.Length; i++)
+        {
+            rounds[i] = PlatformTimer.ToNanoseconds(workload(repetitions)) / repetitions;
+        }
+
+        Array.Sort(rounds);
+        return rounds[rounds.Length / 2];
+    }
+
+    /// <summary>Counter ticks a batch has to span - about a millisecond - to be worth timing.</summary>
+    private static long MinBatchTicks => Math.Max(1L, Stopwatch.Frequency / 1_000L);
+
+    /// <summary>Ticks taken by <paramref name="repetitions"/> bursts of <paramref name="spins"/> spins.</summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long RunSpinBurst(int spins, int repetitions)
+    {
+        long start = Stopwatch.GetTimestamp();
+
+        for (int r = 0; r < repetitions; r++)
+        {
+            var spinWait = new SpinWait();
+            int spinCount = 0;
+
+            for (int i = 0; i < spins; i++)
+            {
+                SpinLock.SpinOnce(ref spinWait, ref spinCount);
+            }
+
+            _sink = spinCount;
+        }
+
+        return Stopwatch.GetTimestamp() - start;
+    }
+
+    /// <summary>Ticks taken by <paramref name="repetitions"/> uncontended <c>Thread.SpinWait(1)</c> calls.</summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long RunPause(int repetitions)
+    {
+        long start = Stopwatch.GetTimestamp();
+
+        for (int i = 0; i < repetitions; i++)
+        {
+            Thread.SpinWait(1);
+        }
+
+        return Stopwatch.GetTimestamp() - start;
+    }
+
+    /// <summary>Cost of the primitive the whole backoff is built out of.</summary>
+    private static double MeasurePauseNanoseconds()
+        => Measure(RunPause);
+
+    /// <summary>Lock overhead with nothing in the critical section: the floor the workloads sit on.</summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long RunEmptyCriticalSection(int repetitions)
+    {
+        var spinLock = new SpinLock();
+        long start = Stopwatch.GetTimestamp();
+
+        for (int i = 0; i < repetitions; i++)
+        {
+            spinLock.Enter();
+            spinLock.Exit();
+        }
+
+        return Stopwatch.GetTimestamp() - start;
+    }
+
+    /// <summary>
+    /// The uncontended release path of the async primitives: check whether anyone is queued, and if not
+    /// drop the held flag.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long RunReleaseCriticalSection(int repetitions)
+    {
+        var spinLock = new SpinLock();
+        var waiters = new WaiterQueue<bool>();
+        int taken = 1;
+
+        long start = Stopwatch.GetTimestamp();
+
+        for (int i = 0; i < repetitions; i++)
+        {
+            spinLock.Enter();
+            if (waiters.Count == 0)
+            {
+                taken = 0;
+            }
+
+            spinLock.Exit();
+            _sink = taken;
+        }
+
+        return Stopwatch.GetTimestamp() - start;
+    }
+
+    /// <summary>The same release path with the lock taken out, to time the guarded body on its own.</summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long RunReleaseBody(int repetitions)
+    {
+        var waiters = new WaiterQueue<bool>();
+        int taken = 1;
+
+        long start = Stopwatch.GetTimestamp();
+
+        for (int i = 0; i < repetitions; i++)
+        {
+            if (waiters.Count == 0)
+            {
+                taken = 0;
+            }
+
+            _sink = taken;
+        }
+
+        return Stopwatch.GetTimestamp() - start;
+    }
+
+    /// <summary>
+    /// The contended path: a waiter is spliced into the intrusive queue and the next one is spliced back
+    /// out. This is the longest body any of the primitives runs under the lock on its normal path.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long RunWaiterHandoffCriticalSection(int repetitions)
+    {
+        var spinLock = new SpinLock();
+        var waiters = new WaiterQueue<bool>();
+        var waiter = new LocalManualResetValueTaskSource<bool>(new object());
+
+        long start = Stopwatch.GetTimestamp();
+
+        for (int i = 0; i < repetitions; i++)
+        {
+            spinLock.Enter();
+            waiters.Enqueue(waiter);
+            _sink = waiters.Count;
+            _ = waiters.Dequeue();
+            spinLock.Exit();
+        }
+
+        return Stopwatch.GetTimestamp() - start;
+    }
+
+    /// <summary>The same handoff with the lock taken out, to time the guarded body on its own.</summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long RunWaiterHandoffBody(int repetitions)
+    {
+        var waiters = new WaiterQueue<bool>();
+        var waiter = new LocalManualResetValueTaskSource<bool>(new object());
+
+        long start = Stopwatch.GetTimestamp();
+
+        for (int i = 0; i < repetitions; i++)
+        {
+            waiters.Enqueue(waiter);
+            _sink = waiters.Count;
+            _ = waiters.Dequeue();
+        }
+
+        return Stopwatch.GetTimestamp() - start;
+    }
+
+    /// <summary>
+    /// Times <c>TimeProvider.System.CreateTimer</c>, which every <c>*Async(TimeSpan, …)</c> overload in
+    /// the library calls while holding the spin lock.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not auto-calibrated: each repetition allocates a live timer, so the batch is fixed
+    /// and small. The timers are disposed outside the timed region, because the critical section only
+    /// creates them - charging disposal to it would overstate the cost being reported.
+    /// </remarks>
+    private static double MeasureTimerCreationNanoseconds()
+    {
+        var timers = new ITimer[TimerCreationBatch];
+        var callback = new TimerCallback(static _ => { });
+        double[] rounds = new double[MeasurementRounds];
+
+        // A finite due time, as the library passes. An infinite one is never inserted into the runtime's
+        // timer queue at all, so it would measure an allocation and miss the queue lock entirely. The
+        // value is far enough out that nothing fires while the measurement runs.
+        TimeSpan dueTime = TimeSpan.FromMinutes(10);
+
+        // One unmeasured round to jit the path and warm the runtime's timer queue.
+        for (int round = -1; round < rounds.Length; round++)
+        {
+            long start = Stopwatch.GetTimestamp();
+
+            for (int i = 0; i < timers.Length; i++)
+            {
+                timers[i] = TimeProvider.System.CreateTimer(
+                    callback, null, dueTime, Timeout.InfiniteTimeSpan);
+            }
+
+            long ticks = Stopwatch.GetTimestamp() - start;
+
+            for (int i = 0; i < timers.Length; i++)
+            {
+                timers[i].Dispose();
+            }
+
+            if (round >= 0)
+            {
+                rounds[round] = PlatformTimer.ToNanoseconds(ticks) / timers.Length;
+            }
+        }
+
+        Array.Sort(rounds);
+        return rounds[rounds.Length / 2];
+    }
+}

--- a/tests/Threading/Internal/SpinLockTests.cs
+++ b/tests/Threading/Internal/SpinLockTests.cs
@@ -78,7 +78,7 @@ public class SpinLockTests
     /// <summary>
     /// Number of threads to use in contention tests.
     /// </summary>
-    private int _threadCount = Environment.ProcessorCount;
+    private readonly int _threadCount = Environment.ProcessorCount;
 
     [Test, CancelAfter(5_000)]
     public void TryEnterReturnsTrueWhenUncontended()

--- a/tests/Threading/Internal/SpinLockTests.cs
+++ b/tests/Threading/Internal/SpinLockTests.cs
@@ -5,6 +5,7 @@ namespace Threading.Tests.Internal;
 
 using NUnit.Framework;
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -34,7 +35,16 @@ using SpinLock = CryptoHives.Foundation.Threading.Internal.SpinLock;
 ///   <item><description>Store ordering: data written inside the critical section is fully visible
 ///     to the next thread that acquires the lock.</description></item>
 ///   <item><description>No lost updates: a shared counter incremented under the lock never loses increments.</description></item>
+///   <item><description>No quantum stalls: the run completes at a mean cost per acquisition that is
+///     impossible if waiters are being parked on the scheduler-quantum timer.</description></item>
 /// </list>
+/// </para>
+/// <para>
+/// Each contention test is bounded twice over. <c>CancelAfter</c> is the outer bound - it stops a run that
+/// has stalled outright rather than letting it hang the suite - and
+/// <see cref="MaxMeanAcquisitionMicroseconds"/> is the inner one, which fails long before the outer bound
+/// is reached. Per-acquisition latency, rather than the aggregate, is measured in
+/// <see cref="SpinLockLatencyTests"/>.
 /// </para>
 /// </remarks>
 [TestFixture]
@@ -42,16 +52,35 @@ using SpinLock = CryptoHives.Foundation.Threading.Internal.SpinLock;
 public class SpinLockTests
 {
     /// <summary>
-    /// Number of threads to use in contention tests.
-    /// </summary>
-    private const int ThreadCount = 8;
-
-    /// <summary>
     /// Number of iterations each thread performs.
     /// </summary>
     private const int IterationsPerThread = 200_000;
 
-    [Test]
+    /// <summary>
+    /// Ceiling on the mean wall-clock cost of one acquisition across a contention run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the aggregate form of the per-acquisition assertion in <see cref="SpinLockLatencyTests"/>.
+    /// A contended acquisition of a nanosecond-scale critical section costs a fraction of a microsecond,
+    /// so a mean in the tens of microseconds can only mean waiters are being parked on the scheduler
+    /// quantum - roughly 15.6 ms on Windows, see the contention policy on <see cref="SpinLock"/>.
+    /// </para>
+    /// <para>
+    /// The bound is deliberately loose against measured throughput - runs here sit well under a
+    /// microsecond per acquisition - because it has to hold on a loaded CI agent. It is still tight
+    /// enough to be worth having: at 15.6 ms a park, one park per six hundred acquisitions would breach
+    /// it, and a regression to the framework's default backoff parks far more often than that.
+    /// </para>
+    /// </remarks>
+    private const double MaxMeanAcquisitionMicroseconds = 25.0;
+
+    /// <summary>
+    /// Number of threads to use in contention tests.
+    /// </summary>
+    private int _threadCount = Environment.ProcessorCount;
+
+    [Test, CancelAfter(5_000)]
     public void TryEnterReturnsTrueWhenUncontended()
     {
         var spinLock = new SpinLock();
@@ -61,7 +90,7 @@ public class SpinLockTests
         spinLock.Exit();
     }
 
-    [Test]
+    [Test, CancelAfter(5_000)]
     public void TryEnterReturnsFalseWhenAlreadyHeld()
     {
         var spinLock = new SpinLock();
@@ -72,7 +101,7 @@ public class SpinLockTests
         spinLock.Exit();
     }
 
-    [Test]
+    [Test, CancelAfter(5_000)]
     public void EnterAndExitAreReusable()
     {
         var spinLock = new SpinLock();
@@ -99,7 +128,7 @@ public class SpinLockTests
         var spinLock = new SpinLock();
         long sharedCounter = 0;
 
-        RunContentionTest(ThreadCount, IterationsPerThread, () => {
+        TimeSpan elapsed = RunContentionTest(_threadCount, IterationsPerThread, () => {
             for (int i = 0; i < IterationsPerThread; i++)
             {
                 spinLock.Enter();
@@ -108,7 +137,9 @@ public class SpinLockTests
             }
         });
 
-        Assert.That(sharedCounter, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+        AssertNoQuantumStalls(nameof(MutualExclusionUnderContention), _threadCount, (long)_threadCount * IterationsPerThread, elapsed);
+
+        Assert.That(sharedCounter, Is.EqualTo((long)_threadCount * IterationsPerThread));
     }
 
     /// <summary>
@@ -130,7 +161,7 @@ public class SpinLockTests
         long sharedB = 0;
         int violations = 0;
 
-        RunContentionTest(ThreadCount, IterationsPerThread, () => {
+        TimeSpan elapsed = RunContentionTest(_threadCount, IterationsPerThread, () => {
             for (int i = 0; i < IterationsPerThread; i++)
             {
                 spinLock.Enter();
@@ -152,12 +183,14 @@ public class SpinLockTests
             }
         });
 
+        AssertNoQuantumStalls(nameof(StoreOrderingIsPreservedAcrossRelease), _threadCount, (long)_threadCount * IterationsPerThread, elapsed);
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(violations, Is.Zero, "Inconsistent pair observed: release reordered before stores");
             Assert.That(sharedA, Is.EqualTo(sharedB));
+            Assert.That(sharedA, Is.EqualTo((long)_threadCount * IterationsPerThread));
         }
-        Assert.That(sharedA, Is.EqualTo((long)ThreadCount * IterationsPerThread));
     }
 
     /// <summary>
@@ -174,7 +207,7 @@ public class SpinLockTests
         long word0 = 0, word1 = 0, word2 = 0, word3 = 0;
         int violations = 0;
 
-        RunContentionTest(ThreadCount, IterationsPerThread, () => {
+        TimeSpan elapsed = RunContentionTest(_threadCount, IterationsPerThread, () => {
             for (int i = 0; i < IterationsPerThread; i++)
             {
                 spinLock.Enter();
@@ -200,10 +233,12 @@ public class SpinLockTests
             }
         });
 
+        AssertNoQuantumStalls(nameof(AcquirerSeesAllStoresFromPreviousHolder), _threadCount, (long)_threadCount * IterationsPerThread, elapsed);
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(violations, Is.Zero, "Acquirer observed partially-written state from previous holder");
-            Assert.That(word0, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+            Assert.That(word0, Is.EqualTo((long)_threadCount * IterationsPerThread));
         }
     }
 
@@ -220,7 +255,7 @@ public class SpinLockTests
         long payload = 0;
         int violations = 0;
 
-        RunContentionTest(ThreadCount, IterationsPerThread, () => {
+        TimeSpan elapsed = RunContentionTest(_threadCount, IterationsPerThread, () => {
             for (int i = 0; i < IterationsPerThread; i++)
             {
                 spinLock.Enter();
@@ -243,10 +278,12 @@ public class SpinLockTests
             }
         });
 
+        AssertNoQuantumStalls(nameof(ProducerConsumerHandoffIsOrdered), _threadCount, (long)_threadCount * IterationsPerThread, elapsed);
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(violations, Is.Zero, "Payload/sequence mismatch: release did not fence stores");
-            Assert.That(sequence, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+            Assert.That(sequence, Is.EqualTo((long)_threadCount * IterationsPerThread));
         }
     }
 
@@ -263,7 +300,7 @@ public class SpinLockTests
         int concurrencyViolations = 0;
         long totalIterations = 0;
 
-        RunContentionTest(ThreadCount, IterationsPerThread, () => {
+        TimeSpan elapsed = RunContentionTest(_threadCount, IterationsPerThread, () => {
             for (int i = 0; i < IterationsPerThread; i++)
             {
                 spinLock.Enter();
@@ -284,10 +321,12 @@ public class SpinLockTests
             }
         });
 
+        AssertNoQuantumStalls(nameof(NoConcurrentCriticalSectionEntry), _threadCount, (long)_threadCount * IterationsPerThread, elapsed);
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(concurrencyViolations, Is.Zero, "Multiple threads entered the critical section simultaneously");
-            Assert.That(totalIterations, Is.EqualTo((long)ThreadCount * IterationsPerThread));
+            Assert.That(totalIterations, Is.EqualTo((long)_threadCount * IterationsPerThread));
         }
     }
 
@@ -303,10 +342,10 @@ public class SpinLockTests
         long sharedCounter = 0;
         int iterations = IterationsPerThread / 2;
 
-        var threads = new Thread[ThreadCount];
+        var threads = new Thread[_threadCount];
         using var barrier = new ManualResetEventSlim(false);
 
-        for (int t = 0; t < ThreadCount; t++)
+        for (int t = 0; t < _threadCount; t++)
         {
             int threadId = t;
             threads[t] = new Thread(() => {
@@ -336,22 +375,32 @@ public class SpinLockTests
             threads[t].Start();
         }
 
+        long start = Stopwatch.GetTimestamp();
         barrier.Set();
 
-        for (int t = 0; t < ThreadCount; t++)
+        for (int t = 0; t < _threadCount; t++)
         {
             threads[t].Join();
         }
 
-        Assert.That(sharedCounter, Is.EqualTo((long)ThreadCount * iterations));
+        TimeSpan elapsed = Elapsed(start);
+
+        AssertNoQuantumStalls(nameof(AsymmetricWorkloadMaintainsConsistency), _threadCount, (long)_threadCount * iterations, elapsed);
+
+        Assert.That(sharedCounter, Is.EqualTo((long)_threadCount * iterations));
     }
 
     /// <summary>
     /// Runs the specified action on <paramref name="threadCount"/> threads in parallel,
     /// with a barrier to synchronize start and maximize contention.
     /// </summary>
+    /// <returns>
+    /// Wall-clock time from the moment the threads were released to the moment the last one finished,
+    /// taken from the high performance counter. The timer starts after the threads have been created, so
+    /// thread-creation cost is not charged to the lock.
+    /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void RunContentionTest(int threadCount, int iterationsPerThread, Action body)
+    private static TimeSpan RunContentionTest(int threadCount, int iterationsPerThread, Action body)
     {
         var threads = new Thread[threadCount];
         using var barrier = new ManualResetEventSlim(false);
@@ -368,11 +417,42 @@ public class SpinLockTests
         }
 
         // Release all threads simultaneously for maximum contention.
+        long start = Stopwatch.GetTimestamp();
         barrier.Set();
 
         for (int t = 0; t < threadCount; t++)
         {
             threads[t].Join();
         }
+
+        return Elapsed(start);
+    }
+
+    /// <summary>High performance counter ticks since <paramref name="start"/>, as a <see cref="TimeSpan"/>.</summary>
+    private static TimeSpan Elapsed(long start)
+        => TimeSpan.FromMilliseconds((Stopwatch.GetTimestamp() - start) * 1000.0 / Stopwatch.Frequency);
+
+    /// <summary>
+    /// Reports the throughput of a contention run and asserts that no waiter was parked on the
+    /// scheduler-quantum timer often enough to show up in the aggregate.
+    /// </summary>
+    /// <param name="operation">Name of the run, for the report.</param>
+    /// <param name="threadCount">Threads that took part.</param>
+    /// <param name="acquisitions">Total lock acquisitions across all threads.</param>
+    /// <param name="elapsed">Wall-clock time the run took.</param>
+    private static void AssertNoQuantumStalls(string operation, int threadCount, long acquisitions, TimeSpan elapsed)
+    {
+        double microsecondsPerAcquisition = elapsed.TotalMilliseconds * 1000.0 / acquisitions;
+
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"{operation}: {acquisitions:N0} acquisitions on {threadCount} threads in {elapsed.TotalMilliseconds:N1} ms");
+        TestContext.Out.WriteLine($"{"  mean per acquisition",-32} {microsecondsPerAcquisition,10:N3} us");
+        TestContext.Out.WriteLine($"{"  budget",-32} {MaxMeanAcquisitionMicroseconds,10:N3} us");
+
+        Assert.That(
+            microsecondsPerAcquisition,
+            Is.LessThan(MaxMeanAcquisitionMicroseconds),
+            $"{microsecondsPerAcquisition:N1} us per acquisition of a critical section that is a handful of " +
+            "instructions long: waiters are being parked rather than spun.");
     }
 }


### PR DESCRIPTION
## Description

On high contention the spin lock may fall into the Sleep(1) trap too early, so the threshold is increased from default 20 to 200.
Add codepath for older TFM that don't support the parameter.
Add tests to measure the latency and cost of the spin lock.

## Type of change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [x] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [ ] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

## Notes for reviewers

<!--
  Cryptography: cross-validated against a reference implementation and known-answer test vectors?
  Threading:    ValueTask contract respected (no CHT00x analyzer violations)?
  Perf-sensitive: benchmark numbers before/after?
-->
