### PR TITLE
Fix AsyncBarrier deadlock by running the post-phase action outside the lock

### DIFF
--- a/src/Threading/Async/Pooled/AsyncBarrier.cs
+++ b/src/Threading/Async/Pooled/AsyncBarrier.cs
@@ -33,6 +33,18 @@ using System.Threading.Tasks.Sources;
 /// receive a <see cref="BarrierPostPhaseException"/>.
 /// </para>
 /// <para>
+/// <b>Post-phase action contract:</b> the action runs on the thread of the participant that completed
+/// the phase - the last to signal, or the caller of <see cref="RemoveParticipants"/> that removed the
+/// last outstanding one. It observes <see cref="CurrentPhase"/> as the phase it is completing, and no
+/// participant is released until it returns. It runs with no internal lock held, so it may block, do
+/// I/O, or take as long as it needs; in particular it may cancel a
+/// <see cref="CancellationToken"/> that one of this barrier's own waiters is registered on without
+/// deadlocking. It must not reenter the barrier:
+/// <see cref="SignalAndWaitAsync(CancellationToken)"/>, <see cref="AddParticipants"/> and
+/// <see cref="RemoveParticipants"/> all throw <see cref="InvalidOperationException"/> when called from
+/// within it.
+/// </para>
+/// <para>
 /// <b>Optional timeout and cancellation token</b> parameters on
 /// <see cref="SignalAndWaitAsync(TimeSpan, CancellationToken)"/>.
 /// </para>
@@ -80,14 +92,20 @@ using System.Threading.Tasks.Sources;
 /// </remarks>
 public sealed class AsyncBarrier
 {
+    /// <summary>
+    /// Value of <see cref="_phaseTransitionThreadId"/> when no post-phase action is running.
+    /// </summary>
+    private const int NoPhaseTransition = 0;
+
     private readonly IGetPooledManualResetValueTaskSource<bool> _pool;
     private readonly Action<AsyncBarrier>? _postPhaseAction;
-    private Internal.SpinLock _spinLock;
+    private readonly object _lock;
     private WaiterQueue<bool> _waiters;
     private int _participantCount;
     private int _participantsRemaining;
     private long _currentPhase;
     private bool _runContinuationAsynchronously;
+    private int _phaseTransitionThreadId;
 
     /// <summary>
     /// Constructs a new AsyncBarrier instance with the specified number of participants.
@@ -122,7 +140,8 @@ public sealed class AsyncBarrier
         _currentPhase = 0;
         _postPhaseAction = postPhaseAction;
         _runContinuationAsynchronously = runContinuationAsynchronously;
-        _spinLock = new();
+        _phaseTransitionThreadId = NoPhaseTransition;
+        _lock = new();
         _waiters = new();
         _pool = pool ?? ValueTaskSourceObjectPools.ValueTaskSourcePoolBoolean;
     }
@@ -208,12 +227,14 @@ public sealed class AsyncBarrier
         if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan) throw new ArgumentOutOfRangeException(nameof(timeout));
 
         ManualResetValueTaskSource<bool>? toReleaseChain = null;
-        Exception? postPhaseException = null;
-        bool earlyExit = false;
+        PooledManualResetValueTaskSource<bool>? waiter = null;
+        bool postPhaseActionPending = false;
+        short version = 0;
 
-        _spinLock.Enter();
-        try
+        lock (_lock)
         {
+            WaitForStablePhase();
+
             if (_participantsRemaining <= 0)
             {
                 throw new InvalidOperationException("The number of threads using the barrier exceeded the total number of registered participants.");
@@ -235,11 +256,11 @@ public sealed class AsyncBarrier
                     return new ValueTask(Task.FromException(new TimeoutException()));
                 }
 
-                PooledManualResetValueTaskSource<bool> waiter = _pool.GetPooledWaiter(this);
+                waiter = _pool.GetPooledWaiter(this);
                 waiter.RunContinuationsAsynchronously = _runContinuationAsynchronously;
                 waiter.CancellationToken = cancellationToken;
 
-                short version = waiter.Version;
+                version = waiter.Version;
                 _waiters.Enqueue(waiter);
 
                 if (timeout != Timeout.InfiniteTimeSpan)
@@ -247,65 +268,140 @@ public sealed class AsyncBarrier
                     waiter.TimeoutTimer = TimeProvider.System.CreateTimer(
                         _timerCallbackAction, new TimeoutState<bool>(waiter), timeout, Timeout.InfiniteTimeSpan);
                 }
+            }
+            else
+            {
+                // Last participant. Detach the waiters up front, so timeout or cancel callback can finish
+                // instead of waiting for the post phase action.
+                toReleaseChain = _waiters.DetachAll(out _);
 
-                earlyExit = true;
-                _spinLock.Exit();
-
-                if (cancellationToken.CanBeCanceled)
+                if (_postPhaseAction is null)
                 {
-#if NET6_0_OR_GREATER
-                    // Use UnsafeRegister on .NET 6+ for allocation free registration
-                    waiter.CancellationTokenRegistration =
-                        cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
-#else
-                    waiter.CancellationTokenRegistration =
-                        cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
-#endif
+                    AdvancePhase();
                 }
                 else
                 {
-                    Debug.Assert(waiter.CancellationTokenRegistration == default);
+                    // Advancing is deferred until the action has run, so that it observes the phase it
+                    // is completing rather than the next one.
+                    _phaseTransitionThreadId = Environment.CurrentManagedThreadId;
+                    postPhaseActionPending = true;
                 }
-
-                return new ValueTask(waiter, version);
-            }
-
-            // Last participant - execute post-phase action, then release all waiters and advance phase
-            if (_postPhaseAction is not null)
-            {
-                try
-                {
-                    _postPhaseAction(this);
-                }
-                catch (Exception ex) when (ex is not OutOfMemoryException
-                    && ex is not StackOverflowException
-                    && ex is not AccessViolationException)
-                {
-                    postPhaseException = new BarrierPostPhaseException(ex);
-                }
-            }
-
-            _participantsRemaining = _participantCount;
-            _currentPhase++;
-
-            toReleaseChain = _waiters.DetachAll(out _);
-        }
-        finally
-        {
-            if (!earlyExit)
-            {
-                _spinLock.Exit();
             }
         }
 
-        if (postPhaseException is not null)
+        if (waiter is not null)
         {
-            WaiterQueue<bool>.SetChainException(toReleaseChain, postPhaseException);
-            return new ValueTask(Task.FromException(postPhaseException));
+            // Registered outside the lock: the callback can fire synchronously on this thread if the
+            // token is already cancelled, and it takes the lock itself.
+            if (cancellationToken.CanBeCanceled)
+            {
+#if NET6_0_OR_GREATER
+                // Use UnsafeRegister on .NET 6+ for allocation free registration
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.UnsafeRegister(_cancellationCallbackAction, waiter);
+#else
+                waiter.CancellationTokenRegistration =
+                    cancellationToken.Register(CancellationCallback, waiter, useSynchronizationContext: false);
+#endif
+            }
+            else
+            {
+                Debug.Assert(waiter.CancellationTokenRegistration == default);
+            }
+
+            return new ValueTask(waiter, version);
+        }
+
+        if (postPhaseActionPending)
+        {
+            Exception? postPhaseException = RunPostPhaseActionAndAdvancePhase();
+
+            if (postPhaseException is not null)
+            {
+                WaiterQueue<bool>.SetChainException(toReleaseChain, postPhaseException);
+                return new ValueTask(Task.FromException(postPhaseException));
+            }
         }
 
         toReleaseChain?.SetChainResult(true);
         return default;
+    }
+
+    /// <summary>
+    /// Resets the participant count for the next phase and advances the phase number.
+    /// </summary>
+    /// <remarks>Must be called while holding <see cref="_lock"/>.</remarks>
+    private void AdvancePhase()
+    {
+        _participantsRemaining = _participantCount;
+        _currentPhase++;
+    }
+
+    /// <summary>
+    /// Blocks until no post-phase action is running.
+    /// </summary>
+    /// <remarks>
+    /// Must be called while holding <see cref="_lock"/>. The reentrancy check has to precede the wait:
+    /// a monitor is reentrant, so the thread running the action would otherwise re-enter the lock and
+    /// then wait for itself to finish.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from the thread currently running the post-phase action.
+    /// </exception>
+    private void WaitForStablePhase()
+    {
+        while (_phaseTransitionThreadId != NoPhaseTransition)
+        {
+            if (_phaseTransitionThreadId == Environment.CurrentManagedThreadId)
+            {
+                throw new InvalidOperationException(
+                    "The barrier cannot be reentered from within its own post-phase action.");
+            }
+
+            Monitor.Wait(_lock);
+        }
+    }
+
+    /// <summary>
+    /// Runs the post-phase action outside <see cref="_lock"/>, then advances the phase and ends the
+    /// transition under it.
+    /// </summary>
+    /// <remarks>
+    /// The phase is advanced in a <see langword="finally"/> so that an action throwing something outside
+    /// the caught set - <see cref="OutOfMemoryException"/> and friends - still leaves the barrier usable
+    /// rather than wedged in a transition no other operation can get past.
+    /// </remarks>
+    /// <returns>
+    /// The <see cref="BarrierPostPhaseException"/> wrapping whatever the action threw, or
+    /// <see langword="null"/> if it returned normally.
+    /// </returns>
+    private Exception? RunPostPhaseActionAndAdvancePhase()
+    {
+        Debug.Assert(_postPhaseAction is not null, "Caller checked for a post-phase action.");
+
+        Exception? postPhaseException = null;
+
+        try
+        {
+            _postPhaseAction!(this);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException
+            && ex is not StackOverflowException
+            && ex is not AccessViolationException)
+        {
+            postPhaseException = new BarrierPostPhaseException(ex);
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                AdvancePhase();
+                _phaseTransitionThreadId = NoPhaseTransition;
+                Monitor.PulseAll(_lock);
+            }
+        }
+
+        return postPhaseException;
     }
 
     /// <summary>
@@ -323,15 +419,23 @@ public sealed class AsyncBarrier
     /// </summary>
     /// <param name="participantCount">The number of additional participants to add.</param>
     /// <returns>The phase number of the barrier when the participants are added.</returns>
+    /// <remarks>
+    /// If a post-phase action is running on another thread this waits for it to finish first, so the
+    /// participant count never changes underneath it.
+    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="participantCount"/> is less than 1.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when adding participants would cause an overflow.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when adding participants would cause an overflow, or when called from within the barrier's
+    /// own post-phase action.
+    /// </exception>
     public long AddParticipants(int participantCount)
     {
         if (participantCount < 1) throw new ArgumentOutOfRangeException(nameof(participantCount), participantCount, "The participantCount argument must be a positive value.");
 
-        _spinLock.Enter();
-        try
+        lock (_lock)
         {
+            WaitForStablePhase();
+
             // Check for overflow
             if (_participantCount > int.MaxValue - participantCount)
             {
@@ -341,10 +445,6 @@ public sealed class AsyncBarrier
             _participantCount += participantCount;
             _participantsRemaining += participantCount;
             return _currentPhase;
-        }
-        finally
-        {
-            _spinLock.Exit();
         }
     }
 
@@ -361,18 +461,31 @@ public sealed class AsyncBarrier
     /// Notifies the <see cref="AsyncBarrier"/> that there will be fewer participants.
     /// </summary>
     /// <param name="participantCount">The number of participants to remove.</param>
+    /// <remarks>
+    /// If a post-phase action is running on another thread this waits for it to finish first, so the
+    /// participant count never changes underneath it. Removing the last outstanding participant
+    /// completes the phase, and therefore runs the post-phase action on the calling thread.
+    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="participantCount"/> is less than 1.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when there are not enough participants to remove, or when the barrier would have zero participants.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when there are not enough participants to remove, when the barrier would have zero
+    /// participants, or when called from within the barrier's own post-phase action.
+    /// </exception>
+    /// <exception cref="BarrierPostPhaseException">
+    /// Thrown when removing the last outstanding participant completes the phase and the post-phase
+    /// action throws.
+    /// </exception>
     public void RemoveParticipants(int participantCount)
     {
         if (participantCount < 1) throw new ArgumentOutOfRangeException(nameof(participantCount), participantCount, "The participantCount argument must be a positive value.");
 
         ManualResetValueTaskSource<bool>? toRelease = null;
-        Exception? postPhaseException = null;
+        bool postPhaseActionPending = false;
 
-        _spinLock.Enter();
-        try
+        lock (_lock)
         {
+            WaitForStablePhase();
+
             if (participantCount > _participantCount)
             {
                 throw new InvalidOperationException("The participantCount argument is greater than the number of participants.");
@@ -389,23 +502,18 @@ public sealed class AsyncBarrier
             // If this causes remaining to hit zero, advance the phase
             if (_participantsRemaining == 0 && _participantCount > 0)
             {
-                // Execute post-phase action
-                if (_postPhaseAction is not null)
-                {
-                    try
-                    {
-                        _postPhaseAction(this);
-                    }
-                    catch (Exception ex)
-                    {
-                        postPhaseException = new BarrierPostPhaseException(ex);
-                    }
-                }
-
-                _currentPhase++;
-                _participantsRemaining = _participantCount;
-
+                // Detached before the action runs, for the same reason as in SignalAndWaitAsync.
                 toRelease = _waiters.DetachAll(out _);
+
+                if (_postPhaseAction is null)
+                {
+                    AdvancePhase();
+                }
+                else
+                {
+                    _phaseTransitionThreadId = Environment.CurrentManagedThreadId;
+                    postPhaseActionPending = true;
+                }
             }
             else if (_participantCount == 0)
             {
@@ -421,15 +529,16 @@ public sealed class AsyncBarrier
                 return;
             }
         }
-        finally
-        {
-            _spinLock.Exit();
-        }
 
-        if (postPhaseException is not null)
+        if (postPhaseActionPending)
         {
-            WaiterQueue<bool>.SetChainException(toRelease, postPhaseException);
-            throw postPhaseException;
+            Exception? postPhaseException = RunPostPhaseActionAndAdvancePhase();
+
+            if (postPhaseException is not null)
+            {
+                WaiterQueue<bool>.SetChainException(toRelease, postPhaseException);
+                throw postPhaseException;
+            }
         }
 
         toRelease?.SetChainResult(true);
@@ -473,24 +582,33 @@ public sealed class AsyncBarrier
     /// <summary>
     /// O(1) removal from intrusive linked list.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deliberately does <b>not</b> call <see cref="WaitForStablePhase"/>. This is the timeout and
+    /// cancellation path, and letting it run while a post-phase action is in flight is the entire point
+    /// of running that action outside <see cref="_lock"/>. It is safe during a transition because the
+    /// queue has already been detached, so the removal simply fails and the waiter is completed by the
+    /// detached chain instead.
+    /// </para>
+    /// <para>
+    /// It also runs reentrantly, when a post-phase action cancels a token one of this barrier's own
+    /// waiters is registered on - the registration fires synchronously on that thread. A monitor
+    /// tolerates that; the library's spin lock would have deadlocked.
+    /// </para>
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private ManualResetValueTaskSource<bool>? RemoveWaiter(ManualResetValueTaskSource<bool> waiter, short version)
     {
-        _spinLock.Enter();
-        try
+        lock (_lock)
         {
             // A stale timer callback must not touch a recycled waiter: the version
             // changes when the waiter is reset for reuse, and re-enqueueing requires
-            // this spin lock, so the check and the removal are atomic w.r.t. reuse.
+            // this lock, so the check and the removal are atomic w.r.t. reuse.
             if (waiter.Version == version && _waiters.Remove(waiter))
             {
                 _participantsRemaining++;
                 return waiter;
             }
-        }
-        finally
-        {
-            _spinLock.Exit();
         }
 
         return null;

--- a/src/Threading/Internal/SpinLock.cs
+++ b/src/Threading/Internal/SpinLock.cs
@@ -33,6 +33,12 @@ using System.Threading;
 /// that may run on a single-core container or with the holder descheduled by a long GC pause, and in
 /// those genuinely pathological cases backing off is better than yielding forever.
 /// </para>
+/// <para>
+/// Sidenote: <see cref="CryptoHives.Foundation.Threading.Async.Pooled.AsyncBarrier"/> does not use this
+/// lock: it runs a user-supplied post-phase action as part of completing a phase, which is unbounded by
+/// definition. A primitive that has to hold state across code it does not control wants a monitor, whose
+/// waiters park, rather than this lock, whose waiters spin.
+/// </para>
 /// </remarks>
 internal struct SpinLock
 {

--- a/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncBarrierTests.cs
@@ -622,6 +622,138 @@ public class AsyncBarrierTests
         Assert.That(barrier.ParticipantCount, Is.EqualTo(2));
     }
 
+    /// <summary>
+    /// A post-phase action that cancels a token one of the barrier's own waiters is registered on must
+    /// not deadlock.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the sharpest consequence of running the action outside the barrier's lock. A
+    /// cancellation registration fires synchronously on the thread calling <c>Cancel()</c>, so the
+    /// callback reenters the barrier to unqueue the waiter. While the action ran under the internal spin
+    /// lock - which is not reentrant - that reentry spun forever against a lock the same thread already
+    /// held, and the test hung rather than failed.
+    /// </para>
+    /// <para>
+    /// The waiter has already been detached by the time the action runs, so the cancellation loses the
+    /// race and the waiter is released with the phase. The assertion is only that everything completes.
+    /// </para>
+    /// </remarks>
+    [Test, CancelAfter(30_000)]
+    public async Task PostPhaseActionCanCancelAWaiterWithoutDeadlocking()
+    {
+        using var cts = new CancellationTokenSource();
+        bool actionRan = false;
+
+        var barrier = new AsyncBarrier(2, _ => {
+            actionRan = true;
+            cts.Cancel();
+        });
+
+        Task waiting = barrier.SignalAndWaitAsync(cts.Token).AsTask();
+        Task completing = Task.Run(() => barrier.SignalAndWaitAsync().AsTask());
+
+        await completing.ConfigureAwait(false);
+
+        try
+        {
+            await waiting.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Legitimate if the cancellation won the race against the phase completing.
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actionRan, Is.True);
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+        }
+    }
+
+    /// <summary>
+    /// Changing the participant count from inside the post-phase action used to deadlock outright: the
+    /// action ran while holding a non-reentrant spin lock that the change needed. It now throws.
+    /// </summary>
+    [Test, CancelAfter(30_000)]
+    public async Task PostPhaseActionCannotChangeParticipantCount()
+    {
+        Exception? fromAdd = null;
+        Exception? fromRemove = null;
+
+        var barrier = new AsyncBarrier(1, b => {
+            fromAdd = Assert.Catch(() => b.AddParticipant());
+            fromRemove = Assert.Catch(() => b.RemoveParticipant());
+        });
+
+        await barrier.SignalAndWaitAsync().ConfigureAwait(false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(fromAdd, Is.TypeOf<InvalidOperationException>());
+            Assert.That(fromRemove, Is.TypeOf<InvalidOperationException>());
+
+            // The phase still completed normally despite the rejected reentrancy.
+            Assert.That(barrier.CurrentPhase, Is.EqualTo(1));
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(1));
+        }
+    }
+
+    /// <summary>
+    /// Signalling the barrier from inside its own post-phase action is rejected rather than deadlocking.
+    /// </summary>
+    [Test, CancelAfter(30_000)]
+    public async Task PostPhaseActionCannotSignalTheBarrier()
+    {
+        Exception? fromSignal = null;
+
+        var barrier = new AsyncBarrier(1, b => {
+            fromSignal = Assert.CatchAsync(async () => await b.SignalAndWaitAsync().ConfigureAwait(false));
+        });
+
+        await barrier.SignalAndWaitAsync().ConfigureAwait(false);
+
+        Assert.That(fromSignal, Is.TypeOf<InvalidOperationException>());
+    }
+
+    /// <summary>
+    /// A participant-count change from another thread waits for the post-phase action rather than
+    /// observing the barrier mid-transition.
+    /// </summary>
+    [Test, CancelAfter(30_000)]
+    public async Task ParticipantCountChangeWaitsForPostPhaseAction()
+    {
+        using var actionStarted = new ManualResetEventSlim(false);
+        using var releaseAction = new ManualResetEventSlim(false);
+        long phaseSeenByAdd = -1;
+
+        var barrier = new AsyncBarrier(1, _ => {
+            actionStarted.Set();
+            releaseAction.Wait(TimeSpan.FromSeconds(20));
+        });
+
+        Task completing = Task.Run(() => barrier.SignalAndWaitAsync().AsTask());
+
+        Assert.That(actionStarted.Wait(TimeSpan.FromSeconds(10)), Is.True, "Post-phase action never started.");
+
+        Task adding = Task.Run(() => phaseSeenByAdd = barrier.AddParticipant());
+
+        // The add must not complete while the action is still running.
+        Assert.That(adding.Wait(TimeSpan.FromMilliseconds(500)), Is.False,
+            "AddParticipant did not wait for the post-phase action.");
+
+        releaseAction.Set();
+        await completing.ConfigureAwait(false);
+        await adding.ConfigureAwait(false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // The phase had advanced before the add was let through.
+            Assert.That(phaseSeenByAdd, Is.EqualTo(1));
+            Assert.That(barrier.ParticipantCount, Is.EqualTo(2));
+        }
+    }
+
     [Test]
     public async Task PostPhaseActionWithMultiplePhases()
     {

--- a/tests/Threading/Internal/MeasurementGate.cs
+++ b/tests/Threading/Internal/MeasurementGate.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace Threading.Tests.Internal;

--- a/tests/Threading/Internal/PlatformTimer.cs
+++ b/tests/Threading/Internal/PlatformTimer.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace Threading.Tests.Internal;

--- a/tests/Threading/Internal/SpinLockLatencyTests.cs
+++ b/tests/Threading/Internal/SpinLockLatencyTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace Threading.Tests.Internal;

--- a/tests/Threading/Internal/SpinLockSpinCostTests.cs
+++ b/tests/Threading/Internal/SpinLockSpinCostTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+﻿// SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
 // SPDX-License-Identifier: MIT
 
 namespace Threading.Tests.Internal;


### PR DESCRIPTION
## Description

AsyncBarrier invoked the user-supplied post-phase action while holding Internal.SpinLock. That lock's contention policy is explicitly built for critical sections measured in nanoseconds - its waiters spin for a budget of ~40 us and only then park - so holding it across arbitrary user code broke the premise the policy rests on, and it is not reentrant.

The reentrancy was the sharper problem. A post-phase action that cancels a CancellationToken belonging to one of the barrier's own waiters fires that registration synchronously on the same thread, which re-enters the barrier through RemoveWaiter and spins forever against a lock the thread already holds. The same applied to AddParticipant()/RemoveParticipant() called from the action. A regression test written against the old code hangs outright - CancelAfter cannot recover it, because a spin loop has no cancellation point and .NET Core has no Thread.Abort.

AsyncBarrier now guards its state with a monitor and runs the post-phase action with no lock held:

- The lock is a plain object. System.Threading.Lock is not usable here: it exposes no Wait/PulseAll, and passing it to Monitor is CS9216, an error under TreatWarningsAsErrors.
- WaitForStablePhase(), called inside the lock by every public operation, blocks on Monitor.Wait while an action is in flight, so no caller observes the barrier mid-transition - the same ordering callers had when the action ran under the lock.
- RemoveWaiter deliberately does not wait. It is the timeout and cancellation path, only touches the waiter queue, and letting it through is the point of hoisting the action out.
- The phase is advanced and PulseAll issued in a finally, so an action throwing OutOfMemoryException cannot wedge the barrier in a transition.
- The earlyExit flag is gone; cancellation registration now happens naturally after the lock block.

Behaviour change: reentering the barrier from its own post-phase action now throws InvalidOperationException instead of hanging. This matches what System.Threading.Barrier documents for the same situation.

Cost, from AsyncBarrierSignalAndWaitBenchmark on a Ryzen 7600X / net10.0:

  participants   before      after
  1              11.49 ns    14.64 ns   (+3.2 ns)
  10            276.21 ns   316.99 ns   (+40.8 ns)

Both remain allocation-free and 30-86x faster than System.Threading.Barrier and the TaskCompletionSource reference implementation. Note the benchmark issues all signals sequentially from one thread, so these are uncontended figures only; the change is not measured under real lock contention.

Adds four tests covering the cancellation deadlock, reentrancy rejection from AddParticipant/RemoveParticipant and from SignalAndWaitAsync, and a concurrent participant-count change waiting out the action. 2,695 tests pass across net48/net8.0/net10.0.

## Type of change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [x] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [ ] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

## Notes for reviewers

<!--
  Cryptography: cross-validated against a reference implementation and known-answer test vectors?
  Threading:    ValueTask contract respected (no CHT00x analyzer violations)?
  Perf-sensitive: benchmark numbers before/after?
-->
