### PR TITLE
Raises QuantumBandOutlierTolerance in SpinLockLatencyTests to 5%.

### DIFF
--- a/tests/Threading/Internal/SpinLockLatencyTests.cs
+++ b/tests/Threading/Internal/SpinLockLatencyTests.cs
@@ -94,7 +94,22 @@ public class SpinLockLatencyTests
     /// Fraction of handoffs permitted to land in the quantum band regardless. A waiter can be descheduled
     /// by the operating system through no fault of the lock, so a hard zero would be a flake.
     /// </summary>
-    private const double QuantumBandOutlierTolerance = 0.002;
+    /// <remarks>
+    /// <para>
+    /// Sized from measurement rather than taste. <see cref="MeasurementGate"/> stops two timing fixtures
+    /// from measuring at once, but it cannot stop the <em>ordinary</em> tests in the sibling
+    /// per-target-framework processes from running - and several of those spawn a thread per core. Under
+    /// that load this fixture has been observed to put around 1% of handoffs in the band with the lock
+    /// behaving perfectly correctly.
+    /// </para>
+    /// <para>
+    /// The signal being guarded against is far larger: when the framework's default backoff hits the
+    /// quantum cliff it parks on 25% to 100% of handoffs. Five percent sits an order of magnitude above
+    /// the load-induced noise and an order of magnitude below the regression, which is the widest
+    /// separation available - so it is where the threshold belongs, even though it looks generous.
+    /// </para>
+    /// </remarks>
+    private const double QuantumBandOutlierTolerance = 0.05;
 
     /// <summary>Absolute floor for the outlier allowance, so short runs are not hair-triggered.</summary>
     private const int MinQuantumBandOutlierAllowance = 3;


### PR DESCRIPTION
## Description

MeasurementGate serialises the timing fixtures against each other but not against the ~900 ordinary tests running in the sibling per-target-framework processes, several of which spawn a thread per core. Under that load the fixture put ~1% of handoffs in the quantum band with the lock behaving correctly, which failed intermittently. The regression it guards against parks on 25-100% of handoffs, so 5% sits an order of magnitude clear of both.

## Type of change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [x] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [ ] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

## Notes for reviewers

<!--
  Cryptography: cross-validated against a reference implementation and known-answer test vectors?
  Threading:    ValueTask contract respected (no CHT00x analyzer violations)?
  Perf-sensitive: benchmark numbers before/after?
-->
