### PR TITLE
Cryptography dashboard: Table mode, run environments, and an idempotent rebuild

### DIFF
--- a/docfx/packages/security/cryptography/benchmark-trends/index.html
+++ b/docfx/packages/security/cryptography/benchmark-trends/index.html
@@ -22,6 +22,16 @@
   .legend-hint { font-size: 0.78rem; color: #888; margin: -0.2rem 0 0.5rem; }
   #chart-container { position: relative; height: 480px; }
   .hint { color: #888; font-size: 0.8rem; margin-top: 1rem; }
+  #table-container { overflow-x: auto; max-height: 70vh; }
+  table.data-table { border-collapse: collapse; width: 100%; font-size: 0.82rem; font-variant-numeric: tabular-nums; }
+  table.data-table th, table.data-table td { border: 1px solid #ddd; padding: 0.3rem 0.55rem; text-align: left; white-space: nowrap; }
+  table.data-table th { background: #f5f5f5; position: sticky; top: 0; z-index: 1; }
+  table.data-table td.numeric, table.data-table th.numeric { text-align: right; }
+  table.data-table tr.group-start td { border-top: 2px solid #bbb; }
+  table.data-table tr.baseline td { background: #fff6e6; font-weight: 600; }
+  table.data-table td.worse { color: #b91c1c; }
+  table.data-table td.better { color: #15803d; }
+  .table-note { font-size: 0.8rem; color: #666; margin: 0 0 0.6rem; }
 </style>
 </head>
 <body>
@@ -38,7 +48,8 @@
 
 <fieldset class="mode-toggle">
   <legend>View</legend>
-  <label><input type="radio" name="mode" value="trend" checked> Trend over time</label>
+  <label><input type="radio" name="mode" value="table" checked> Table (one run)</label>
+  <label><input type="radio" name="mode" value="trend"> Trend over time</label>
   <label><input type="radio" name="mode" value="scaling"> Scaling by size</label>
 </fieldset>
 
@@ -60,6 +71,12 @@
       <option value="mean_ns">Mean time (ns)</option>
       <option value="allocated_bytes">Allocated bytes</option>
     </select>
+  </label>
+  <label id="run-picker" hidden>Run
+    <select id="run"></select>
+  </label>
+  <label id="compare-picker" hidden>Compare with
+    <select id="compare"></select>
   </label>
   <label>Date range
     <select id="date-range">
@@ -83,15 +100,24 @@
 <div id="legend-colors" class="legend-row"></div>
 <div id="legend-dashes" class="legend-row"></div>
 <div id="chart-container"><canvas id="chart"></canvas></div>
+<p id="table-note" class="table-note" hidden></p>
+<div id="table-container" hidden><table class="data-table" id="data-table">
+<thead><tr id="data-table-head"></tr></thead><tbody id="data-table-body"></tbody></table></div>
 
 <p class="hint">
-  Data source: <code>benchmark-history.sqlite</code>, appended to by
-  <code>scripts/cryptography-benchmark-trends/record-benchmark-run.ps1</code> whenever someone decides a local
-  run is worth keeping. Each point is one recorded run; hover a point for the exact commit and value.
-  <strong>Trend over time</strong> plots every recorded data size for the current filters at once
-  (use the line-style legend below to hide sizes you don't want). <strong>Scaling by size</strong>
-  plots data size on the X axis using each implementation's most recent run, showing how it scales
-  across sizes at a glance.
+  Data source: <code>benchmark-history.sqlite</code>, generated at build time by
+  <code>scripts/cryptography-benchmark-trends/import_run_archive.py</code> from the run archive on
+  the <code>benchmarks</code> branch — so it is a derived artifact rather than a committed file, and
+  any recorded run can be rebuilt from the archive at any time.
+  <strong>Table (one run)</strong> is the default: it reproduces one run's report, with the baseline
+  row highlighted and Ratio computed against it per data size. Pick any recorded run rather than
+  only the newest, and optionally a second one to compare against — two dates on one machine, or
+  the same commit on two machines, which the run list marks as <em>(same commit)</em>.
+  The chart modes plot one point per recorded run; hover a point for the exact commit, value and
+  the .NET runtime it was measured on. <strong>Trend over time</strong> plots every recorded data
+  size for the current filters at once (use the line-style legend below to hide sizes you don't
+  want). <strong>Scaling by size</strong> plots data size on the X axis using each implementation's
+  most recent run, showing how it scales across sizes at a glance.
 </p>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.js"></script>
@@ -113,8 +139,66 @@
   const dateRangeSel = document.getElementById("date-range");
   const legendHintEl = document.getElementById("legend-hint");
   const modeRadios = document.querySelectorAll('input[name="mode"]');
+  const runSel = document.getElementById("run");
+  const compareSel = document.getElementById("compare");
+  const runPickerEl = document.getElementById("run-picker");
+  const comparePickerEl = document.getElementById("compare-picker");
+  const chartContainerEl = document.getElementById("chart-container");
+  const tableContainerEl = document.getElementById("table-container");
+  const tableNoteEl = document.getElementById("table-note");
+  const dataTableHeadEl = document.getElementById("data-table-head");
+  const dataTableBodyEl = document.getElementById("data-table-body");
 
-  const PALETTE = ["#2563eb", "#dc2626", "#16a34a", "#d97706", "#7c3aed", "#0891b2", "#db2777", "#65a30d"];
+  const PALETTE = [
+    "#2563eb", "#dc2626", "#16a34a", "#7c3aed", "#0891b2", "#db2777", "#65a30d",
+    "#0d9488", "#4f46e5", "#be123c", "#78716c", "#059669", "#0369a1",
+  ];
+
+  // This library's own implementations are pinned to the CryptoHives amber (#FFB643, sampled from
+  // the logo) rather than taking whatever the rotating palette hands them, so "ours" is the same
+  // colour on every chart instead of moving as the variant list changes between families.
+  //
+  // A family can expose several of ours at once - a scalar path plus AVX2, AVX-512, NEON and so on
+  // - so they walk a ramp around the brand colour: recognisably the same family, still told apart.
+  // The plain "CryptoHives" name, and then the portable scalar path, take the brand colour itself,
+  // since those are the ones a reader compares against. Amber tones were dropped from PALETTE above
+  // so no third-party variant can land near them.
+  const BRAND_AMBER = "#FFB643";
+  const OURS_RAMP = [
+    BRAND_AMBER, "#c2410c", "#a16207", "#f59e0b", "#7c2d12", "#fcd34d", "#ea580c", "#92400e",
+  ];
+
+  // Ours draw from their own ramp and everything else from PALETTE, counted separately so a
+  // family exposing many of our SIMD paths does not push the third-party variants along it.
+  function colorsForVariants(variantOrder) {
+    const ours = variantOrder.filter(isOurs).slice().sort((a, b) => oursRank(a) - oursRank(b) || a.localeCompare(b));
+    let otherIndex = 0;
+    return new Map(variantOrder.map((v) => {
+      if (isOurs(v)) return [v, OURS_RAMP[ours.indexOf(v) % OURS_RAMP.length]];
+      return [v, PALETTE[otherIndex++ % PALETTE.length]];
+    }));
+  }
+
+  // The runtime a point was measured on belongs next to the commit: the recorded runs span .NET
+  // 10.0.2 to 10.0.10 across three machines, so a step in a line cannot be read as a code change
+  // without knowing whether the floor moved under it. Runs recorded before the environment table
+  // existed simply omit it rather than showing a blank.
+  function pointFooter(raw) {
+    const commit = `commit ${raw.commit?.slice(0, 8) ?? "?"}`;
+    return raw.runtime ? `${commit} · .NET ${raw.runtime}` : commit;
+  }
+
+  function isOurs(variant) {
+    return variant === "CryptoHives" || variant.startsWith("CryptoHives-");
+  }
+
+  // Order within the ramp: the plain name first, then the scalar path, then the rest as sorted.
+  // Deliberately not "whichever is fastest" - a baseline that moves with the data is not a baseline.
+  function oursRank(variant) {
+    if (variant === "CryptoHives") return 0;
+    if (variant === "CryptoHives-Scalar") return 1;
+    return 2;
+  }
 
   // Custom legends replace Chart.js's built-in one-entry-per-dataset legend, which would
   // otherwise show one row per (variant, size) combination in multi-size trend mode — e.g.
@@ -219,6 +303,8 @@
       range: params.get("range") ?? undefined,
       mode: params.get("mode") ?? undefined,
       log: params.has("log") ? params.get("log") === "1" : undefined,
+      run: params.get("run") ?? undefined,
+      compare: params.get("compare") ?? undefined,
     };
   }
 
@@ -232,6 +318,13 @@
     params.set("range", dateRangeSel.value);
     params.set("mode", currentMode());
     params.set("log", logScaleCb.checked ? "1" : "0");
+    // Only in table mode, where which run is on screen is the whole point of the link. In the
+    // chart modes the run set is derived from the filters, so recording it would pin a link to a
+    // run that a later import may push out of view.
+    if (currentMode() === "table") {
+      if (runSel.value) params.set("run", runSel.value);
+      if (compareSel.value) params.set("compare", compareSel.value);
+    }
     const newHash = "#" + params.toString();
     if (location.hash !== newHash) history.replaceState(null, "", newHash);
   }
@@ -339,11 +432,14 @@
     const placeholders = sizes.map(() => "?").join(",");
     const cutoff = dateRangeCutoffIso();
     const stmt = db.prepare(`
-      SELECT variant, data_size_label, run_date, commit_sha, ${metric} AS value
-      FROM benchmark_results
-      WHERE platform = ? AND category = ? AND family = ? AND method = ? AND data_size_label IN (${placeholders})
-        ${cutoff ? "AND run_date >= ?" : ""}
-      ORDER BY variant, data_size_label, run_date
+      SELECT r.variant, r.data_size_label, r.run_date, r.commit_sha, b.runtime_version,
+             r.${metric} AS value
+      FROM benchmark_results r
+      LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
+      WHERE r.platform = ? AND r.category = ? AND r.family = ? AND r.method = ?
+        AND r.data_size_label IN (${placeholders})
+        ${cutoff ? "AND r.run_date >= ?" : ""}
+      ORDER BY r.variant, r.data_size_label, r.run_date
     `);
     stmt.bind([platformSel.value, categorySel.value, familySel.value, methodSel.value, ...sizes, ...(cutoff ? [cutoff] : [])]);
 
@@ -353,7 +449,9 @@
       const row = stmt.getAsObject();
       const key = multiSize ? `${row.variant} @ ${row.data_size_label}` : row.variant;
       if (!seriesByKey.has(key)) seriesByKey.set(key, { variant: row.variant, sizeLabel: row.data_size_label, points: [] });
-      seriesByKey.get(key).points.push({ x: row.run_date, y: row.value, commit: row.commit_sha });
+      seriesByKey.get(key).points.push({
+        x: row.run_date, y: row.value, commit: row.commit_sha, runtime: row.runtime_version,
+      });
     }
     stmt.free();
 
@@ -366,7 +464,7 @@
     for (const { variant } of seriesByKey.values()) {
       if (!variantOrder.includes(variant)) variantOrder.push(variant);
     }
-    const colorForVariant = new Map(variantOrder.map((v, i) => [v, PALETTE[i % PALETTE.length]]));
+    const colorForVariant = colorsForVariants(variantOrder);
 
     const DASH_PATTERNS = [[], [6, 3], [2, 2], [8, 3, 2, 3], [1, 3], [10, 4], [4, 2, 1, 2]];
     const dashForSize = new Map(sizes.map((label, i) => [label, DASH_PATTERNS[i % DASH_PATTERNS.length]]));
@@ -388,7 +486,7 @@
         x: { type: "time", time: { unit: "day" }, title: { display: true, text: "Run date" } },
         y: yAxisScale(metric),
       },
-      (ctx) => `commit ${ctx.raw.commit?.slice(0, 8) ?? "?"}`
+      (ctx) => pointFooter(ctx.raw)
     );
 
     renderColorLegend(variantOrder.map((v) => ({ variant: v, color: colorForVariant.get(v) })));
@@ -405,11 +503,13 @@
     const metric = metricSel.value;
     const cutoff = dateRangeCutoffIso();
     const stmt = db.prepare(`
-      SELECT variant, data_size_bytes, data_size_label, run_date, commit_sha, ${metric} AS value
-      FROM benchmark_results
-      WHERE platform = ? AND category = ? AND family = ? AND method = ?
-        ${cutoff ? "AND run_date >= ?" : ""}
-      ORDER BY variant, data_size_bytes, run_date
+      SELECT r.variant, r.data_size_bytes, r.data_size_label, r.run_date, r.commit_sha,
+             b.runtime_version, r.${metric} AS value
+      FROM benchmark_results r
+      LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
+      WHERE r.platform = ? AND r.category = ? AND r.family = ? AND r.method = ?
+        ${cutoff ? "AND r.run_date >= ?" : ""}
+      ORDER BY r.variant, r.data_size_bytes, r.run_date
     `);
     stmt.bind([platformSel.value, categorySel.value, familySel.value, methodSel.value, ...(cutoff ? [cutoff] : [])]);
 
@@ -425,12 +525,13 @@
         y: row.value,
         size_label: row.data_size_label,
         commit: row.commit_sha,
+        runtime: row.runtime_version,
       });
     }
     stmt.free();
 
     const variantOrder = Array.from(latestByVariant.keys());
-    const colorForVariant = new Map(variantOrder.map((v, i) => [v, PALETTE[i % PALETTE.length]]));
+    const colorForVariant = colorsForVariants(variantOrder);
 
     const datasets = variantOrder.map((variant) => ({
       label: variant,
@@ -448,7 +549,7 @@
         x: { type: "logarithmic", title: { display: true, text: "Data size (bytes)" } },
         y: yAxisScale(metric),
       },
-      (ctx) => `${ctx.raw.size_label} · commit ${ctx.raw.commit?.slice(0, 8) ?? "?"}`
+      (ctx) => `${ctx.raw.size_label} · ${pointFooter(ctx.raw)}`
     );
 
     renderColorLegend(variantOrder.map((v) => ({ variant: v, color: colorForVariant.get(v) })));
@@ -460,9 +561,264 @@
       : "No data for this selection yet.";
   }
 
+  // ---------------------------------------------------------------- table mode
+  //
+  // Reproduces what one benchmark run's report looked like: every dimension that run carried as
+  // its own column, grouped and ordered the way BenchmarkDotNet ordered it. Sibling of the same
+  // mode in the Threading dashboard, adapted to this data shape - a data size where that one has
+  // a contention level, and no cancellation axis.
+  //
+  // Ratio is computed here rather than stored: the database keeps measurements, not derived
+  // columns, and these reports carry no Ratio column at all - BenchmarkDotNet was never told which
+  // row is the baseline.
+
+  function formatMeanNs(ns) {
+    if (ns == null) return "-";
+    let value, unit;
+    if (ns < 1000) { value = ns; unit = "ns"; }
+    else if (ns < 1e6) { value = ns / 1000; unit = "μs"; }
+    else if (ns < 1e9) { value = ns / 1e6; unit = "ms"; }
+    else { value = ns / 1e9; unit = "s"; }
+    const digits = value < 10 ? 4 : value < 100 ? 3 : 2;
+    return value.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits }) + " " + unit;
+  }
+
+  function formatAllocated(bytes) {
+    if (bytes == null) return "?";
+    if (bytes === 0) return "-";              // the convention the reports use for a measured zero
+    if (bytes < 1024) return bytes.toLocaleString() + " B";
+    const kb = bytes / 1024;
+    return kb.toLocaleString(undefined, { maximumFractionDigits: kb < 10 ? 2 : 1 }) + " KB";
+  }
+
+  // The baseline is this library's own implementation, and nothing in the data marks one - so it
+  // is chosen the same way the colour ramp orders ours, and left blank for a group with none (a
+  // family compared only against third parties).
+  function baselineVariantOf(variants) {
+    const ours = variants.filter(isOurs).slice().sort((a, b) => oursRank(a) - oursRank(b) || a.localeCompare(b));
+    return ours.length ? ours[0] : null;
+  }
+
+  function runKey(runId, platform) { return runId + " " + platform; }
+
+  let pendingRunFromUrl = null;
+  let pendingCompareFromUrl = null;
+
+  // Every (run, platform) carrying rows for the current selection, newest first. Both pickers are
+  // filled from this, which is what makes "the same commit on two machines" fall out for free:
+  // those share a run_id and differ only in platform.
+  function availableRuns() {
+    const stmt = db.prepare(
+      "SELECT DISTINCT r.run_id, r.platform, r.run_date, r.commit_sha, b.runtime_version " +
+      "FROM benchmark_results r " +
+      "LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform " +
+      "WHERE r.category = ? AND r.family = ? AND r.method = ? " +
+      "ORDER BY r.run_date DESC, r.platform"
+    );
+    stmt.bind([categorySel.value, familySel.value, methodSel.value]);
+    const runs = [];
+    while (stmt.step()) runs.push(stmt.getAsObject());
+    stmt.free();
+    return runs;
+  }
+
+  function runOptionLabel(run) {
+    const date = (run.run_date || "").slice(0, 10);
+    const sha = run.commit_sha ? run.commit_sha.slice(0, 8) : "?";
+    const rt = run.runtime_version ? " · .NET " + run.runtime_version : "";
+    return date + " · " + run.platform + " · " + sha + rt;
+  }
+
+  function refreshRunPickers() {
+    const runs = availableRuns();
+    const previousRun = runSel.value;
+    const previousCompare = compareSel.value;
+
+    runSel.innerHTML = "";
+    for (const run of runs) {
+      const opt = document.createElement("option");
+      opt.value = runKey(run.run_id, run.platform);
+      opt.textContent = runOptionLabel(run);
+      runSel.appendChild(opt);
+    }
+    // Default to the newest run on the platform already selected above, so switching into table
+    // mode shows the data the charts were showing rather than jumping to another machine.
+    const preferred = runs.find((r) => r.platform === platformSel.value) || runs[0];
+    const fromUrl = pendingRunFromUrl;
+    pendingRunFromUrl = null;
+    const wanted = (fromUrl && runs.some((r) => runKey(r.run_id, r.platform) === fromUrl)) ? fromUrl
+                 : (runs.some((r) => runKey(r.run_id, r.platform) === previousRun) ? previousRun : null);
+    runSel.value = wanted || (preferred ? runKey(preferred.run_id, preferred.platform) : "");
+
+    const chosenRunId = (runSel.value || "").split(" ")[0];
+    compareSel.innerHTML = "";
+    const none = document.createElement("option");
+    none.value = "";
+    none.textContent = "(nothing — single run)";
+    compareSel.appendChild(none);
+    for (const run of runs) {
+      if (runKey(run.run_id, run.platform) === runSel.value) continue;
+      const opt = document.createElement("option");
+      opt.value = runKey(run.run_id, run.platform);
+      opt.textContent = runOptionLabel(run) + (run.run_id === chosenRunId ? "   (same commit)" : "");
+      compareSel.appendChild(opt);
+    }
+    const wantedCompare = pendingCompareFromUrl ?? previousCompare;
+    pendingCompareFromUrl = null;
+    compareSel.value = Array.from(compareSel.options).some((o) => o.value === wantedCompare)
+      ? wantedCompare : "";
+  }
+
+  function fetchRunRows(key) {
+    if (!key) return [];
+    const parts = key.split(" ");
+    const stmt = db.prepare(
+      "SELECT variant, data_size_label, data_size_bytes, mean_ns, allocated_bytes " +
+      "FROM benchmark_results WHERE run_id = ? AND platform = ? AND category = ? " +
+      "  AND family = ? AND method = ?"
+    );
+    stmt.bind([parts[0], parts[1], categorySel.value, familySel.value, methodSel.value]);
+    const rows = [];
+    while (stmt.step()) rows.push(stmt.getAsObject());
+    stmt.free();
+    return rows;
+  }
+
+  function renderTableView() {
+    const rows = fetchRunRows(runSel.value);
+    const compareRows = fetchRunRows(compareSel.value);
+    const compareBy = new Map();
+    for (const r of compareRows) {
+      compareBy.set(r.variant + "\u001f" + (r.data_size_label || ""), r);
+    }
+    const comparing = compareSel.value !== "" && compareRows.length > 0;
+
+    dataTableHeadEl.innerHTML = "";
+    dataTableBodyEl.innerHTML = "";
+    if (!rows.length) {
+      tableNoteEl.hidden = true;
+      statusEl.textContent = "No data for this run yet.";
+      return;
+    }
+
+    const hasSize = rows.some((r) => r.data_size_label);
+
+    // Grouped as the report groups: one baseline per data size.
+    const groups = new Map();
+    for (const r of rows) {
+      const key = r.data_size_label || "";
+      if (!groups.has(key)) groups.set(key, { sizeLabel: key, sizeBytes: r.data_size_bytes, rows: [] });
+      groups.get(key).rows.push(r);
+    }
+
+    const columns = [{ key: "description", label: "Description" }];
+    if (hasSize) columns.push({ key: "size", label: "TestDataSize", numeric: true });
+    columns.push({ key: "mean", label: "Mean", numeric: true });
+    columns.push({ key: "ratio", label: "Ratio", numeric: true });
+    columns.push({ key: "allocated", label: "Allocated", numeric: true });
+    if (comparing) {
+      columns.push({ key: "cmpMean", label: "Mean (compared)", numeric: true });
+      columns.push({ key: "cmpDelta", label: "Δ Mean", numeric: true });
+      columns.push({ key: "cmpAlloc", label: "Allocated (compared)", numeric: true });
+    }
+
+    for (const col of columns) {
+      const th = document.createElement("th");
+      th.textContent = col.label;
+      if (col.numeric) th.classList.add("numeric");
+      dataTableHeadEl.appendChild(th);
+    }
+
+    // Groups by data size ascending in bytes - "1KB" sorts before "128KB" numerically, which it
+    // would not as text. Rows within a group by mean ascending, which is how reports read.
+    const orderedKeys = Array.from(groups.keys()).sort((a, b) => {
+      const x = groups.get(a).sizeBytes, y = groups.get(b).sizeBytes;
+      if (x == null && y == null) return 0;
+      if (x == null) return -1;
+      if (y == null) return 1;
+      return x - y;
+    });
+
+    let total = 0;
+    for (const key of orderedKeys) {
+      const group = groups.get(key).rows.slice().sort((a, b) => a.mean_ns - b.mean_ns);
+      const baselineVariant = baselineVariantOf(group.map((r) => r.variant));
+      const baseline = group.find((r) => r.variant === baselineVariant);
+      let first = true;
+      for (const r of group) {
+        const tr = document.createElement("tr");
+        if (first) tr.classList.add("group-start");
+        if (r.variant === baselineVariant) tr.classList.add("baseline");
+        first = false;
+        const cmp = compareBy.get(r.variant + "\u001f" + (r.data_size_label || ""));
+        const delta = (cmp && cmp.mean_ns) ? (r.mean_ns / cmp.mean_ns - 1) * 100 : null;
+
+        for (const col of columns) {
+          const td = document.createElement("td");
+          if (col.numeric) td.classList.add("numeric");
+          if (col.key === "description") {
+            td.textContent = methodSel.value + " · " + familySel.value + " · " + r.variant;
+          } else if (col.key === "size") {
+            td.textContent = r.data_size_label || "-";
+          } else if (col.key === "mean") {
+            td.textContent = formatMeanNs(r.mean_ns);
+          } else if (col.key === "ratio") {
+            td.textContent = (baseline && baseline.mean_ns) ? (r.mean_ns / baseline.mean_ns).toFixed(2) : "-";
+          } else if (col.key === "allocated") {
+            td.textContent = formatAllocated(r.allocated_bytes);
+          } else if (col.key === "cmpMean") {
+            td.textContent = cmp ? formatMeanNs(cmp.mean_ns) : "-";
+          } else if (col.key === "cmpAlloc") {
+            td.textContent = cmp ? formatAllocated(cmp.allocated_bytes) : "-";
+          } else if (col.key === "cmpDelta") {
+            if (delta === null) {
+              td.textContent = "-";
+            } else {
+              td.textContent = (delta >= 0 ? "+" : "") + delta.toFixed(1) + "%";
+              // Positive means this run took longer. Coloured only past 5%, since run-to-run
+              // noise below that says nothing.
+              if (Math.abs(delta) >= 5) td.classList.add(delta > 0 ? "worse" : "better");
+            }
+          }
+          tr.appendChild(td);
+        }
+        dataTableBodyEl.appendChild(tr);
+        total++;
+      }
+    }
+
+    const chosen = Array.from(runSel.options).find((o) => o.value === runSel.value);
+    const against = Array.from(compareSel.options).find((o) => o.value === compareSel.value);
+    tableNoteEl.hidden = false;
+    tableNoteEl.textContent =
+      "Baseline (highlighted) is this library's own implementation; Ratio is each row's mean over " +
+      "it, computed per data size." +
+      (comparing ? "  Δ Mean is against " + (against ? against.textContent.trim() : "the second run") +
+                   " — positive means slower here." : "");
+    statusEl.textContent = total + " row(s) from " + (chosen ? chosen.textContent.trim() : "the selected run");
+  }
+
   function renderChart() {
-    if (currentMode() === "scaling") renderScalingChart();
-    else renderTrendChart();
+    const mode = currentMode();
+    const isTable = mode === "table";
+
+    chartContainerEl.hidden = isTable;
+    legendColorsEl.hidden = isTable;
+    legendDashesEl.hidden = isTable;
+    if (isTable) legendHintEl.hidden = true;   // otherwise left to renderColorLegend below
+    tableContainerEl.hidden = !isTable;
+    tableNoteEl.hidden = !isTable;
+    runPickerEl.hidden = !isTable;
+    comparePickerEl.hidden = !isTable;
+
+    if (isTable) {
+      refreshRunPickers();
+      renderTableView();
+    } else if (mode === "scaling") {
+      renderScalingChart();
+    } else {
+      renderTrendChart();
+    }
     syncUrlHash();
   }
 
@@ -497,6 +853,10 @@
     dateRangeSel.onchange = renderChart;
     logScaleCb.onchange = renderChart;
     modeRadios.forEach((r) => (r.onchange = renderChart));
+    // Changing the run also rebuilds the comparison list, since the shown run must not appear as
+    // its own comparison.
+    runSel.onchange = () => { refreshRunPickers(); renderTableView(); syncUrlHash(); };
+    compareSel.onchange = () => { renderTableView(); syncUrlHash(); };
     copyLinkBtn.onclick = async () => {
       try {
         await navigator.clipboard.writeText(location.href);
@@ -514,6 +874,8 @@
       if (radio) radio.checked = true;
     }
     if (restoreState?.log !== undefined) logScaleCb.checked = restoreState.log;
+    pendingRunFromUrl = restoreState?.run ?? null;
+    pendingCompareFromUrl = restoreState?.compare ?? null;
 
     populateSelect(categorySel, distinct("category", "WHERE platform = ?", [platformSel.value]), null, restoreState?.category);
     refreshFamilies(restoreState);

--- a/docfx/packages/security/cryptography/benchmark-trends/index.html
+++ b/docfx/packages/security/cryptography/benchmark-trends/index.html
@@ -28,7 +28,13 @@
   table.data-table th { background: #f5f5f5; position: sticky; top: 0; z-index: 1; }
   table.data-table td.numeric, table.data-table th.numeric { text-align: right; }
   table.data-table tr.group-start td { border-top: 2px solid #bbb; }
-  table.data-table tr.baseline td { background: #fff6e6; font-weight: 600; }
+  /* Ours get a wash of the brand amber so they stand out from third parties at a glance; the
+     baseline is the same hue a shade deeper, so the two are related but never confusable. */
+  table.data-table tr.ours td { background: #fffcf4; }
+  table.data-table tr.baseline td { background: #ffeecc; font-weight: 600; }
+  table.data-table tr.experimental td { color: #6b5b3e; }
+  table.data-table td .flag { font-size: 0.72rem; color: #92400e; border: 1px solid #e6c893;
+    border-radius: 3px; padding: 0 0.25rem; margin-left: 0.35rem; white-space: nowrap; }
   table.data-table td.worse { color: #b91c1c; }
   table.data-table td.better { color: #15803d; }
   .table-note { font-size: 0.8rem; color: #666; margin: 0 0 0.6rem; }
@@ -188,6 +194,35 @@
     return raw.runtime ? `${commit} · .NET ${raw.runtime}` : commit;
   }
 
+  // Implementations compiled in for measurement but excluded from the published packages.
+  //
+  // common.props defines EXPERIMENTAL unless the packaging build passes
+  // /p:EnableExperimentalAlgorithms=false, so these paths exist in a local benchmark run and not in
+  // the NuGet output. Nothing in the recorded data marks them, so the list is declared here and
+  // derived from the `#if EXPERIMENTAL` guards in src/Security/Cryptography/Hash/.
+  //
+  // It has to be per (family, variant) rather than per variant: BLAKE2b's AVX2 path ships while
+  // BLAKE2s's does not, and the Keccak core's AVX2 and AVX-512 permutes are excluded with the
+  // comment "turned out to be slower than scalar keccak" while its Arm64 scalar path ships.
+  //
+  // Source of each entry:
+  //   Keccak core   KeccakCoreState.cs:147   (Avx512F, Avx2 - dispatch behind the guard)
+  //   BLAKE2b       Blake2bState.Avx2.cs:62  (Neon only; Avx2 is detected outside the guard)
+  //   BLAKE2s       Blake2s.Simd.cs:48       (Avx2, Sse2, Neon; Ssse3 is outside the guard)
+  //   BLAKE3        no guards - every path ships
+  const KECCAK_FAMILIES = /^(SHA3-|SHAKE|cSHAKE|Keccak-|KMAC-|KT\d|TurboSHAKE|ParallelHash)/;
+
+  function experimentalVariants(family) {
+    if (KECCAK_FAMILIES.test(family)) return ["CryptoHives-AVX2", "CryptoHives-AVX512F"];
+    if (family.startsWith("BLAKE2b")) return ["CryptoHives-Neon"];
+    if (family.startsWith("BLAKE2s")) return ["CryptoHives-AVX2", "CryptoHives-Sse2", "CryptoHives-Neon"];
+    return [];
+  }
+
+  function isExperimental(family, variant) {
+    return experimentalVariants(family).includes(variant);
+  }
+
   function isOurs(variant) {
     return variant === "CryptoHives" || variant.startsWith("CryptoHives-");
   }
@@ -223,6 +258,17 @@
       swatch.className = "legend-swatch";
       swatch.style.background = color;
       item.append(swatch, document.createTextNode(variant));
+      // The charts share the legend across whichever family is selected, so an experimental path
+      // is marked here too rather than only in the table - otherwise a line that will never appear
+      // in a released package looks like one that will.
+      if (isExperimental(familySel.value, variant)) {
+        const flag = document.createElement("span");
+        flag.className = "flag";
+        flag.textContent = "not in package";
+        flag.title = "Compiled in for measurement but excluded from the published NuGet package: " +
+                     "this path is guarded by #if EXPERIMENTAL.";
+        item.appendChild(flag);
+      }
       item.onclick = () => {
         if (hiddenVariants.has(variant)) hiddenVariants.delete(variant);
         else hiddenVariants.add(variant);
@@ -748,7 +794,10 @@
       for (const r of group) {
         const tr = document.createElement("tr");
         if (first) tr.classList.add("group-start");
+        if (isOurs(r.variant)) tr.classList.add("ours");
         if (r.variant === baselineVariant) tr.classList.add("baseline");
+        const experimental = isExperimental(familySel.value, r.variant);
+        if (experimental) tr.classList.add("experimental");
         first = false;
         const cmp = compareBy.get(r.variant + "\u001f" + (r.data_size_label || ""));
         const delta = (cmp && cmp.mean_ns) ? (r.mean_ns / cmp.mean_ns - 1) * 100 : null;
@@ -758,6 +807,14 @@
           if (col.numeric) td.classList.add("numeric");
           if (col.key === "description") {
             td.textContent = methodSel.value + " · " + familySel.value + " · " + r.variant;
+            if (experimental) {
+              const flag = document.createElement("span");
+              flag.className = "flag";
+              flag.textContent = "not in package";
+              flag.title = "Compiled in for measurement but excluded from the published NuGet " +
+                           "package: this path is guarded by #if EXPERIMENTAL.";
+              td.appendChild(flag);
+            }
           } else if (col.key === "size") {
             td.textContent = r.data_size_label || "-";
           } else if (col.key === "mean") {
@@ -791,8 +848,9 @@
     const against = Array.from(compareSel.options).find((o) => o.value === compareSel.value);
     tableNoteEl.hidden = false;
     tableNoteEl.textContent =
-      "Baseline (highlighted) is this library's own implementation; Ratio is each row's mean over " +
-      "it, computed per data size." +
+      "This library's own implementations are shaded, the baseline more deeply; Ratio is each " +
+      "row's mean over that baseline, computed per data size. Rows marked “not in package” " +
+      "are compiled in for measurement only and excluded from the published NuGet package." +
       (comparing ? "  Δ Mean is against " + (against ? against.textContent.trim() : "the second run") +
                    " — positive means slower here." : "");
     statusEl.textContent = total + " row(s) from " + (chosen ? chosen.textContent.trim() : "the selected run");

--- a/scripts/cryptography-benchmark-trends/import_historical_markdown.py
+++ b/scripts/cryptography-benchmark-trends/import_historical_markdown.py
@@ -464,5 +464,65 @@ def main() -> int:
     return 0
 
 
+# Mirrors scripts/threading-benchmark-trends/markdown_parser.py. Duplicated rather than shared:
+# these two pipelines are deliberate siblings, each with its own parser and schema, and a third
+# module for one 50-line function would couple them for less than it costs. The preamble format is
+# BenchmarkDotNet's, so it does not drift with either package.
+# BenchmarkDotNet's machine-spec preamble, e.g.
+#
+#     BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8875/25H2/2025Update/HudsonValley2)
+#     AMD Ryzen 5 7600X 4.70GHz, 1 CPU, 12 logical and 6 physical cores
+#     .NET SDK 11.0.100-preview.5.26302.115
+#     [Host]    : .NET 10.0.10 (10.0.10, 10.0.1026.32716), X64 RyuJIT x86-64-v4
+#
+# Every field is optional: the flat era's files and the per-platform era's differ in wording, and
+# a missing line should leave a NULL column rather than abort the import of a whole run.
+_BDN_LINE = re.compile(r"^BenchmarkDotNet v(?P<bdn>[\w.\-+]+),\s*(?P<os>.+?)\s*$", re.M)
+_CPU_LINE = re.compile(
+    r"^(?P<cpu>.+?),\s*\d+ CPU,\s*(?P<logical>\d+) logical(?: and (?P<physical>\d+) physical)? cores",
+    re.M,
+)
+_SDK_LINE = re.compile(r"^\.NET SDK (?P<sdk>[\w.\-+]+)", re.M)
+_HOST_LINE = re.compile(
+    r"^\s*\[Host\]\s*:\s*\.NET (?P<runtime>[\w.\-+]+)\s*\([^)]*\),\s*(?P<jit>.+?)\s*$", re.M
+)
+
+
+def parse_machine_spec(text: str) -> dict:
+    """Extracts the environment fields from a machine-spec.md.
+
+    Returns a dict with bdn_version/os/cpu/logical_cores/physical_cores/sdk_version/
+    runtime_version/jit, each None when that line is absent.
+    """
+    spec = {
+        "bdn_version": None, "os": None, "cpu": None,
+        "logical_cores": None, "physical_cores": None,
+        "sdk_version": None, "runtime_version": None, "jit": None,
+    }
+
+    match = _BDN_LINE.search(text)
+    if match:
+        spec["bdn_version"] = match.group("bdn")
+        spec["os"] = match.group("os")
+
+    match = _CPU_LINE.search(text)
+    if match:
+        spec["cpu"] = match.group("cpu").strip()
+        spec["logical_cores"] = int(match.group("logical"))
+        if match.group("physical"):
+            spec["physical_cores"] = int(match.group("physical"))
+
+    match = _SDK_LINE.search(text)
+    if match:
+        spec["sdk_version"] = match.group("sdk")
+
+    match = _HOST_LINE.search(text)
+    if match:
+        spec["runtime_version"] = match.group("runtime")
+        spec["jit"] = match.group("jit")
+
+    return spec
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/cryptography-benchmark-trends/import_run_archive.py
+++ b/scripts/cryptography-benchmark-trends/import_run_archive.py
@@ -42,6 +42,7 @@ sys.path.insert(0, SCRIPT_DIR)
 
 from import_historical_markdown import (  # noqa: E402
     classify_category,
+    parse_machine_spec,
     parse_markdown_table,
 )
 
@@ -79,6 +80,15 @@ def discover_runs(archive_root):
     found.sort(key=lambda entry: entry[0])
     for _date, run_id, platform, run_dir, metadata in found:
         yield run_id, platform, run_dir, metadata
+
+
+def read_environment(run_dir):
+    """The machine and runtime a run was measured on, or None when the run carries no spec."""
+    path = os.path.join(run_dir, "machine-spec.md")
+    if not os.path.isfile(path):
+        return None
+    with open(path, encoding="utf-8") as handle:
+        return parse_machine_spec(handle.read())
 
 
 def main():
@@ -127,6 +137,24 @@ def main():
                      row["method"], row["family"], row["variant"], row["data_size_label"],
                      row["data_size_bytes"], row["mean_ns"], row["stddev_ns"],
                      row["allocated_bytes"]))
+
+        # Recorded per (run, platform) so a step in a trend line can be checked against a runtime
+        # or SDK change before being read as a code regression - the recorded runs span .NET 10.0.2
+        # to 10.0.9 across three machines.
+        environment = read_environment(run_dir)
+        if environment and not args.dry_run:
+            conn.execute(
+                "INSERT OR REPLACE INTO benchmark_runs "
+                "(run_id, platform, run_date, commit_sha, branch, bdn_version, os, cpu, "
+                " logical_cores, physical_cores, sdk_version, runtime_version, jit) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (run_id, platform, run_date, commit_sha, branch, environment["bdn_version"],
+                 environment["os"], environment["cpu"], environment["logical_cores"],
+                 environment["physical_cores"], environment["sdk_version"],
+                 environment["runtime_version"], environment["jit"]))
+        elif not environment:
+            print(f"  [warn] {run_id}/{platform}: no machine-spec.md; environment not recorded",
+                  file=sys.stderr)
 
         print(f"  [{'dry-run' if args.dry_run else 'ok'}] {run_id}/{platform}: {run_rows} row(s)")
         total_rows += run_rows

--- a/scripts/cryptography-benchmark-trends/import_run_archive.py
+++ b/scripts/cryptography-benchmark-trends/import_run_archive.py
@@ -105,6 +105,22 @@ def main():
     conn = sqlite3.connect(args.db)
     conn.executescript(schema_sql)
 
+    # Start from empty. The database is derived from the archive, so anything already in the file
+    # is either about to be rewritten or is no longer true - a run withdrawn from the archive, or
+    # rows keyed differently by an earlier version of the parser.
+    #
+    # INSERT OR REPLACE alone does not achieve this. param_label is part of the primary key and is
+    # NULL for benchmarks with no [Params] axis, and SQLite treats NULLs in a key as distinct, so
+    # those rows never match an existing one and every rebuild appends another copy. Locally that
+    # grew the Threading database from 4,718 rows to 6,413 across four rebuilds, all of the excess
+    # in unparameterised benchmarks. CI never saw it, because it always starts from a fresh
+    # checkout with no database file.
+    #
+    # Deleting inside the same transaction as the inserts, rather than unlinking the file, means a
+    # failed import leaves the previous database intact instead of an empty one.
+    conn.execute("DELETE FROM benchmark_results")
+    conn.execute("DELETE FROM benchmark_runs")
+
     total_rows = 0
     total_runs = 0
     for run_id, platform, run_dir, metadata in discover_runs(args.archive):

--- a/scripts/cryptography-benchmark-trends/schema.sql
+++ b/scripts/cryptography-benchmark-trends/schema.sql
@@ -32,3 +32,35 @@ CREATE TABLE IF NOT EXISTS benchmark_results (
 CREATE INDEX IF NOT EXISTS idx_family_variant ON benchmark_results(family, variant);
 CREATE INDEX IF NOT EXISTS idx_run_date        ON benchmark_results(run_date);
 CREATE INDEX IF NOT EXISTS idx_platform        ON benchmark_results(platform);
+
+-- One row per (run, platform): the environment the numbers were produced in.
+--
+-- Mirrors the table of the same name in scripts/threading-benchmark-trends/schema.sql - these two
+-- pipelines are deliberate siblings rather than one generic one, because their result shapes
+-- differ, but the environment a run was measured in is identical across both.
+--
+-- Kept beside benchmark_results rather than folded into it, since it is constant across a run's
+-- hundreds of rows. Every field is parsed out of the machine-spec.md that sits next to the
+-- scenario tables in the run archive, so this backfills across the whole history.
+--
+-- The point is attribution: the recorded runs span .NET 10.0.2 through 10.0.9 on three different
+-- machines, so a step in a trend line cannot be read as a code regression without knowing whether
+-- the floor moved under it.
+CREATE TABLE IF NOT EXISTS benchmark_runs (
+    run_id          TEXT NOT NULL,
+    platform        TEXT NOT NULL,  -- matches benchmark_results.platform
+    run_date        TEXT,           -- ISO 8601, same value as the results rows
+    commit_sha      TEXT,
+    branch          TEXT,
+    bdn_version     TEXT,           -- e.g. '0.15.8'
+    os              TEXT,           -- e.g. 'Windows 10 (10.0.19045.6456/22H2/2022Update)'
+    cpu             TEXT,           -- e.g. 'Intel Xeon CPU E3-1240 v5 3.50GHz'
+    logical_cores   INTEGER,
+    physical_cores  INTEGER,
+    sdk_version     TEXT,           -- e.g. '10.0.102'
+    runtime_version TEXT,           -- host runtime, e.g. '10.0.2'
+    jit             TEXT,           -- e.g. 'X64 RyuJIT x86-64-v3'
+    PRIMARY KEY (run_id, platform)
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_runtime ON benchmark_runs(runtime_version);

--- a/scripts/threading-benchmark-trends/import_run_archive.py
+++ b/scripts/threading-benchmark-trends/import_run_archive.py
@@ -99,6 +99,22 @@ def main():
     conn = sqlite3.connect(args.db)
     conn.executescript(schema_sql)
 
+    # Start from empty. The database is derived from the archive, so anything already in the file
+    # is either about to be rewritten or is no longer true - a run withdrawn from the archive, or
+    # rows keyed differently by an earlier version of the parser.
+    #
+    # INSERT OR REPLACE alone does not achieve this. param_label is part of the primary key and is
+    # NULL for benchmarks with no [Params] axis, and SQLite treats NULLs in a key as distinct, so
+    # those rows never match an existing one and every rebuild appends another copy. Locally that
+    # grew the Threading database from 4,718 rows to 6,413 across four rebuilds, all of the excess
+    # in unparameterised benchmarks. CI never saw it, because it always starts from a fresh
+    # checkout with no database file.
+    #
+    # Deleting inside the same transaction as the inserts, rather than unlinking the file, means a
+    # failed import leaves the previous database intact instead of an empty one.
+    conn.execute("DELETE FROM benchmark_results")
+    conn.execute("DELETE FROM benchmark_runs")
+
     total_rows = 0
     total_runs = 0
     for run_id, platform, run_dir, metadata in discover_runs(args.archive):


### PR DESCRIPTION
## Description

Brings the Cryptography dashboard up to what the Threading one gained over #223–#226 — it was still a chart-only view with no way to read a single run off it — and fixes a rebuild bug found while testing it locally.

### Run environments

The Cryptography schema had no `benchmark_runs` table, so its dashboard could not say which runtime a point was measured on. That is the confounder that motivated adding it to Threading, and it matters more here: the recorded runs span **.NET 10.0.2 to 10.0.10 across three machines**.

| CPU | JIT | runs |
|---|---|---:|
| AMD Ryzen 5 7600X | x86-64-v4 | 21 |
| Apple M4 | armv8.0-a | 8 |
| Intel Xeon E3-1240 v5 | **x86-64-v3** | 1 |

For SIMD-heavy crypto that last row is the interesting one — it predates AVX-512 and the v4 baseline, so it is the only data point where the AVX2 and SSSE3 paths are the fast ones.

Every crypto run in the archive already carried `machine-spec.md`, so this backfills across the whole history: **30 environments, no result row without one**. The chart tooltips now name the runtime beside the commit.

### Table mode

Ported as a sibling rather than shared code — the two schemas differ enough (a data size here, a contention level and cancellation state there) that a generic version would be mostly branching. Same behaviour as Threading's: one run's report with the baseline row highlighted, Ratio computed against it, any recorded run selectable rather than only the newest, and a second run comparable against it, including the same commit on two machines.

Two adaptations the data forced:

- **The baseline is chosen, not declared.** These reports carry no Ratio column at all, so BenchmarkDotNet was never told which row is the baseline. The rule is the plain `CryptoHives` name, then the portable `CryptoHives-Scalar` path, then the rest sorted — deliberately *not* "whichever of ours is fastest", since a baseline that moves with the data is not a baseline. A family compared only against third parties gets a blank Ratio rather than a wrong one.
- **Size groups sort on `data_size_bytes`, not the label.** As text, `10MB` sorts before `4B`.

Ours are pinned to the CryptoHives amber, walking a ramp where a family exposes several SIMD paths at once, with amber tones dropped from the palette so no third-party variant lands near them.

### Rebuilding was not idempotent

Found by testing the local loop: rebuilding kept **adding** rows rather than replacing them. The Threading database had grown from 4,718 to **6,413** across four rebuilds.

`INSERT OR REPLACE` does not replace those rows. `param_label` is part of the primary key and is NULL for benchmarks with no `[Params]` axis, and **SQLite treats NULLs in a key as distinct** — so such a row never matches an existing one and each rebuild appends another copy.

The numbers isolate it exactly:

| | total | NULL param | non-NULL |
|---|---:|---:|---:|
| after four local rebuilds | 6,413 | 2,260 | 4,153 |
| fresh build | 4,718 | 565 | 4,153 |

The non-NULL count is identical; all 1,695 extra rows are unparameterised benchmarks at 4× duplication. CI never saw it, because it starts from a fresh checkout with no database file, and Cryptography was immune entirely because its `data_size_label` is never NULL.

Both importers now clear the tables first, **inside the same transaction as the inserts** — so a failed import leaves the previous database intact rather than an empty one, and a run withdrawn from the archive actually disappears, which appending never did.

### Also

Fixes a dangling reference missed in #226: the Cryptography dashboard's footer still named `record-benchmark-run.ps1`, deleted there. A repo-wide grep for both retired scripts is now clean.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [x] 📝 Documentation only
- [x] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [x] Build / CI / NuGet packaging / docs

## Checklist

- [x] The solution builds clean with `TreatWarningsAsErrors=true`.
- [x] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [x] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [x] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

No library code changes: zero files under `src/` or `tests/`.

Verified against the live database rather than by eye: the dashboard's SQL executes, `Hash · BLAKE3 · TryComputeHash` produces 19 size groups ordering correctly from 4B to 10MB with one baseline per group at ratio 1.00, the page passes `node --check`, and rebuilding twice in a row now yields 4,718 and 23,198 both times.

## Notes for reviewers

Worth a look at `Hash · BLAKE3 · TryComputeHash` in Table mode — eight variants including several of our SIMD paths, so it exercises the baseline rule and the amber ramp together.

The two dashboards are now near-identical in capability but remain separate files. Extracting the shared parts is a reasonable follow-up now that both exist and the genuinely common logic is visible; it was not worth guessing at before.