### PR TITLE
Record what each benchmark run measured against, and under which framework

### DIFF
--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -5,22 +5,26 @@ name: DocFX Deployment
 # Trigger on push to main, but only when documentation or the API-doc sources change.
 # (API reference is generated from src/**; other churn does not affect the site.)
 #
-# Also on push to `benchmarks`, the orphan branch holding recorded benchmark runs: the trends
-# database is generated from it at build time, so a newly recorded run has to republish the site
-# to become visible. `threading/**` and `cryptography/**` are that branch's layout and match
-# nothing on main, so they add no spurious main builds. Note that `paths` applies to every listed
-# branch, which is why the archive needs its own entries rather than being covered by `docfx/**`.
+# Recording a benchmark run does NOT publish it. The trends databases are generated at build time
+# from the orphan `benchmarks` branch, so a new run only becomes visible once this workflow runs
+# again - but a push to that branch cannot start it. For push events GitHub only runs workflows
+# that exist in the pushed ref, and `benchmarks` carries nothing but README.md and the two run
+# directories; it has no .github/ at all. Listing it here looked right and never once fired.
+#
+# So after pushing a recorded run, publish it deliberately:
+#
+#     gh workflow run docfx.yml
+#
+# which is what workflow_dispatch below is for. Any later push to main republishes it too, since
+# the build always reads the archive branch fresh.
 on:
   workflow_dispatch:
   push:
     branches:
       - main
-      - benchmarks
     paths:
       - 'docfx/**'
       - 'src/**'
-      - 'threading/**'
-      - 'cryptography/**'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -7,9 +7,9 @@ name: DocFX Deployment
 #
 # Also on push to `benchmarks`, the orphan branch holding recorded benchmark runs: the trends
 # database is generated from it at build time, so a newly recorded run has to republish the site
-# to become visible. `threading/**` is that branch's layout and matches nothing on main, so it
-# adds no spurious main builds. Note that `paths` applies to every listed branch, which is why the
-# archive needs its own entry rather than being covered by `docfx/**`.
+# to become visible. `threading/**` and `cryptography/**` are that branch's layout and match
+# nothing on main, so they add no spurious main builds. Note that `paths` applies to every listed
+# branch, which is why the archive needs its own entries rather than being covered by `docfx/**`.
 on:
   workflow_dispatch:
   push:
@@ -20,6 +20,7 @@ on:
       - 'docfx/**'
       - 'src/**'
       - 'threading/**'
+      - 'cryptography/**'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -95,6 +96,13 @@ jobs:
           if [ "$rows" -eq 0 ]; then
             echo "::error::$db is empty - refusing to publish a dashboard with no data."
             exit 1
+          fi
+          # The dashboard degrades quietly without these - tooltips just stop naming the
+          # competitor's version - so an empty table has to be loud rather than invisible.
+          packages=$(python -c "import sqlite3,sys; print(sqlite3.connect(sys.argv[1]).execute('select count(*) from benchmark_run_packages').fetchone()[0])" "$db")
+          echo "$db: $packages package version(s)"
+          if [ "$packages" -eq 0 ]; then
+            echo "::warning::$db records no third-party package versions - competitor regressions cannot be attributed."
           fi
         done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Diagnostics:
 - Each test project has `OutputType=Exe` and links `tests/Common/Main.cs` (NUnit entry point)
 - Cryptography tests use **BouncyCastle**, **NaCl.Core**, **HashifyNET**, and other reference implementations for cross-validation
 - Threading tests benchmark against **AsyncKeyedLock**, **Nito.AsyncEx**, **NeoSmart.AsyncLock**, **ProtoPromise**, **KeyedSemaphores**, **Dao.IndividualLock**, **AsyncUtilities**, and **Microsoft.VisualStudio.Threading**
-- Benchmark runs are recorded on the orphan `benchmarks` branch, one directory per run keyed by the commit measured; the trends database under `docfx/**/benchmark-trends/` is generated from it at build time and is not committed. Record with `update-benchmark-docs.ps1 -DestDir <archive worktree>`, rebuild locally with `build-trends-database.ps1`
+- Benchmark runs are recorded on the orphan `benchmarks` branch as `<package>/<code-commit>/<platform>/<framework>/`, keyed by the commit measured rather than the commit recording it; the trends database under `docfx/**/benchmark-trends/` is generated from it at build time and is not committed. Each run's `run.json` also records the resolved version of every third-party library it measured against. Record with `update-benchmark-docs.ps1 -DestDir <archive worktree>`, rebuild locally with `build-trends-database.ps1`
 - `tests/Directory.Build.props` imports the root props and adds shared `GlobalSuppressions.cs`
 - Some test-only packages (e.g., `Konscious.Security.Cryptography.Blake2`, `Blake3`) are excluded when strong-name signing is active because they are not signed
 

--- a/docfx/packages/security/cryptography/benchmark-trends/index.html
+++ b/docfx/packages/security/cryptography/benchmark-trends/index.html
@@ -36,6 +36,9 @@
   table.data-table td .flag { font-size: 0.72rem; color: #92400e; border: 1px solid #e6c893;
     border-radius: 3px; padding: 0 0.25rem; margin-left: 0.35rem; white-space: nowrap; }
   table.data-table td.worse { color: #b91c1c; }
+  /* A delta whose reference implementation also changed version between the two runs. Not an
+     error state - the number is real - so it is marked rather than coloured. */
+  table.data-table td .pkg-changed { color: #92400e; cursor: help; margin-left: 0.3rem; }
   table.data-table td.better { color: #15803d; }
   .table-note { font-size: 0.8rem; color: #666; margin: 0 0 0.6rem; }
 </style>
@@ -62,6 +65,9 @@
 <div class="controls">
   <label>Platform
     <select id="platform"></select>
+  </label>
+  <label id="framework-picker" hidden>Framework
+    <select id="framework"></select>
   </label>
   <label>Category
     <select id="category"></select>
@@ -133,6 +139,13 @@
 (async function () {
   const statusEl = document.getElementById("status");
   const platformSel = document.getElementById("platform");
+  const frameworkSel = document.getElementById("framework");
+  const frameworkPickerEl = document.getElementById("framework-picker");
+  // Whether the archive holds more than one target framework at all. Until a second one is
+  // recorded the picker would be a single fixed option and the run labels would repeat the same
+  // word on every line, so both stay out of the way rather than advertising a dimension the data
+  // does not yet have.
+  let hasMultipleFrameworks = false;
   const categorySel = document.getElementById("category");
   const familySel = document.getElementById("family");
   const methodSel = document.getElementById("method");
@@ -185,13 +198,88 @@
     }));
   }
 
+  // Which NuGet package supplies each reference implementation, so a step in that line can be
+  // attributed to the reference shipping a release rather than to a change in this repository.
+  // BouncyCastle went 2.6.2 -> 2.7.0 in #210, which no recorded run could previously show.
+  //
+  // Declared here rather than recorded, because nothing in a BenchmarkDotNet report names the
+  // package behind a display label. Ids must match Directory.Packages.props exactly.
+  //
+  // The three BLAKE3 entries are three genuinely different packages, not three builds of one:
+  // "Blake3" is xoofx's binding (aliased Blake3Managed in the csproj), "Blake3.Native" carries
+  // its native assets, and "Blake3.Managed" is Dissimilis's independent pure-C# implementation.
+  //
+  // No entry for CryptoHives-*, for "OS" (the platform's own System.Security.Cryptography, which
+  // moves with the runtime that benchmark_runs records) or for "ArmSha256" (an intrinsics probe
+  // in tests/, not a package).
+  const VARIANT_PACKAGES = {
+    "Blake2Fast": "SauceControl.Blake2Fast",
+    "Blake3Dissimilis": "Blake3.Managed",
+    "Blake3Managed": "Blake3",
+    "Blake3Native": "Blake3.Native",
+    "BouncyCastle": "BouncyCastle.Cryptography",
+    "HashifyNET": "HashifyNET",
+    "Konscious": "Konscious.Security.Cryptography.Blake2",
+    "NaCl.Core": "NaCl.Core",
+    "OpenGost": "OpenGost.Security.Cryptography",
+  };
+
+  // (run_id + platform) -> { packageId: version }, loaded once at startup. A few hundred rows
+  // across the whole archive, so joining it per query would cost more than it saves.
+  let runPackages = new Map();
+  let runPackagesSource = new Map();
+
+  function loadRunPackages() {
+    runPackages = new Map();
+    runPackagesSource = new Map();
+    let stmt;
+    try {
+      stmt = db.prepare("SELECT run_id, platform, framework, package_id, version, source " +
+                        "FROM benchmark_run_packages");
+    } catch {
+      return;   // database built before the table existed; the UI just shows no versions
+    }
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      const key = runKey(row.run_id, row.platform, row.framework);
+      if (!runPackages.has(key)) runPackages.set(key, {});
+      runPackages.get(key)[row.package_id] = row.version;
+      if (row.source) runPackagesSource.set(key, row.source);
+    }
+    stmt.free();
+  }
+
+  // "BouncyCastle.Cryptography 2.7.0" for a variant backed by a package in that run, else null.
+  function packageLabel(variant, runId, platform, framework) {
+    const packageId = VARIANT_PACKAGES[variant];
+    if (!packageId) return null;
+    const version = runPackages.get(runKey(runId, platform, framework))?.[packageId];
+    return version ? `${packageId} ${version}` : null;
+  }
+
+  // Packages whose version differs between the two runs being compared. This is the whole point
+  // of recording them: a reference implementation's Δ Mean is only evidence about our code if
+  // that reference was the same build in both runs, and several were not.
+  function changedPackages(keyA, keyB) {
+    const a = runPackages.get(keyA) || {};
+    const b = runPackages.get(keyB) || {};
+    const changed = new Map();
+    for (const id of Object.keys(a)) {
+      if (b[id] && b[id] !== a[id]) changed.set(id, [b[id], a[id]]);   // [compared, chosen]
+    }
+    return changed;
+  }
+
   // The runtime a point was measured on belongs next to the commit: the recorded runs span .NET
   // 10.0.2 to 10.0.10 across three machines, so a step in a line cannot be read as a code change
   // without knowing whether the floor moved under it. Runs recorded before the environment table
   // existed simply omit it rather than showing a blank.
   function pointFooter(raw) {
-    const commit = `commit ${raw.commit?.slice(0, 8) ?? "?"}`;
-    return raw.runtime ? `${commit} · .NET ${raw.runtime}` : commit;
+    const parts = [`commit ${raw.commit?.slice(0, 8) ?? "?"}`];
+    if (raw.runtime) parts.push(`.NET ${raw.runtime}`);
+    // Only reference-implementation series carry one; ours is pinned by the commit already here.
+    if (raw.pkg) parts.push(raw.pkg);
+    return parts.join(" · ");
   }
 
   // Implementations compiled in for measurement but excluded from the published packages.
@@ -342,6 +430,7 @@
     if ([...params.keys()].length === 0) return null;
     return {
       platform: params.get("platform") ?? undefined,
+      framework: params.get("framework") ?? undefined,
       category: params.get("category") ?? undefined,
       family: params.get("family") ?? undefined,
       method: params.get("method") ?? undefined,
@@ -357,6 +446,7 @@
   function syncUrlHash() {
     const params = new URLSearchParams();
     params.set("platform", platformSel.value);
+    params.set("framework", frameworkSel.value);
     params.set("category", categorySel.value);
     params.set("family", familySel.value);
     params.set("method", methodSel.value);
@@ -407,11 +497,25 @@
     return cutoff.toISOString();
   }
 
+  // Framework sits directly under platform in the cascade, because it narrows the same way a
+  // platform does: the same commit measured under net8.0 and net10.0 is two sets of numbers that
+  // must never share a line. Which frameworks exist is per platform - a net48 run only happens on
+  // Windows - so this is re-derived on every platform change rather than filled once.
+  function refreshFrameworks(preferred) {
+    const frameworks = distinct("framework", "WHERE platform = ?", [platformSel.value]);
+    populateSelect(frameworkSel, frameworks, null, preferred?.framework);
+    populateSelect(categorySel,
+                   distinct("category", "WHERE platform = ? AND framework = ?",
+                            [platformSel.value, frameworkSel.value]),
+                   null, preferred?.category);
+    refreshFamilies(preferred);
+  }
+
   function refreshFamilies(preferred) {
     const families = distinct(
       "family",
-      "WHERE platform = ? AND category = ?",
-      [platformSel.value, categorySel.value]
+      "WHERE platform = ? AND framework = ? AND category = ?",
+      [platformSel.value, frameworkSel.value, categorySel.value]
     );
     populateSelect(familySel, families, null, preferred?.family);
     refreshMethods(preferred);
@@ -423,8 +527,8 @@
     // these measure different things and must never be plotted on the same line.
     const methods = distinct(
       "method",
-      "WHERE platform = ? AND category = ? AND family = ?",
-      [platformSel.value, categorySel.value, familySel.value]
+      "WHERE platform = ? AND framework = ? AND category = ? AND family = ?",
+      [platformSel.value, frameworkSel.value, categorySel.value, familySel.value]
     );
     populateSelect(methodSel, methods, null, preferred?.method);
     refreshSizes(preferred);
@@ -437,10 +541,11 @@
     hiddenSizes.clear();
     const stmt = db.prepare(
       `SELECT DISTINCT data_size_label, data_size_bytes FROM benchmark_results
-       WHERE platform = ? AND category = ? AND family = ? AND method = ?
+       WHERE platform = ? AND framework = ? AND category = ? AND family = ? AND method = ?
        ORDER BY data_size_bytes`
     );
-    stmt.bind([platformSel.value, categorySel.value, familySel.value, methodSel.value]);
+    stmt.bind([platformSel.value, frameworkSel.value, categorySel.value, familySel.value,
+               methodSel.value]);
     currentSizes = [];
     while (stmt.step()) currentSizes.push(stmt.getAsObject().data_size_label);
     stmt.free();
@@ -478,16 +583,17 @@
     const placeholders = sizes.map(() => "?").join(",");
     const cutoff = dateRangeCutoffIso();
     const stmt = db.prepare(`
-      SELECT r.variant, r.data_size_label, r.run_date, r.commit_sha, b.runtime_version,
+      SELECT r.variant, r.data_size_label, r.run_date, r.run_id, r.commit_sha, b.runtime_version,
              r.${metric} AS value
       FROM benchmark_results r
       LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
-      WHERE r.platform = ? AND r.category = ? AND r.family = ? AND r.method = ?
-        AND r.data_size_label IN (${placeholders})
+      WHERE r.platform = ? AND r.framework = ? AND r.category = ? AND r.family = ?
+        AND r.method = ? AND r.data_size_label IN (${placeholders})
         ${cutoff ? "AND r.run_date >= ?" : ""}
       ORDER BY r.variant, r.data_size_label, r.run_date
     `);
-    stmt.bind([platformSel.value, categorySel.value, familySel.value, methodSel.value, ...sizes, ...(cutoff ? [cutoff] : [])]);
+    stmt.bind([platformSel.value, frameworkSel.value, categorySel.value, familySel.value,
+               methodSel.value, ...sizes, ...(cutoff ? [cutoff] : [])]);
 
     const multiSize = sizes.length > 1;
     const seriesByKey = new Map();
@@ -497,6 +603,7 @@
       if (!seriesByKey.has(key)) seriesByKey.set(key, { variant: row.variant, sizeLabel: row.data_size_label, points: [] });
       seriesByKey.get(key).points.push({
         x: row.run_date, y: row.value, commit: row.commit_sha, runtime: row.runtime_version,
+        pkg: packageLabel(row.variant, row.run_id, platformSel.value, frameworkSel.value),
       });
     }
     stmt.free();
@@ -557,7 +664,8 @@
         ${cutoff ? "AND r.run_date >= ?" : ""}
       ORDER BY r.variant, r.data_size_bytes, r.run_date
     `);
-    stmt.bind([platformSel.value, categorySel.value, familySel.value, methodSel.value, ...(cutoff ? [cutoff] : [])]);
+    stmt.bind([platformSel.value, frameworkSel.value, categorySel.value, familySel.value,
+               methodSel.value, ...(cutoff ? [cutoff] : [])]);
 
     // ORDER BY run_date ASC means the last row seen for a given (variant, size) is the most
     // recent recorded run within the selected date range — exactly the one we want for a
@@ -572,6 +680,7 @@
         size_label: row.data_size_label,
         commit: row.commit_sha,
         runtime: row.runtime_version,
+        pkg: packageLabel(row.variant, row.run_id, platformSel.value, frameworkSel.value),
       });
     }
     stmt.free();
@@ -645,7 +754,12 @@
     return ours.length ? ours[0] : null;
   }
 
-  function runKey(runId, platform) { return runId + " " + platform; }
+  // Identity of one recorded run. Framework is part of it because the archive nests a framework
+  // level under the platform: the same commit on the same machine under net8.0 and net10.0 is two
+  // runs, and collapsing them here would make each look up the other's package versions.
+  function runKey(runId, platform, framework) {
+    return runId + " " + platform + " " + framework;
+  }
 
   let pendingRunFromUrl = null;
   let pendingCompareFromUrl = null;
@@ -655,11 +769,13 @@
   // those share a run_id and differ only in platform.
   function availableRuns() {
     const stmt = db.prepare(
-      "SELECT DISTINCT r.run_id, r.platform, r.run_date, r.commit_sha, b.runtime_version " +
+      "SELECT DISTINCT r.run_id, r.platform, r.framework, r.run_date, r.commit_sha, " +
+      "       b.runtime_version " +
       "FROM benchmark_results r " +
       "LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform " +
+      "                          AND b.framework = r.framework " +
       "WHERE r.category = ? AND r.family = ? AND r.method = ? " +
-      "ORDER BY r.run_date DESC, r.platform"
+      "ORDER BY r.run_date DESC, r.platform, r.framework"
     );
     stmt.bind([categorySel.value, familySel.value, methodSel.value]);
     const runs = [];
@@ -672,7 +788,10 @@
     const date = (run.run_date || "").slice(0, 10);
     const sha = run.commit_sha ? run.commit_sha.slice(0, 8) : "?";
     const rt = run.runtime_version ? " · .NET " + run.runtime_version : "";
-    return date + " · " + run.platform + " · " + sha + rt;
+    // The framework only earns a place in the label once more than one has been recorded;
+    // otherwise it is the same word on every option and says nothing.
+    const fw = hasMultipleFrameworks ? " · " + run.framework : "";
+    return date + " · " + run.platform + fw + " · " + sha + rt;
   }
 
   function refreshRunPickers() {
@@ -683,18 +802,22 @@
     runSel.innerHTML = "";
     for (const run of runs) {
       const opt = document.createElement("option");
-      opt.value = runKey(run.run_id, run.platform);
+      opt.value = runKey(run.run_id, run.platform, run.framework);
       opt.textContent = runOptionLabel(run);
       runSel.appendChild(opt);
     }
     // Default to the newest run on the platform already selected above, so switching into table
     // mode shows the data the charts were showing rather than jumping to another machine.
-    const preferred = runs.find((r) => r.platform === platformSel.value) || runs[0];
+    const preferred = runs.find((r) => r.platform === platformSel.value
+                                   && r.framework === frameworkSel.value)
+                   || runs.find((r) => r.platform === platformSel.value)
+                   || runs[0];
     const fromUrl = pendingRunFromUrl;
     pendingRunFromUrl = null;
-    const wanted = (fromUrl && runs.some((r) => runKey(r.run_id, r.platform) === fromUrl)) ? fromUrl
-                 : (runs.some((r) => runKey(r.run_id, r.platform) === previousRun) ? previousRun : null);
-    runSel.value = wanted || (preferred ? runKey(preferred.run_id, preferred.platform) : "");
+    const wanted = (fromUrl && runs.some((r) => runKey(r.run_id, r.platform, r.framework) === fromUrl)) ? fromUrl
+                 : (runs.some((r) => runKey(r.run_id, r.platform, r.framework) === previousRun) ? previousRun : null);
+    runSel.value = wanted
+      || (preferred ? runKey(preferred.run_id, preferred.platform, preferred.framework) : "");
 
     const chosenRunId = (runSel.value || "").split(" ")[0];
     compareSel.innerHTML = "";
@@ -703,9 +826,9 @@
     none.textContent = "(nothing — single run)";
     compareSel.appendChild(none);
     for (const run of runs) {
-      if (runKey(run.run_id, run.platform) === runSel.value) continue;
+      if (runKey(run.run_id, run.platform, run.framework) === runSel.value) continue;
       const opt = document.createElement("option");
-      opt.value = runKey(run.run_id, run.platform);
+      opt.value = runKey(run.run_id, run.platform, run.framework);
       opt.textContent = runOptionLabel(run) + (run.run_id === chosenRunId ? "   (same commit)" : "");
       compareSel.appendChild(opt);
     }
@@ -720,10 +843,10 @@
     const parts = key.split(" ");
     const stmt = db.prepare(
       "SELECT variant, data_size_label, data_size_bytes, mean_ns, allocated_bytes " +
-      "FROM benchmark_results WHERE run_id = ? AND platform = ? AND category = ? " +
-      "  AND family = ? AND method = ?"
+      "FROM benchmark_results WHERE run_id = ? AND platform = ? AND framework = ? " +
+      "  AND category = ? AND family = ? AND method = ?"
     );
-    stmt.bind([parts[0], parts[1], categorySel.value, familySel.value, methodSel.value]);
+    stmt.bind([parts[0], parts[1], parts[2], categorySel.value, familySel.value, methodSel.value]);
     const rows = [];
     while (stmt.step()) rows.push(stmt.getAsObject());
     stmt.free();
@@ -738,6 +861,7 @@
       compareBy.set(r.variant + "\u001f" + (r.data_size_label || ""), r);
     }
     const comparing = compareSel.value !== "" && compareRows.length > 0;
+    const changed = comparing ? changedPackages(runSel.value, compareSel.value) : new Map();
 
     dataTableHeadEl.innerHTML = "";
     dataTableBodyEl.innerHTML = "";
@@ -801,6 +925,7 @@
         first = false;
         const cmp = compareBy.get(r.variant + "\u001f" + (r.data_size_label || ""));
         const delta = (cmp && cmp.mean_ns) ? (r.mean_ns / cmp.mean_ns - 1) * 100 : null;
+        const movedPackage = comparing ? changed.get(VARIANT_PACKAGES[r.variant]) : undefined;
 
         for (const col of columns) {
           const td = document.createElement("td");
@@ -835,6 +960,15 @@
               // Positive means this run took longer. Coloured only past 5%, since run-to-run
               // noise below that says nothing.
               if (Math.abs(delta) >= 5) td.classList.add(delta > 0 ? "worse" : "better");
+              if (movedPackage) {
+                const marker = document.createElement("span");
+                marker.className = "pkg-changed";
+                marker.textContent = "‡";
+                marker.title = VARIANT_PACKAGES[r.variant] + " " + movedPackage[0] + " → " +
+                  movedPackage[1] + " between these runs, so this delta is not attributable to " +
+                  "CryptoHives.Foundation alone.";
+                td.appendChild(marker);
+              }
             }
           }
           tr.appendChild(td);
@@ -847,12 +981,35 @@
     const chosen = Array.from(runSel.options).find((o) => o.value === runSel.value);
     const against = Array.from(compareSel.options).find((o) => o.value === compareSel.value);
     tableNoteEl.hidden = false;
-    tableNoteEl.textContent =
+    let note =
       "This library's own implementations are shaded, the baseline more deeply; Ratio is each " +
       "row's mean over that baseline, computed per data size. Rows marked “not in package” " +
       "are compiled in for measurement only and excluded from the published NuGet package." +
       (comparing ? "  Δ Mean is against " + (against ? against.textContent.trim() : "the second run") +
                    " — positive means slower here." : "");
+
+    // Named explicitly rather than left to the per-row markers: a reader scanning for a regression
+    // should learn that a reference moved underneath the comparison before reading any number.
+    if (comparing && changed.size) {
+      note += "  Reference versions differ between these runs — " +
+        Array.from(changed, ([id, [from, to]]) => `${id} ${from} → ${to}`).join(", ") +
+        ". Rows marked ‡ measure a different build of the library, not only different code here.";
+    } else if (!comparing) {
+      const packages = runPackages.get(runSel.value);
+      const measured = packages && Object.values(VARIANT_PACKAGES)
+        .filter((id, i, all) => all.indexOf(id) === i && packages[id])
+        .map((id) => `${id} ${packages[id]}`);
+      if (measured && measured.length) {
+        // Declared central pins recovered from git read the same as a resolved graph, and they
+        // are not the same claim, so runs backfilled that way say so.
+        const source = runPackagesSource.get(runSel.value);
+        note += "  Measured against " + measured.join(", ") + "." +
+          (source === "Directory.Packages.props"
+            ? " (Versions recovered from the central pins at that commit, not from the run itself.)"
+            : "");
+      }
+    }
+    tableNoteEl.textContent = note;
     statusEl.textContent = total + " row(s) from " + (chosen ? chosen.textContent.trim() : "the selected run");
   }
 
@@ -896,13 +1053,27 @@
     if (!response.ok) throw new Error(`fetch failed: ${response.status}`);
     const buffer = await response.arrayBuffer();
     db = new SQL.Database(new Uint8Array(buffer));
+    loadRunPackages();
 
     const restoreState = parseUrlState();
 
     populateSelect(platformSel, distinct("platform", ""), null, restoreState?.platform);
-    platformSel.onchange = () => {
-      populateSelect(categorySel, distinct("category", "WHERE platform = ?", [platformSel.value]));
-      refreshFamilies();
+    hasMultipleFrameworks = distinct("framework", "").length > 1;
+    frameworkPickerEl.hidden = !hasMultipleFrameworks;
+    platformSel.onchange = () => refreshFrameworks({
+      framework: frameworkSel.value,
+      category: categorySel.value,
+      family: familySel.value,
+      method: methodSel.value,
+    });
+    // Same intent as the platform handler: keep the rest of the selection when the new framework
+    // also has it, which is the whole point of switching framework - you want the same chart.
+    frameworkSel.onchange = () => {
+      populateSelect(categorySel,
+                     distinct("category", "WHERE platform = ? AND framework = ?",
+                              [platformSel.value, frameworkSel.value]),
+                     null, categorySel.value);
+      refreshFamilies({ family: familySel.value, method: methodSel.value });
     };
     categorySel.onchange = refreshFamilies;
     familySel.onchange = refreshMethods;
@@ -935,8 +1106,7 @@
     pendingRunFromUrl = restoreState?.run ?? null;
     pendingCompareFromUrl = restoreState?.compare ?? null;
 
-    populateSelect(categorySel, distinct("category", "WHERE platform = ?", [platformSel.value]), null, restoreState?.category);
-    refreshFamilies(restoreState);
+    refreshFrameworks(restoreState);
   } catch (err) {
     statusEl.textContent = `Failed to load benchmark-history.sqlite: ${err.message}`;
     console.error(err);

--- a/docfx/packages/security/cryptography/benchmarks.md
+++ b/docfx/packages/security/cryptography/benchmarks.md
@@ -145,7 +145,10 @@ The following tables show the per-instance memory footprint (internal state + bu
    The script derives a platform id from the report's machine-spec preamble (override with `-PlatformId`
    for self-reported machines) and writes `run.json`, defaulting the code commit to `HEAD` — pass
    `-CodeCommit` when recording after the fact. It never commits or pushes: review the result and commit
-   in that worktree when the run is worth keeping. Pushing the branch republishes the site.
+   in that worktree when the run is worth keeping. Pushing the branch does not republish the site on
+   its own — GitHub only runs workflows that exist in the pushed branch, and the orphan archive branch
+   carries no `.github/`. Publish a new run deliberately with `gh workflow run docfx.yml`, or let the
+   next push to `main` pick it up.
 
    It also records the version of every reference implementation the run measured against, read from the
    benchmark project's resolved NuGet graph. A reference's trend line steps when that library ships a

--- a/docfx/packages/security/cryptography/benchmarks.md
+++ b/docfx/packages/security/cryptography/benchmarks.md
@@ -122,13 +122,20 @@ The following tables show the per-instance memory footprint (internal state + bu
    ```
 2. Recorded runs live on the orphan **`benchmarks`** branch, one directory per run:
    ```
-   cryptography/<code-commit>/<platform>/
-       run.json          what the numbers measure
+   cryptography/<code-commit>/<platform>/<framework>/
+       run.json          what the numbers measure, and against which library versions
        machine-spec.md   the machine and runtime they were measured on
        <scenario>.md     one report per benchmark class
    ```
    A run is keyed by the commit its binaries were built from, not by the commit that records it, so two
    machines measuring the same build land in one run directory as two platform directories.
+
+   The framework level below that does the same job for target frameworks: the same commit on the same
+   machine under net10.0 and net8.0 is two runs, so the Table view can put them side by side exactly as
+   it does two platforms. Pass `-Framework` to `run-benchmarks.ps1` and the matching `-TargetFramework`
+   to `update-benchmark-docs.ps1`. A single run covering several runtimes at once
+   (`-Runtimes "net8.0, net10.0"`) works too and needs neither: BenchmarkDotNet emits a `Runtime` column
+   when the runtime varies, and each row is recorded against its own framework.
 
    Write the reports into a worktree of that branch:
    ```powershell
@@ -139,6 +146,14 @@ The following tables show the per-instance memory footprint (internal state + bu
    for self-reported machines) and writes `run.json`, defaulting the code commit to `HEAD` — pass
    `-CodeCommit` when recording after the fact. It never commits or pushes: review the result and commit
    in that worktree when the run is worth keeping. Pushing the branch republishes the site.
+
+   It also records the version of every reference implementation the run measured against, read from the
+   benchmark project's resolved NuGet graph. A reference's trend line steps when that library ships a
+   release just as readily as when this library changes, and nothing else in a recorded run tells the two
+   apart — BouncyCastle moved 2.6.2 to 2.7.0, and Blake3 2.2.0 to 3.0.2, between runs already in the
+   archive. The dashboard shows the version in each point's tooltip, and marks any compared row whose
+   library moved between the two runs. Pass `-TargetFramework` if the benchmarks did not run on the
+   default `net10.0`.
 3. The dashboard database is a derived artifact, not a tracked file — SQLite rewrites pages throughout on
    every change, so committing it added a fresh multi-megabyte blob per rebuild for data that is fully
    reproducible from the archive. The docs workflow builds it, and so can you:

--- a/docfx/packages/threading/benchmark-trends/index.html
+++ b/docfx/packages/threading/benchmark-trends/index.html
@@ -30,6 +30,9 @@
   table.data-table tr.group-start td { border-top: 2px solid #bbb; }
   table.data-table tr.baseline td { background: #fff6e6; font-weight: 600; }
   table.data-table td.worse { color: #b91c1c; }
+  /* A delta whose competitor also changed version between the two runs. Not an error state -
+     the number is real - so it is marked rather than coloured, and carries its own tooltip. */
+  table.data-table td .pkg-changed { color: #92400e; cursor: help; margin-left: 0.3rem; }
   table.data-table td.better { color: #15803d; }
   .table-note { font-size: 0.8rem; color: #666; margin: 0 0 0.6rem; }
 </style>
@@ -61,6 +64,9 @@
 <div class="controls">
   <label>Platform
     <select id="platform"></select>
+  </label>
+  <label id="framework-picker" hidden>Framework
+    <select id="framework"></select>
   </label>
   <label>Family
     <select id="family"></select>
@@ -141,6 +147,8 @@
 (async function () {
   const statusEl = document.getElementById("status");
   const platformSel = document.getElementById("platform");
+  const frameworkSel = document.getElementById("framework");
+  const frameworkPickerEl = document.getElementById("framework-picker");
   const familySel = document.getElementById("family");
   const methodSel = document.getElementById("method");
   const cancellationSel = document.getElementById("cancellation");
@@ -282,6 +290,11 @@
   // Timeout instead of shifting depending on which variants happen to appear in one method's
   // result set. Rebuilt in refreshMethods(), which already runs on every platform/family change.
   let familyColors = new Map();
+  // Whether the archive holds more than one target framework at all. Until a second one is
+  // recorded the picker would be a single fixed option and the run labels would repeat the same
+  // word on every line, so both stay out of the way rather than advertising a dimension the data
+  // does not yet have.
+  let hasMultipleFrameworks = false;
 
   function distinct(column, whereSql, params) {
     const stmt = db.prepare(`SELECT DISTINCT ${column} FROM benchmark_results ${whereSql} ORDER BY ${column}`);
@@ -352,6 +365,7 @@
     if ([...params.keys()].length === 0) return null;
     return {
       platform: params.get("platform") ?? undefined,
+      framework: params.get("framework") ?? undefined,
       family: params.get("family") ?? undefined,
       method: params.get("method") ?? undefined,
       cancellation: params.get("cancellation") ?? undefined,
@@ -367,6 +381,7 @@
   function syncUrlHash() {
     const params = new URLSearchParams();
     params.set("platform", platformSel.value);
+    params.set("framework", frameworkSel.value);
     params.set("family", familySel.value);
     params.set("method", methodSel.value);
     params.set("cancellation", cancellationSel.value);
@@ -417,8 +432,19 @@
     return cutoff.toISOString();
   }
 
+  // Framework sits directly under platform in the cascade, because it narrows the same way a
+  // platform does: the same commit measured under net8.0 and net10.0 is two sets of numbers that
+  // must never share a line. Which frameworks exist is per platform - a net48 run only happens on
+  // Windows - so this is re-derived on every platform change rather than filled once.
+  function refreshFrameworks(preferred) {
+    const frameworks = distinct("framework", "WHERE platform = ?", [platformSel.value]);
+    populateSelect(frameworkSel, frameworks, null, preferred?.framework);
+    refreshFamilies(preferred);
+  }
+
   function refreshFamilies(preferred) {
-    const families = distinct("family", "WHERE platform = ?", [platformSel.value]);
+    const families = distinct("family", "WHERE platform = ? AND framework = ?",
+                              [platformSel.value, frameworkSel.value]);
     populateSelect(familySel, families, null, preferred?.family);
     refreshMethods(preferred);
   }
@@ -428,8 +454,8 @@
     // "Multiple") — these measure different scenarios and must never be plotted on one line.
     const methods = distinct(
       "method",
-      "WHERE platform = ? AND family = ?",
-      [platformSel.value, familySel.value]
+      "WHERE platform = ? AND framework = ? AND family = ?",
+      [platformSel.value, frameworkSel.value, familySel.value]
     );
     populateSelect(methodSel, methods, null, preferred?.method);
     refreshFamilyColors();
@@ -440,6 +466,10 @@
   // set — not just the ones present under the currently selected method — so e.g. "Pooled" is the
   // same color under Single, Multiple, and Timeout instead of shifting with whatever else happens
   // to be in that method's result set.
+  //
+  // Deliberately not narrowed by framework, for the same reason it is not narrowed by method: a
+  // variant should keep its colour when you switch from net10.0 to net8.0, which is exactly the
+  // moment you are comparing the two by eye.
   function refreshFamilyColors() {
     const variants = distinct(
       "variant",
@@ -468,8 +498,8 @@
     // making it the most comparable choice across the whole family.
     const states = distinct(
       "cancellation",
-      "WHERE platform = ? AND family = ? AND method = ?",
-      [platformSel.value, familySel.value, methodSel.value]
+      "WHERE platform = ? AND framework = ? AND family = ? AND method = ?",
+      [platformSel.value, frameworkSel.value, familySel.value, methodSel.value]
     );
     populateSelect(cancellationSel, states, null, preferred?.cancellation ?? "None", cancellationLabel);
     refreshParams();
@@ -490,14 +520,73 @@
     // query anyway, so a level with no rows for the selected state simply plots nothing.
     const stmt = db.prepare(
       `SELECT DISTINCT param_label, param_value FROM benchmark_results
-       WHERE platform = ? AND family = ? AND method = ? AND param_label IS NOT NULL
+       WHERE platform = ? AND framework = ? AND family = ? AND method = ?
+         AND param_label IS NOT NULL
        ORDER BY param_value`
     );
-    stmt.bind([platformSel.value, familySel.value, methodSel.value]);
+    stmt.bind([platformSel.value, frameworkSel.value, familySel.value, methodSel.value]);
     currentParams = [];
     while (stmt.step()) currentParams.push(stmt.getAsObject().param_label);
     stmt.free();
     renderChart();
+  }
+
+  // Which NuGet package supplies each competitor, so a step in that competitor's line can be
+  // attributed to the competitor shipping a release rather than to a change in this repository.
+  //
+  // Declared here rather than recorded, because nothing in a BenchmarkDotNet report names the
+  // package behind a display label - the labels are chosen in the benchmark classes, and only the
+  // classes know that "VS.Threading" means Microsoft.VisualStudio.Threading. Ids must match
+  // Directory.Packages.props exactly, since that is what ends up in benchmark_run_packages.
+  //
+  // Variants with no entry are deliberate, not omissions: Pooled* is our own code (identified by
+  // the run's commit), RefImpl is vendored source in tests/, and the BCL rows (Lock, SemaphoreSlim,
+  // Interlocked.*, ...) move with the runtime, which benchmark_runs already records.
+  const VARIANT_PACKAGES = {
+    "AsyncKeyedLock": "AsyncKeyedLock",
+    "AsyncKeyedLock (Striped)": "AsyncKeyedLock",
+    "AsyncUtilities (Striped)": "AsyncUtilities",
+    "Dao.IndividualLock": "Dao.IndividualLock",
+    "KeyedSemaphores": "KeyedSemaphores",
+    "KeyedSemaphores (Striped)": "KeyedSemaphores",
+    "NeoSmart": "NeoSmart.AsyncLock",
+    "Nito": "Nito.AsyncEx",
+    "ProtoPromise": "ProtoPromise",
+    "VS.Threading": "Microsoft.VisualStudio.Threading",
+  };
+
+  // (run_id + platform) -> { packageId: version }, loaded once at startup. Small enough to hold
+  // whole (a few hundred rows across the entire archive) that joining it per query would cost
+  // more than it saves.
+  let runPackages = new Map();
+  let runPackagesSource = new Map();
+
+  function loadRunPackages() {
+    runPackages = new Map();
+    runPackagesSource = new Map();
+    let stmt;
+    try {
+      stmt = db.prepare("SELECT run_id, platform, framework, package_id, version, source " +
+                        "FROM benchmark_run_packages");
+    } catch {
+      return;   // database built before the table existed; the UI just shows no versions
+    }
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      const key = runKey(row.run_id, row.platform, row.framework);
+      if (!runPackages.has(key)) runPackages.set(key, {});
+      runPackages.get(key)[row.package_id] = row.version;
+      if (row.source) runPackagesSource.set(key, row.source);
+    }
+    stmt.free();
+  }
+
+  // "AsyncKeyedLock 8.0.2" for a variant backed by a package in that run, otherwise null.
+  function packageLabel(variant, runId, platform, framework) {
+    const packageId = VARIANT_PACKAGES[variant];
+    if (!packageId) return null;
+    const version = runPackages.get(runKey(runId, platform, framework))?.[packageId];
+    return version ? `${packageId} ${version}` : null;
   }
 
   // The runtime a point was measured on belongs next to the commit: between the recorded runs so
@@ -505,8 +594,11 @@
   // in a line cannot be read as a code change without knowing whether the floor moved under it.
   // Older rows predate the environment table and simply omit it rather than showing a blank.
   function pointFooter(raw) {
-    const commit = `commit ${raw.commit?.slice(0, 8) ?? "?"}`;
-    return raw.runtime ? `${commit} · .NET ${raw.runtime}` : commit;
+    const parts = [`commit ${raw.commit?.slice(0, 8) ?? "?"}`];
+    if (raw.runtime) parts.push(`.NET ${raw.runtime}`);
+    // Only third-party series carry one; ours is pinned by the commit already in this footer.
+    if (raw.pkg) parts.push(raw.pkg);
+    return parts.join(" · ");
   }
 
   function renderChartInstance(datasets, scales, tooltipAfterLabel) {
@@ -540,16 +632,18 @@
     const cutoff = dateRangeCutoffIso();
     const paramClause = hasRealParams ? `AND param_label IN (${placeholders})` : "AND param_label IS NULL";
     const stmt = db.prepare(`
-      SELECT r.variant, r.param_label, r.run_date, r.commit_sha, b.runtime_version,
+      SELECT r.variant, r.param_label, r.run_date, r.run_id, r.commit_sha, b.runtime_version,
              r.${metric} AS value
       FROM benchmark_results r
       LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
-      WHERE r.platform = ? AND r.family = ? AND r.method = ? AND r.cancellation = ? ${paramClause.replace(/param_label/g, "r.param_label")}
+      WHERE r.platform = ? AND r.framework = ? AND r.family = ? AND r.method = ?
+        AND r.cancellation = ? ${paramClause.replace(/param_label/g, "r.param_label")}
         ${cutoff ? "AND r.run_date >= ?" : ""}
       ORDER BY r.variant, r.param_label, r.run_date
     `);
     stmt.bind([
-      platformSel.value, familySel.value, methodSel.value, cancellationSel.value,
+      platformSel.value, frameworkSel.value, familySel.value, methodSel.value,
+      cancellationSel.value,
       ...(hasRealParams ? params : []),
       ...(cutoff ? [cutoff] : []),
     ]);
@@ -562,6 +656,7 @@
       if (!seriesByKey.has(key)) seriesByKey.set(key, { variant: row.variant, paramLabel: row.param_label, points: [] });
       seriesByKey.get(key).points.push({
         x: row.run_date, y: row.value, commit: row.commit_sha, runtime: row.runtime_version,
+        pkg: packageLabel(row.variant, row.run_id, platformSel.value, frameworkSel.value),
       });
     }
     stmt.free();
@@ -635,15 +730,16 @@
     const hasRealParams = currentParams.length > 0;
     const paramClause = hasRealParams ? "AND r.param_label IS NOT NULL" : "AND r.param_label IS NULL";
     const stmt = db.prepare(`
-      SELECT r.variant, r.cancellation, r.param_value, r.param_label, r.run_date, r.commit_sha,
-             b.runtime_version, r.mean_ns, r.allocated_bytes
+      SELECT r.variant, r.cancellation, r.param_value, r.param_label, r.run_date, r.run_id,
+             r.commit_sha, b.runtime_version, r.mean_ns, r.allocated_bytes
       FROM benchmark_results r
       LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
-      WHERE r.platform = ? AND r.family = ? AND r.method = ? ${paramClause}
+      WHERE r.platform = ? AND r.framework = ? AND r.family = ? AND r.method = ? ${paramClause}
         ${cutoff ? "AND r.run_date >= ?" : ""}
       ORDER BY r.variant, r.cancellation, r.param_value, r.run_date
     `);
-    stmt.bind([platformSel.value, familySel.value, methodSel.value, ...(cutoff ? [cutoff] : [])]);
+    stmt.bind([platformSel.value, frameworkSel.value, familySel.value, methodSel.value,
+               ...(cutoff ? [cutoff] : [])]);
 
     // ORDER BY run_date ASC means the last row seen for a given (variant, cancellation, level) is
     // the most recent recorded run within the selected date range - exactly the one we want for a
@@ -686,6 +782,7 @@
             param_label: hasRealParams ? r.param_label : "single scenario",
             commit: r.commit_sha,
             runtime: r.runtime_version,
+            pkg: packageLabel(variant, r.run_id, platformSel.value, frameworkSel.value),
           })),
           yAxisID: metric.axis,
           borderColor: familyColors.get(variant),
@@ -806,18 +903,25 @@
   let pendingRunFromUrl = null;
   let pendingCompareFromUrl = null;
 
-  function runKey(runId, platform) { return runId + " " + platform; }
+  // Identity of one recorded run. Framework is part of it because the archive nests a framework
+  // level under the platform: the same commit on the same machine under net8.0 and net10.0 is two
+  // runs, and collapsing them here would make each look up the other's package versions.
+  function runKey(runId, platform, framework) {
+    return runId + " " + platform + " " + framework;
+  }
 
   // Every (run, platform) carrying rows for the current family+method, newest first. Both pickers
   // are filled from this, which is what makes "macOS vs Windows at the same commit" fall out for
   // free: those two share a run_id and differ only in platform.
   function availableRuns() {
     const stmt = db.prepare(
-      "SELECT DISTINCT r.run_id, r.platform, r.run_date, r.commit_sha, b.runtime_version " +
+      "SELECT DISTINCT r.run_id, r.platform, r.framework, r.run_date, r.commit_sha, " +
+      "       b.runtime_version " +
       "FROM benchmark_results r " +
       "LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform " +
+      "                          AND b.framework = r.framework " +
       "WHERE r.family = ? AND r.method = ? " +
-      "ORDER BY r.run_date DESC, r.platform"
+      "ORDER BY r.run_date DESC, r.platform, r.framework"
     );
     stmt.bind([familySel.value, methodSel.value]);
     const runs = [];
@@ -830,7 +934,10 @@
     const date = (run.run_date || "").slice(0, 10);
     const sha = run.commit_sha ? run.commit_sha.slice(0, 8) : "?";
     const rt = run.runtime_version ? " · .NET " + run.runtime_version : "";
-    return date + " · " + run.platform + " · " + sha + rt;
+    // The framework only earns a place in the label once more than one has been recorded;
+    // otherwise it is the same word on every option and says nothing.
+    const fw = hasMultipleFrameworks ? " · " + run.framework : "";
+    return date + " · " + run.platform + fw + " · " + sha + rt;
   }
 
   function refreshRunPickers() {
@@ -841,19 +948,23 @@
     runSel.innerHTML = "";
     for (const run of runs) {
       const opt = document.createElement("option");
-      opt.value = runKey(run.run_id, run.platform);
+      opt.value = runKey(run.run_id, run.platform, run.framework);
       opt.textContent = runOptionLabel(run);
       runSel.appendChild(opt);
     }
     // Default to the newest run on the platform already selected above, so switching into table
     // mode shows the data the charts were showing rather than jumping to another machine.
-    const preferred = runs.find((r) => r.platform === platformSel.value) || runs[0];
+    const preferred = runs.find((r) => r.platform === platformSel.value
+                                   && r.framework === frameworkSel.value)
+                   || runs.find((r) => r.platform === platformSel.value)
+                   || runs[0];
     // A run named in the URL wins once, on first render, then normal selection takes over.
     const fromUrl = pendingRunFromUrl;
     pendingRunFromUrl = null;
-    const wanted = (fromUrl && runs.some((r) => runKey(r.run_id, r.platform) === fromUrl)) ? fromUrl
-                 : (runs.some((r) => runKey(r.run_id, r.platform) === previousRun) ? previousRun : null);
-    runSel.value = wanted || (preferred ? runKey(preferred.run_id, preferred.platform) : "");
+    const wanted = (fromUrl && runs.some((r) => runKey(r.run_id, r.platform, r.framework) === fromUrl)) ? fromUrl
+                 : (runs.some((r) => runKey(r.run_id, r.platform, r.framework) === previousRun) ? previousRun : null);
+    runSel.value = wanted
+      || (preferred ? runKey(preferred.run_id, preferred.platform, preferred.framework) : "");
 
     const chosenRunId = (runSel.value || "").split(" ")[0];
     compareSel.innerHTML = "";
@@ -862,9 +973,9 @@
     none.textContent = "(nothing — single run)";
     compareSel.appendChild(none);
     for (const run of runs) {
-      if (runKey(run.run_id, run.platform) === runSel.value) continue;
+      if (runKey(run.run_id, run.platform, run.framework) === runSel.value) continue;
       const opt = document.createElement("option");
-      opt.value = runKey(run.run_id, run.platform);
+      opt.value = runKey(run.run_id, run.platform, run.framework);
       opt.textContent = runOptionLabel(run) + (run.run_id === chosenRunId ? "   (same commit)" : "");
       compareSel.appendChild(opt);
     }
@@ -879,9 +990,10 @@
     const parts = key.split(" ");
     const stmt = db.prepare(
       "SELECT variant, cancellation, param_label, mean_ns, allocated_bytes " +
-      "FROM benchmark_results WHERE run_id = ? AND platform = ? AND family = ? AND method = ?"
+      "FROM benchmark_results WHERE run_id = ? AND platform = ? AND framework = ? " +
+      "  AND family = ? AND method = ?"
     );
-    stmt.bind([parts[0], parts[1], familySel.value, methodSel.value]);
+    stmt.bind([parts[0], parts[1], parts[2], familySel.value, methodSel.value]);
     const rows = [];
     while (stmt.step()) rows.push(stmt.getAsObject());
     stmt.free();
@@ -889,6 +1001,19 @@
   }
 
   const CANCELLATION_ORDER = ["None", "NotCancelled", "Cancelled", "Timed", "NotCancelledTimed"];
+
+  // Packages whose version differs between the two runs being compared. This is the whole point
+  // of recording them: a competitor's Δ Mean is only evidence about our code if that competitor
+  // was the same build in both runs, and across the recorded history several were not.
+  function changedPackages(keyA, keyB) {
+    const a = runPackages.get(keyA) || {};
+    const b = runPackages.get(keyB) || {};
+    const changed = new Map();
+    for (const id of Object.keys(a)) {
+      if (b[id] && b[id] !== a[id]) changed.set(id, [b[id], a[id]]);   // [compared, chosen]
+    }
+    return changed;
+  }
 
   function renderTableView() {
     const rows = fetchRunRows(runSel.value);
@@ -898,6 +1023,7 @@
       compareBy.set(r.variant + "" + r.cancellation + "" + (r.param_label || ""), r);
     }
     const comparing = compareSel.value !== "" && compareRows.length > 0;
+    const changed = comparing ? changedPackages(runSel.value, compareSel.value) : new Map();
 
     dataTableHeadEl.innerHTML = "";
     dataTableBodyEl.innerHTML = "";
@@ -987,6 +1113,7 @@
         const params = new Map(splitParams(r.param_label));
         const cmp = compareBy.get(r.variant + "" + r.cancellation + "" + (r.param_label || ""));
         const delta = (cmp && cmp.mean_ns) ? (r.mean_ns / cmp.mean_ns - 1) * 100 : null;
+        const movedPackage = comparing ? changed.get(VARIANT_PACKAGES[r.variant]) : undefined;
 
         for (const col of columns) {
           const td = document.createElement("td");
@@ -1016,6 +1143,15 @@
               // Signed against the comparison run: positive means this run took longer. Only
               // coloured past 5%, since run-to-run noise below that says nothing.
               if (Math.abs(delta) >= 5) td.classList.add(delta > 0 ? "worse" : "better");
+              if (movedPackage) {
+                const marker = document.createElement("span");
+                marker.className = "pkg-changed";
+                marker.textContent = "‡";
+                marker.title = VARIANT_PACKAGES[r.variant] + " " + movedPackage[0] + " → " +
+                  movedPackage[1] + " between these runs, so this delta is not attributable to " +
+                  "CryptoHives.Foundation alone.";
+                td.appendChild(marker);
+              }
             }
           }
           tr.appendChild(td);
@@ -1028,11 +1164,36 @@
     const chosen = Array.from(runSel.options).find((o) => o.value === runSel.value);
     const against = Array.from(compareSel.options).find((o) => o.value === compareSel.value);
     tableNoteEl.hidden = false;
-    tableNoteEl.textContent =
+    let note =
       "Baseline (highlighted) is this library's own implementation; Ratio is each row's mean over it, " +
       "computed per parameter combination and cancellation state." +
       (comparing ? "  Δ Mean is against " + (against ? against.textContent.trim() : "the second run") +
                    " — positive means slower here." : "");
+
+    // Named explicitly rather than left to the per-row markers: a reader scanning for a regression
+    // should learn that a competitor moved underneath the comparison before reading any number,
+    // and the markers only appear on rows that happen to be on screen.
+    if (comparing && changed.size) {
+      note += "  Competitor versions differ between these runs — " +
+        Array.from(changed, ([id, [from, to]]) => `${id} ${from} → ${to}`).join(", ") +
+        ". Rows marked ‡ measure a different build of the library, not only different code here.";
+    } else if (!comparing) {
+      const packages = runPackages.get(runSel.value);
+      const measured = packages && Object.keys(VARIANT_PACKAGES)
+        .map((v) => VARIANT_PACKAGES[v])
+        .filter((id, i, all) => all.indexOf(id) === i && packages[id])
+        .map((id) => `${id} ${packages[id]}`);
+      if (measured && measured.length) {
+        // Declared central pins recovered from git read the same as a resolved graph, and they
+        // are not the same claim, so runs backfilled that way say so.
+        const source = runPackagesSource.get(runSel.value);
+        note += "  Measured against " + measured.join(", ") + "." +
+          (source === "Directory.Packages.props"
+            ? " (Versions recovered from the central pins at that commit, not from the run itself.)"
+            : "");
+      }
+    }
+    tableNoteEl.textContent = note;
     statusEl.textContent = total + " row(s) from " + (chosen ? chosen.textContent.trim() : "the selected run");
   }
 
@@ -1077,16 +1238,27 @@
     if (!response.ok) throw new Error(`fetch failed: ${response.status}`);
     const buffer = await response.arrayBuffer();
     db = new SQL.Database(new Uint8Array(buffer));
+    loadRunPackages();
 
     const restoreState = parseUrlState();
 
     populateSelect(platformSel, distinct("platform", ""), null, restoreState?.platform);
+    hasMultipleFrameworks = distinct("framework", "").length > 1;
+    frameworkPickerEl.hidden = !hasMultipleFrameworks;
     // Keep the current family/method/cancellation selected across a platform switch when the
     // other platform has that same combination too — e.g. flipping between windows and macos
     // shouldn't reset back to the first family/method every time. populateSelect() already falls
     // back to the first available option on its own when the preferred value doesn't exist for
     // the new platform, so this is safe even when the two platforms' data don't fully overlap.
-    platformSel.onchange = () => refreshFamilies({
+    platformSel.onchange = () => refreshFrameworks({
+      framework: frameworkSel.value,
+      family: familySel.value,
+      method: methodSel.value,
+      cancellation: cancellationSel.value,
+    });
+    // Same intent as the platform handler: keep the rest of the selection when the new framework
+    // also has it, which is the whole point of switching framework - you want the same chart.
+    frameworkSel.onchange = () => refreshFamilies({
       family: familySel.value,
       method: methodSel.value,
       cancellation: cancellationSel.value,
@@ -1122,7 +1294,7 @@
     pendingRunFromUrl = restoreState?.run ?? null;
     pendingCompareFromUrl = restoreState?.compare ?? null;
 
-    refreshFamilies(restoreState);
+    refreshFrameworks(restoreState);
   } catch (err) {
     statusEl.textContent = `Failed to load benchmark-history.sqlite: ${err.message}`;
     console.error(err);

--- a/docfx/packages/threading/benchmarks.md
+++ b/docfx/packages/threading/benchmarks.md
@@ -19,13 +19,15 @@ Published results live in the interactive benchmark trends dashboard below rathe
 Recorded runs live on the orphan **`benchmarks`** branch, one directory per run:
 
 ```
-threading/<code-commit>/<platform>/
-    run.json          what the numbers measure
+threading/<code-commit>/<platform>/<framework>/
+    run.json          what the numbers measure, and against which library versions
     machine-spec.md   the machine and runtime they were measured on
     <scenario>.md     one report per benchmark class
 ```
 
 A run is keyed by the commit its binaries were built from, not by the commit that records it. Two machines measuring the same build therefore land in one run directory as two platform directories, which is what makes a cross-platform comparison possible at all.
+
+The framework level below that does the same job for target frameworks: the same commit on the same machine under net10.0 and net8.0 is two runs, so the Table view can put them side by side exactly as it does two platforms. Pass `-Framework` to `run-benchmarks.ps1` and the matching `-TargetFramework` to `update-benchmark-docs.ps1`. A single run covering several runtimes at once (`-Runtimes "net8.0, net10.0"`) works too and needs neither: BenchmarkDotNet emits a `Runtime` column when the runtime varies, and each row is recorded against its own framework.
 
 Run the benchmarks locally first (see below), then write the reports into a worktree of that branch:
 
@@ -35,6 +37,8 @@ git worktree add ../foundation-bench benchmarks
 ```
 
 `update-benchmark-docs.ps1` derives a platform id from the report's machine-spec preamble (override with `-PlatformId` for self-reported machines) and writes `run.json`, defaulting the code commit to `HEAD` — pass `-CodeCommit` when recording a run after the fact, or when `HEAD` has moved on since the run. It never commits or pushes: review the result and commit in that worktree when the run is worth keeping.
+
+It also records the version of every third-party library the run measured against, read from the benchmark project's resolved NuGet graph. A competitor's trend line steps when that competitor ships a release just as readily as when this library changes, and nothing else in a recorded run tells the two apart — `Microsoft.VisualStudio.Threading` moved 17.14.15 to 18.7.23 between runs already in the archive. The dashboard shows the version in each point's tooltip, and marks any compared row whose library moved between the two runs. Pass `-TargetFramework` if the benchmarks did not run on the default `net10.0`.
 
 Pushing the branch republishes the site, because the dashboard database is generated at build time rather than committed.
 

--- a/docfx/packages/threading/benchmarks.md
+++ b/docfx/packages/threading/benchmarks.md
@@ -40,7 +40,7 @@ git worktree add ../foundation-bench benchmarks
 
 It also records the version of every third-party library the run measured against, read from the benchmark project's resolved NuGet graph. A competitor's trend line steps when that competitor ships a release just as readily as when this library changes, and nothing else in a recorded run tells the two apart — `Microsoft.VisualStudio.Threading` moved 17.14.15 to 18.7.23 between runs already in the archive. The dashboard shows the version in each point's tooltip, and marks any compared row whose library moved between the two runs. Pass `-TargetFramework` if the benchmarks did not run on the default `net10.0`.
 
-Pushing the branch republishes the site, because the dashboard database is generated at build time rather than committed.
+Pushing the branch does not republish the site on its own. The dashboard database is generated at build time rather than committed, so a new run becomes visible only when the docs workflow runs again — and a push to `benchmarks` cannot start it, because GitHub only runs workflows that exist in the pushed branch and that orphan branch carries no `.github/`. Publish it deliberately with `gh workflow run docfx.yml`, or let the next push to `main` pick it up.
 
 ### Rebuilding the dashboard database
 

--- a/scripts/backfill-run-packages.py
+++ b/scripts/backfill-run-packages.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+# SPDX-License-Identifier: MIT
+"""
+Backfills the `packages` block into run.json for runs recorded before it existed.
+
+update-benchmark-docs.ps1 now records the version of every third-party library a benchmark run
+measured against, read from NuGet's resolved restore graph. Runs recorded before that have no
+such block, which leaves a hole exactly where it hurts: BouncyCastle went 2.6.2 -> 2.7.0 in #210
+and AsyncKeyedLock moved four times across the recorded history, so several existing trend lines
+step for reasons that have nothing to do with this repository's code.
+
+The information is recoverable, because central package management pins every version in
+Directory.Packages.props and each run.json names the commit it measured. This walks the archive,
+reads that file (and the benchmark project's csproj, for which packages were referenced) at each
+run's commit, and writes the result back.
+
+What is recovered is the *declared* pin, not the resolved graph, so every entry is stamped
+packagesSource="Directory.Packages.props". Central pinning makes the two agree in practice, but
+declared is a minimum and resolved is a fact - the distinction is preserved rather than papered
+over, and the dashboard says which it is showing.
+
+Idempotent: a run that already has a `packages` block is left untouched, so this is safe to
+re-run after adding a new run to the archive.
+
+Usage:
+    python scripts/backfill-run-packages.py --archive ../foundation-bench
+    python scripts/backfill-run-packages.py --archive ../foundation-bench --dry-run
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+# The benchmark project whose references define "what this run measured against", per package
+# directory in the archive.
+PROJECTS = {
+    "threading": "tests/Threading/Threading.Tests.csproj",
+    "cryptography": "tests/Security/Cryptography/Cryptography.Tests.csproj",
+}
+
+PACKAGE_VERSION_RE = re.compile(
+    r'<PackageVersion\s+Include="([^"]+)"\s+Version="([^"]+)"', re.IGNORECASE)
+PACKAGE_REFERENCE_RE = re.compile(r'<PackageReference\s+([^>]*?)/?>', re.IGNORECASE)
+INCLUDE_RE = re.compile(r'Include="([^"]+)"', re.IGNORECASE)
+
+
+def git_show(repo_root, commit, path):
+    """File contents at a commit, or None when the path did not exist there."""
+    result = subprocess.run(["git", "-C", repo_root, "show", f"{commit}:{path}"],
+                            capture_output=True, text=True, encoding="utf-8")
+    return result.stdout if result.returncode == 0 else None
+
+
+def referenced_packages(csproj_text):
+    """Package ids the benchmark project references directly.
+
+    MSBuild conditions are deliberately ignored rather than evaluated. Every condition in these
+    two projects gates on target framework or strong-name signing, and the runs being backfilled
+    were all recorded on net10.0 without signing - the case in which every condition holds. An
+    id that was in fact excluded resolves to a version nothing ever asks about, which is
+    harmless; evaluating MSBuild here would not be.
+    """
+    ids = set()
+    for attributes in PACKAGE_REFERENCE_RE.findall(csproj_text):
+        # ExcludeAssets="all" references contribute no code to the benchmark, so they cannot
+        # affect a measurement (IndexRange is polyfill-only, for instance).
+        if 'ExcludeAssets="all"' in attributes:
+            continue
+        match = INCLUDE_RE.search(attributes)
+        if not match:
+            continue
+        package_id = match.group(1)
+        # MSBuild property references are the packed-package self-reference; skip along with the
+        # plain form, since our own version is already identified by the run's code commit.
+        if "$(" in package_id or package_id.startswith("CryptoHives.Foundation."):
+            continue
+        ids.add(package_id)
+    return ids
+
+
+def resolve(repo_root, commit, csproj_path):
+    """{package id: version} the given commit's central pins declare for that project."""
+    props = git_show(repo_root, commit, "Directory.Packages.props")
+    csproj = git_show(repo_root, commit, csproj_path)
+    if props is None or csproj is None:
+        return None, f"Directory.Packages.props or {csproj_path} missing at {commit[:8]}"
+
+    pins = dict(PACKAGE_VERSION_RE.findall(props))
+    wanted = referenced_packages(csproj)
+
+    versions = {}
+    unpinned = []
+    for package_id in sorted(wanted):
+        if package_id in pins:
+            versions[package_id] = pins[package_id]
+        else:
+            unpinned.append(package_id)
+
+    if not versions:
+        return None, "no referenced package matched a central pin"
+    note = f"unpinned: {', '.join(unpinned)}" if unpinned else None
+    return versions, note
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--archive", required=True, help="Root of the run archive (benchmarks-branch worktree)")
+    parser.add_argument("--repo", default=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        help="Repository the code commits live in (defaults to this checkout)")
+    parser.add_argument("--dry-run", action="store_true", help="Report without writing")
+    args = parser.parse_args()
+
+    written = skipped = failed = 0
+
+    for package_dir, csproj_path in sorted(PROJECTS.items()):
+        package_root = os.path.join(args.archive, package_dir)
+        if not os.path.isdir(package_root):
+            continue
+
+        for run_id in sorted(os.listdir(package_root)):
+            run_root = os.path.join(package_root, run_id)
+            if not os.path.isdir(run_root):
+                continue
+            for platform in sorted(os.listdir(run_root)):
+                platform_root = os.path.join(run_root, platform)
+                if not os.path.isdir(platform_root):
+                    continue
+                # The archive nests a framework level under the platform, since the same commit
+                # on the same machine under two target frameworks is two distinct runs.
+                for framework in sorted(os.listdir(platform_root)):
+                    metadata_path = os.path.join(platform_root, framework, "run.json")
+                    if not os.path.isfile(metadata_path):
+                        continue
+
+                    with open(metadata_path, encoding="utf-8") as handle:
+                        metadata = json.load(handle)
+
+                    label = f"{package_dir}/{run_id}/{platform}/{framework}"
+                    if metadata.get("packages"):
+                        print(f"  [skip] {label}: already has {len(metadata['packages'])} package(s)")
+                        skipped += 1
+                        continue
+
+                    commit = metadata.get("codeCommit")
+                    if not commit:
+                        print(f"  [fail] {label}: no codeCommit", file=sys.stderr)
+                        failed += 1
+                        continue
+
+                    versions, note = resolve(args.repo, commit, csproj_path)
+                    if versions is None:
+                        print(f"  [fail] {label}: {note}", file=sys.stderr)
+                        failed += 1
+                        continue
+
+                    metadata["packagesSource"] = "Directory.Packages.props"
+                    metadata["packages"] = versions
+
+                    if args.dry_run:
+                        print(f"  [dry-run] {label}: {len(versions)} package(s)"
+                              + (f"  ({note})" if note else ""))
+                    else:
+                        with open(metadata_path, "w", encoding="utf-8", newline="\n") as handle:
+                            json.dump(metadata, handle, indent=2)
+                            handle.write("\n")
+                        print(f"  [ok] {label}: {len(versions)} package(s)"
+                              + (f"  ({note})" if note else ""))
+                    written += 1
+
+    verb = "Would write" if args.dry_run else "Wrote"
+    print(f"{verb} {written}, skipped {skipped}, failed {failed}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cryptography-benchmark-trends/import_historical_markdown.py
+++ b/scripts/cryptography-benchmark-trends/import_historical_markdown.py
@@ -79,6 +79,40 @@ SIZE_MULTIPLIERS = {"B": 1, "KB": 1024, "MB": 1024 * 1024}
 SIZE_PATTERN = re.compile(r"^(?P<value>\d+)(?P<unit>B|KB|MB)$")
 MEASUREMENT_PATTERN = re.compile(r"^([\d,]+\.?\d*)\s*(ns|μs|us|ms)$")
 
+# BenchmarkDotNet keeps job characteristics in the preamble only while they are constant across
+# the report; the moment one varies it becomes a table column instead. A single-runtime run says
+# "Toolchain=net10.0" above the table, while `--runtimes net8.0 net10.0` grows a "Runtime" column.
+#
+# Unlike Threading's parser - which identifies [Params] by exclusion, so an unknown column would
+# become a spurious parameter - this one reads columns by name and would simply ignore a Runtime
+# column. That failure is quieter and worse: every runtime's rows would share a primary key and
+# silently overwrite one another, leaving one runtime's numbers labelled as the run's.
+#
+# Kept as a deliberate sibling of FRAMEWORK_COLUMNS/normalize_framework in
+# scripts/threading-benchmark-trends/markdown_parser.py rather than shared, matching how the rest
+# of these two pipelines are organized.
+FRAMEWORK_COLUMNS = ("Runtime", "Job")
+
+_FRAMEWORK_DISPLAY = re.compile(r"^\.NET (?P<fw>Framework )?(?P<version>\d+(?:\.\d+){1,2})$")
+
+
+def normalize_framework(value):
+    """'.NET 10.0' -> 'net10.0', '.NET Framework 4.6.2' -> 'net462', 'net10.0' -> 'net10.0'.
+
+    Anything unrecognized is returned unchanged rather than dropped: a value this does not know
+    is still a truthful distinction between rows, and collapsing it would merge runs that differ.
+    """
+    if not value:
+        return None
+    value = value.strip()
+    match = _FRAMEWORK_DISPLAY.match(value)
+    if not match:
+        return value
+    version = match.group("version")
+    if match.group("fw"):
+        return "net" + version.replace(".", "")
+    return "net" + ".".join(version.split(".")[:2])
+
 # The CryptoHives-authored variant names were renamed at various points in history (bare
 # "Managed"/"AVX2"/"AES-NI" etc. -> "CryptoHives-"-prefixed, confirmed by diffing the current
 # registries — HashAlgorithmRegistry.cs, CipherAlgorithmRegistry.cs — against old markdown
@@ -224,6 +258,14 @@ def parse_markdown_table(content: str):
         if mean_ns is None:
             continue  # failed/NA row
 
+        # Present only when the report covers more than one runtime; a single-runtime run leaves
+        # this None and the caller substitutes the framework the run directory names.
+        framework = None
+        for column in FRAMEWORK_COLUMNS:
+            if fields.get(column, "").strip():
+                framework = normalize_framework(fields[column])
+                break
+
         # The joined-cell era packs "Method · Category · Name" (or "Method · Name" for
         # Cipher) into a single raw cell using "·" as the separator; the pre-fix era instead
         # split on literal "|", arriving as separate raw cells already. Splitting every raw
@@ -255,6 +297,7 @@ def parse_markdown_table(content: str):
             "method": method,
             "family": family,
             "variant": variant,
+            "framework": framework,
             "data_size_label": size_label,
             "data_size_bytes": parse_data_size_bytes(size_label),
             "mean_ns": mean_ns,
@@ -498,6 +541,7 @@ def parse_machine_spec(text: str) -> dict:
         "bdn_version": None, "os": None, "cpu": None,
         "logical_cores": None, "physical_cores": None,
         "sdk_version": None, "runtime_version": None, "jit": None,
+        "framework": None,
     }
 
     match = _BDN_LINE.search(text)
@@ -520,6 +564,16 @@ def parse_machine_spec(text: str) -> dict:
     if match:
         spec["runtime_version"] = match.group("runtime")
         spec["jit"] = match.group("jit")
+
+    # "Job=.NET 10.0  Runtime=.NET 10.0  Toolchain=net10.0" - present only while the job is
+    # constant across the report, which is exactly when the table carries no Runtime column.
+    match = re.search(r"Toolchain=(\S+)", text)
+    if match:
+        spec["framework"] = match.group(1)
+    else:
+        match = re.search(r"Runtime=(\.NET(?: Framework)? \d+(?:\.\d+){1,2})", text)
+        if match:
+            spec["framework"] = normalize_framework(match.group(1))
 
     return spec
 

--- a/scripts/cryptography-benchmark-trends/import_run_archive.py
+++ b/scripts/cryptography-benchmark-trends/import_run_archive.py
@@ -6,10 +6,15 @@ Builds the Cryptography trends database from the benchmark run archive.
 
 The archive is a directory tree, one directory per run and one per platform inside it:
 
-    cryptography/<code-commit>/<platform>/run.json
-    cryptography/<code-commit>/<platform>/machine-spec.md
-    cryptography/<code-commit>/<platform>/aes-cbc-128.md
+    cryptography/<code-commit>/<platform>/<framework>/run.json
+    cryptography/<code-commit>/<platform>/<framework>/machine-spec.md
+    cryptography/<code-commit>/<platform>/<framework>/aes-cbc-128.md
     ...
+
+The framework level exists because the same commit on the same machine under two target
+frameworks is two different measurements that would otherwise share a directory and overwrite
+each other file by file. It is also the fallback source of the `framework` column: a report
+covering a single runtime carries no Runtime column, so the path is what names it.
 
 It lives on the `benchmarks` branch, kept out of main so that recording a run does not add to the
 working tree everyone clones. Point --archive at a worktree of that branch, or at any directory
@@ -51,7 +56,7 @@ NON_SCENARIO_FILES = {"machine-spec.md", "run.json", "README.md", "benchmarks.md
 
 
 def discover_runs(archive_root):
-    """Yields (run_id, platform, run_dir, metadata) for every run-platform, oldest first.
+    """Yields (run_id, platform, framework, run_dir, metadata) for every run, oldest first.
 
     Ordered by the run date declared in run.json rather than by directory name: the directory is
     named for the commit measured, which says nothing about when it was measured.
@@ -66,20 +71,25 @@ def discover_runs(archive_root):
         if not os.path.isdir(run_root):
             continue
         for platform in sorted(os.listdir(run_root)):
-            run_dir = os.path.join(run_root, platform)
-            if not os.path.isdir(run_dir):
+            platform_root = os.path.join(run_root, platform)
+            if not os.path.isdir(platform_root):
                 continue
-            metadata_path = os.path.join(run_dir, "run.json")
-            if not os.path.isfile(metadata_path):
-                print(f"  [skip] {run_id}/{platform}: no run.json", file=sys.stderr)
-                continue
-            with open(metadata_path, encoding="utf-8") as handle:
-                metadata = json.load(handle)
-            found.append((metadata.get("recordedAt", ""), run_id, platform, run_dir, metadata))
+            for framework in sorted(os.listdir(platform_root)):
+                run_dir = os.path.join(platform_root, framework)
+                if not os.path.isdir(run_dir):
+                    continue
+                metadata_path = os.path.join(run_dir, "run.json")
+                if not os.path.isfile(metadata_path):
+                    print(f"  [skip] {run_id}/{platform}/{framework}: no run.json", file=sys.stderr)
+                    continue
+                with open(metadata_path, encoding="utf-8") as handle:
+                    metadata = json.load(handle)
+                found.append((metadata.get("recordedAt", ""), run_id, platform, framework,
+                              run_dir, metadata))
 
     found.sort(key=lambda entry: entry[0])
-    for _date, run_id, platform, run_dir, metadata in found:
-        yield run_id, platform, run_dir, metadata
+    for _date, run_id, platform, framework, run_dir, metadata in found:
+        yield run_id, platform, framework, run_dir, metadata
 
 
 def read_environment(run_dir):
@@ -120,10 +130,11 @@ def main():
     # failed import leaves the previous database intact instead of an empty one.
     conn.execute("DELETE FROM benchmark_results")
     conn.execute("DELETE FROM benchmark_runs")
+    conn.execute("DELETE FROM benchmark_run_packages")
 
     total_rows = 0
     total_runs = 0
-    for run_id, platform, run_dir, metadata in discover_runs(args.archive):
+    for run_id, platform, framework, run_dir, metadata in discover_runs(args.archive):
         run_date = metadata.get("recordedAt", "")
         commit_sha = metadata.get("codeCommit")
         branch = metadata.get("branch")
@@ -145,14 +156,17 @@ def main():
                     continue
                 conn.execute(
                     "INSERT OR REPLACE INTO benchmark_results "
-                    "(run_id, run_date, commit_sha, branch, platform, category, class_name, "
-                    " method, family, variant, data_size_label, data_size_bytes, mean_ns, "
-                    " stddev_ns, allocated_bytes) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (run_id, run_date, commit_sha, branch, platform, category, class_name,
-                     row["method"], row["family"], row["variant"], row["data_size_label"],
-                     row["data_size_bytes"], row["mean_ns"], row["stddev_ns"],
-                     row["allocated_bytes"]))
+                    "(run_id, run_date, commit_sha, branch, platform, framework, category, "
+                    " class_name, method, family, variant, data_size_label, data_size_bytes, "
+                    " mean_ns, stddev_ns, allocated_bytes) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (run_id, run_date, commit_sha, branch, platform,
+                     # A report covering several runtimes names each row's own; one covering a
+                     # single runtime has no such column, so the directory is the authority.
+                     row["framework"] or framework,
+                     category, class_name, row["method"], row["family"], row["variant"],
+                     row["data_size_label"], row["data_size_bytes"], row["mean_ns"],
+                     row["stddev_ns"], row["allocated_bytes"]))
 
         # Recorded per (run, platform) so a step in a trend line can be checked against a runtime
         # or SDK change before being read as a code regression - the recorded runs span .NET 10.0.2
@@ -161,18 +175,33 @@ def main():
         if environment and not args.dry_run:
             conn.execute(
                 "INSERT OR REPLACE INTO benchmark_runs "
-                "(run_id, platform, run_date, commit_sha, branch, bdn_version, os, cpu, "
-                " logical_cores, physical_cores, sdk_version, runtime_version, jit) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (run_id, platform, run_date, commit_sha, branch, environment["bdn_version"],
-                 environment["os"], environment["cpu"], environment["logical_cores"],
-                 environment["physical_cores"], environment["sdk_version"],
-                 environment["runtime_version"], environment["jit"]))
+                "(run_id, platform, framework, run_date, commit_sha, branch, bdn_version, os, "
+                " cpu, logical_cores, physical_cores, sdk_version, runtime_version, jit) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (run_id, platform, framework, run_date, commit_sha, branch,
+                 environment["bdn_version"], environment["os"], environment["cpu"],
+                 environment["logical_cores"], environment["physical_cores"],
+                 environment["sdk_version"], environment["runtime_version"], environment["jit"]))
         elif not environment:
-            print(f"  [warn] {run_id}/{platform}: no machine-spec.md; environment not recorded",
-                  file=sys.stderr)
+            print(f"  [warn] {run_id}/{platform}/{framework}: no machine-spec.md; environment "
+                  f"not recorded", file=sys.stderr)
 
-        print(f"  [{'dry-run' if args.dry_run else 'ok'}] {run_id}/{platform}: {run_rows} row(s)")
+        # The versions of the libraries this run measured against, so a step in a competitor's
+        # trend line can be attributed to that competitor shipping a release rather than to a
+        # change in ours. Absent for runs recorded before update-benchmark-docs.ps1 captured it
+        # and never backfilled - the dashboard shows nothing rather than guessing.
+        packages = metadata.get("packages") or {}
+        packages_source = metadata.get("packagesSource")
+        if packages and not args.dry_run:
+            conn.executemany(
+                "INSERT OR REPLACE INTO benchmark_run_packages "
+                "(run_id, platform, framework, package_id, version, source) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                [(run_id, platform, framework, package_id, str(version), packages_source)
+                 for package_id, version in sorted(packages.items())])
+
+        print(f"  [{'dry-run' if args.dry_run else 'ok'}] {run_id}/{platform}/{framework}: "
+              f"{run_rows} row(s)")
         total_rows += run_rows
         total_runs += 1
 
@@ -181,7 +210,7 @@ def main():
     conn.close()
 
     verb = "Would insert" if args.dry_run else "Inserted/updated"
-    print(f"{verb} {total_rows} row(s) from {total_runs} run-platform(s) in {args.archive}")
+    print(f"{verb} {total_rows} row(s) from {total_runs} run(s) in {args.archive}")
     return 0
 
 

--- a/scripts/cryptography-benchmark-trends/schema.sql
+++ b/scripts/cryptography-benchmark-trends/schema.sql
@@ -20,12 +20,18 @@ CREATE TABLE IF NOT EXISTS benchmark_results (
     method          TEXT    NOT NULL,  -- e.g. 'TryComputeHash', 'ComputeMac'
     family          TEXT    NOT NULL,  -- e.g. 'BLAKE3', 'HMAC-SHA256'
     variant         TEXT    NOT NULL,  -- e.g. 'CryptoHives-AVX512F', 'BouncyCastle', 'OS'
+    -- The target framework the row executed on, e.g. 'net10.0', 'net8.0', 'net462'. Part of the
+    -- primary key: the same commit measured on the same machine under two frameworks is two
+    -- distinct results, and without this the second silently overwrites the first. NOT NULL and
+    -- without a DEFAULT - the importer always knows it, since the archive path names it, so a
+    -- missing value means something upstream broke and should fail loudly.
+    framework   TEXT    NOT NULL,
     data_size_label TEXT,              -- e.g. '128KB' (NULL for benchmarks with no size axis)
     data_size_bytes INTEGER,           -- 131072 (for numeric sort/filter; NULL alongside label)
     mean_ns         REAL    NOT NULL,
     stddev_ns       REAL,
     allocated_bytes REAL,
-    PRIMARY KEY (run_id, platform, class_name, method, family, variant, data_size_label)
+    PRIMARY KEY (run_id, platform, framework, class_name, method, family, variant, data_size_label)
 );
 
 -- Powers "all variants of one family/size over time" and "one variant across sizes" queries.
@@ -60,7 +66,39 @@ CREATE TABLE IF NOT EXISTS benchmark_runs (
     sdk_version     TEXT,           -- e.g. '10.0.102'
     runtime_version TEXT,           -- host runtime, e.g. '10.0.2'
     jit             TEXT,           -- e.g. 'X64 RyuJIT x86-64-v3'
-    PRIMARY KEY (run_id, platform)
+    framework       TEXT NOT NULL,  -- target framework, e.g. 'net10.0' - see benchmark_results
+    PRIMARY KEY (run_id, platform, framework)
 );
 
 CREATE INDEX IF NOT EXISTS idx_runs_runtime ON benchmark_runs(runtime_version);
+CREATE INDEX IF NOT EXISTS idx_runs_framework ON benchmark_runs(framework);
+
+-- One row per (run, platform, package): the versions of the libraries the run measured against.
+--
+-- benchmark_runs answers "what machine and runtime", this answers "what did we compare to". A
+-- competitor's line steps when that competitor ships a new version just as readily as when our
+-- code changes, and until this table existed the two were indistinguishable in a trend chart -
+-- BouncyCastle went 2.6.2 -> 2.7.0 in #210 with nothing in the recorded data to show for it.
+--
+-- Its own table rather than columns on benchmark_runs because the set of packages is neither
+-- fixed nor small, and it changes as competitors are added and dropped.
+--
+-- Populated from the `packages` block of each run's run.json. `source` records where that block
+-- came from: 'project.assets.json' is the resolved restore graph, recorded at run time and
+-- authoritative; 'Directory.Packages.props' is the declared central pin, recovered from git for
+-- runs made before the resolved graph was captured. Central pinning makes the two agree in
+-- practice, but declared is a minimum and resolved is a fact, so they are not interchangeable.
+CREATE TABLE IF NOT EXISTS benchmark_run_packages (
+    run_id      TEXT NOT NULL,
+    platform    TEXT NOT NULL,  -- matches benchmark_runs.platform
+    package_id  TEXT NOT NULL,  -- NuGet id, e.g. 'BouncyCastle.Cryptography'
+    version     TEXT NOT NULL,  -- e.g. '2.7.0'
+    source      TEXT,           -- 'project.assets.json' or 'Directory.Packages.props'
+    -- Keyed by framework as well, because the resolved graph genuinely differs between them:
+    -- the Blake3 packages are referenced only for net8.0 and later, so a net48 run measures
+    -- against a smaller set than a net10.0 run of the same commit.
+    framework   TEXT NOT NULL,
+    PRIMARY KEY (run_id, platform, framework, package_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_packages_id ON benchmark_run_packages(package_id);

--- a/scripts/publish-ghpages.ps1
+++ b/scripts/publish-ghpages.ps1
@@ -1,0 +1,175 @@
+﻿# SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+# SPDX-License-Identifier: MIT
+
+# publish-ghpages.ps1
+# Builds the DocFX site locally and publishes it to the `gh-pages` branch.
+#
+# The normal path is .github/workflows/docfx.yml, which builds the site in CI and hands it to
+# GitHub Pages through actions/deploy-pages. This script exists for when that is unavailable -
+# an Actions budget that has run out, an outage, or simply wanting to see the real published
+# site before a change lands. It produces byte-for-byte the same site: the same trends databases
+# from the same archive, the same `docfx docfx/docfx.json`.
+#
+# Publishing from a branch instead of from a workflow requires the repository's Pages source to
+# be set to "Deploy from a branch" -> gh-pages / (root). While it is set to "GitHub Actions",
+# pushing here changes nothing, which makes a dry publish safe but a real one silent.
+#
+# Two details that only matter for branch-based publishing, both handled below:
+#
+#   - `.nojekyll` has to exist, or GitHub runs the site through Jekyll, which silently drops
+#     every path beginning with an underscore. The Actions deploy path bypasses Jekyll entirely,
+#     so this file is not in the build output and has to be added here.
+#   - Each publish replaces the branch with a single orphan commit rather than adding to it. The
+#     site carries ~13 MB of SQLite per publish, and SQLite rewrites pages throughout on every
+#     rebuild, so an accumulating history would add that much again every time - the same reason
+#     the trends databases are not committed to main. gh-pages is a derived artifact; its history
+#     is worth nothing and costs a lot.
+#
+# Usage:
+#   .\scripts\publish-ghpages.ps1                                  # build, then publish
+#   .\scripts\publish-ghpages.ps1 -BenchmarkArchive ../foundation-bench
+#   .\scripts\publish-ghpages.ps1 -NoBuild                         # publish docfx/_site as it is
+#   .\scripts\publish-ghpages.ps1 -DryRun                          # show what would be pushed
+
+[CmdletBinding()]
+param(
+    [Parameter(HelpMessage = "Path to a checkout of the benchmarks branch. A temporary worktree is used when omitted.")]
+    [string]$BenchmarkArchive,
+
+    [Parameter(HelpMessage = "Publish the existing docfx/_site without rebuilding it")]
+    [switch]$NoBuild,
+
+    [Parameter(HelpMessage = "Branch to publish to (default: gh-pages)")]
+    [string]$Branch = "gh-pages",
+
+    [Parameter(HelpMessage = "Git remote to push to (default: origin)")]
+    [string]$Remote = "origin",
+
+    [Parameter(HelpMessage = "Stage and commit locally, but do not push")]
+    [switch]$NoPush,
+
+    [Parameter(HelpMessage = "Dry run - report what would happen without building, committing or pushing")]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path $PSScriptRoot
+$SiteDir = Join-Path $RepoRoot "docfx/_site"
+$WorktreeDir = Join-Path ([System.IO.Path]::GetTempPath()) "cryptohives-ghpages"
+
+Write-Host ""
+Write-Host "========================================"
+Write-Host " Publishing DocFX site to $Branch"
+Write-Host "========================================"
+Write-Host ""
+
+# ---------------------------------------------------------------- build
+if (-not $NoBuild) {
+    $buildArgs = @("-NoProfile", "-File", (Join-Path $PSScriptRoot "run-docfx.ps1"), "-Clean")
+    if ($BenchmarkArchive) { $buildArgs += @("-BenchmarkArchive", $BenchmarkArchive) }
+    if ($DryRun) { $buildArgs += "-DryRun" }
+
+    Write-Host "Building the site..." -ForegroundColor Cyan
+    & pwsh @buildArgs
+    if ($LASTEXITCODE -ne 0) { throw "run-docfx.ps1 failed with exit code $LASTEXITCODE." }
+    Write-Host ""
+}
+
+if (-not (Test-Path $SiteDir)) {
+    throw "No site at $SiteDir. Drop -NoBuild, or build first with .\scripts\run-docfx.ps1."
+}
+
+$siteFileCount = (Get-ChildItem -Recurse -File -Force $SiteDir).Count
+Write-Host "Site: $SiteDir ($siteFileCount file(s))"
+
+# A site with no trends database still publishes, and looks fine until someone opens a dashboard
+# and finds an empty chart - so say so here rather than letting it ship quietly.
+foreach ($db in @("packages/threading/benchmark-trends/benchmark-history.sqlite",
+                  "packages/security/cryptography/benchmark-trends/benchmark-history.sqlite")) {
+    $path = Join-Path $SiteDir $db
+    if (Test-Path $path) {
+        $sizeMb = [math]::Round((Get-Item $path).Length / 1MB, 1)
+        Write-Host "  [OK] $db ($sizeMb MB)" -ForegroundColor Green
+    } else {
+        Write-Host "  [WARN] $db is missing - its dashboard will load empty." -ForegroundColor Yellow
+    }
+}
+Write-Host ""
+
+# ---------------------------------------------------------------- worktree
+# A worktree rather than a second clone: it shares the object store, so publishing does not copy
+# the whole repository, and it keeps the main working tree untouched while the branch is rewritten.
+if (Test-Path $WorktreeDir) {
+    Write-Host "Removing the previous publish worktree..."
+    if (-not $DryRun) {
+        git -C $RepoRoot worktree remove --force $WorktreeDir 2>$null | Out-Null
+        if (Test-Path $WorktreeDir) { Remove-Item -Recurse -Force $WorktreeDir }
+    }
+}
+
+Write-Host "Preparing $Branch in $WorktreeDir"
+if (-not $DryRun) {
+    # --detach, then an orphan commit: the branch ref is only moved at the very end, so a failure
+    # anywhere in between leaves the published site exactly as it was.
+    git -C $RepoRoot worktree add --detach $WorktreeDir HEAD | Out-Null
+    Get-ChildItem -Force $WorktreeDir | Where-Object { $_.Name -ne ".git" } | Remove-Item -Recurse -Force
+
+    Copy-Item -Path (Join-Path $SiteDir "*") -Destination $WorktreeDir -Recurse -Force
+
+    # Without this GitHub runs the site through Jekyll, which drops every underscore-prefixed path.
+    New-Item -ItemType File -Path (Join-Path $WorktreeDir ".nojekyll") -Force | Out-Null
+}
+
+# ---------------------------------------------------------------- commit
+$sourceCommit = (git -C $RepoRoot rev-parse HEAD).Trim()
+$sourceShort = $sourceCommit.Substring(0, 8)
+$message = "Publish docs built from $sourceShort`n`nBuilt locally with scripts/publish-ghpages.ps1."
+
+if ($DryRun) {
+    Write-Host ""
+    Write-Host "[DRY RUN] Would replace '$Branch' with one orphan commit of $siteFileCount file(s)" -ForegroundColor Yellow
+    Write-Host "[DRY RUN] Would force-push it to $Remote/$Branch" -ForegroundColor Yellow
+    Write-Host ""
+    return
+}
+
+Push-Location $WorktreeDir
+try {
+    git add -A --force | Out-Null
+
+    # An orphan commit, so the branch never accumulates the previous publish's blobs.
+    $tree = (git write-tree).Trim()
+    $commit = (git commit-tree $tree -m $message).Trim()
+    git branch -f $Branch $commit | Out-Null
+
+    Write-Host ""
+    Write-Host "  [OK] $Branch now points at $($commit.Substring(0, 8))" -ForegroundColor Green
+
+    if ($NoPush) {
+        Write-Host ""
+        Write-Host "  -NoPush given; nothing was pushed. To publish:" -ForegroundColor Yellow
+        Write-Host "      git push --force $Remote ${Branch}:$Branch"
+    } else {
+        Write-Host "  Pushing to $Remote/$Branch (force, by design - see the header comment)..."
+        # The site is ~13 MB, so this is not instant on a slow link.
+        git push --force $Remote "${Branch}:$Branch"
+        if ($LASTEXITCODE -ne 0) { throw "git push failed with exit code $LASTEXITCODE." }
+        Write-Host "  [OK] Pushed." -ForegroundColor Green
+    }
+} finally {
+    Pop-Location
+    git -C $RepoRoot worktree remove --force $WorktreeDir 2>$null | Out-Null
+}
+
+Write-Host ""
+Write-Host "========================================"
+Write-Host " Published docs built from $sourceShort"
+Write-Host "========================================"
+Write-Host ""
+Write-Host "The site only goes live if the repository's Pages source is set to"
+Write-Host "'Deploy from a branch' -> $Branch / (root). While it is set to 'GitHub Actions',"
+Write-Host "this push changes nothing that visitors see."
+Write-Host ""
+Write-Host "  https://cryptohives.github.io/Foundation/"
+Write-Host ""

--- a/scripts/threading-benchmark-trends/import_run_archive.py
+++ b/scripts/threading-benchmark-trends/import_run_archive.py
@@ -6,10 +6,15 @@ Builds the Threading trends database from the benchmark run archive.
 
 The archive is a directory tree, one directory per run and one per platform inside it:
 
-    threading/<code-commit>/<platform>/run.json
-    threading/<code-commit>/<platform>/machine-spec.md
-    threading/<code-commit>/<platform>/asynckeyedlock-multiple.md
+    threading/<code-commit>/<platform>/<framework>/run.json
+    threading/<code-commit>/<platform>/<framework>/machine-spec.md
+    threading/<code-commit>/<platform>/<framework>/asynckeyedlock-multiple.md
     ...
+
+The framework level exists because the same commit on the same machine under two target
+frameworks is two different measurements that would otherwise share a directory and overwrite
+each other file by file. It is also the fallback source of the `framework` column: a report
+covering a single runtime carries no Runtime column, so the path is what names it.
 
 It normally lives on the `benchmarks` branch, kept out of main so that recording a run does not
 add to the working tree everyone clones. Point --archive at a worktree of that branch, or at any
@@ -46,10 +51,11 @@ NON_SCENARIO_FILES = {"machine-spec.md", "run.json", "README.md", "threading.md"
 
 
 def discover_runs(archive_root):
-    """Yields (run_id, platform, run_dir) for every run-platform in the archive, oldest first.
+    """Yields (run_id, platform, framework, run_dir, metadata) for every run in the archive.
 
-    Ordering is by the run date declared in run.json rather than by directory name, since the
-    directory is named for the commit measured, which says nothing about when it was measured.
+    Oldest first, ordered by the run date declared in run.json rather than by directory name,
+    since the directory is named for the commit measured, which says nothing about when it was
+    measured.
     """
     package_root = os.path.join(archive_root, PACKAGE_DIR)
     if not os.path.isdir(package_root):
@@ -61,20 +67,25 @@ def discover_runs(archive_root):
         if not os.path.isdir(run_root):
             continue
         for platform in sorted(os.listdir(run_root)):
-            run_dir = os.path.join(run_root, platform)
-            if not os.path.isdir(run_dir):
+            platform_root = os.path.join(run_root, platform)
+            if not os.path.isdir(platform_root):
                 continue
-            metadata_path = os.path.join(run_dir, "run.json")
-            if not os.path.isfile(metadata_path):
-                print(f"  [skip] {run_id}/{platform}: no run.json", file=sys.stderr)
-                continue
-            with open(metadata_path, encoding="utf-8") as handle:
-                metadata = json.load(handle)
-            found.append((metadata.get("recordedAt", ""), run_id, platform, run_dir, metadata))
+            for framework in sorted(os.listdir(platform_root)):
+                run_dir = os.path.join(platform_root, framework)
+                if not os.path.isdir(run_dir):
+                    continue
+                metadata_path = os.path.join(run_dir, "run.json")
+                if not os.path.isfile(metadata_path):
+                    print(f"  [skip] {run_id}/{platform}/{framework}: no run.json", file=sys.stderr)
+                    continue
+                with open(metadata_path, encoding="utf-8") as handle:
+                    metadata = json.load(handle)
+                found.append((metadata.get("recordedAt", ""), run_id, platform, framework,
+                              run_dir, metadata))
 
     found.sort(key=lambda entry: entry[0])
-    for _date, run_id, platform, run_dir, metadata in found:
-        yield run_id, platform, run_dir, metadata
+    for _date, run_id, platform, framework, run_dir, metadata in found:
+        yield run_id, platform, framework, run_dir, metadata
 
 
 def read_environment(run_dir):
@@ -114,10 +125,11 @@ def main():
     # failed import leaves the previous database intact instead of an empty one.
     conn.execute("DELETE FROM benchmark_results")
     conn.execute("DELETE FROM benchmark_runs")
+    conn.execute("DELETE FROM benchmark_run_packages")
 
     total_rows = 0
     total_runs = 0
-    for run_id, platform, run_dir, metadata in discover_runs(args.archive):
+    for run_id, platform, framework, run_dir, metadata in discover_runs(args.archive):
         run_date = metadata.get("recordedAt", "")
         commit_sha = metadata.get("codeCommit")
         branch = metadata.get("branch")
@@ -130,8 +142,9 @@ def main():
             with open(os.path.join(run_dir, filename), encoding="utf-8") as handle:
                 content = handle.read()
 
-            for row in parse_markdown_table(content, source_label=f"{run_id}/{platform}/{filename}",
-                                            normalize_variant=normalize_variant):
+            for row in parse_markdown_table(
+                    content, source_label=f"{run_id}/{platform}/{framework}/{filename}",
+                    normalize_variant=normalize_variant):
                 method, family, variant = normalize_family_method_variant(
                     class_name, row["method"], row["family"], row["variant"])
                 run_rows += 1
@@ -139,29 +152,48 @@ def main():
                     continue
                 conn.execute(
                     "INSERT OR REPLACE INTO benchmark_results "
-                    "(run_id, run_date, commit_sha, branch, platform, class_name, method, family, "
-                    " variant, cancellation, param_label, param_value, mean_ns, stddev_ns, allocated_bytes) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (run_id, run_date, commit_sha, branch, platform, class_name, method, family,
-                     variant, row["cancellation"], row["param_label"], row["param_value"],
-                     row["mean_ns"], row["stddev_ns"], row["allocated_bytes"]))
+                    "(run_id, run_date, commit_sha, branch, platform, framework, class_name, "
+                    " method, family, variant, cancellation, param_label, param_value, mean_ns, "
+                    " stddev_ns, allocated_bytes) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (run_id, run_date, commit_sha, branch, platform,
+                     # A report covering several runtimes names each row's own; one covering a
+                     # single runtime has no such column, so the directory is the authority.
+                     row["framework"] or framework,
+                     class_name, method, family, variant, row["cancellation"], row["param_label"],
+                     row["param_value"], row["mean_ns"], row["stddev_ns"], row["allocated_bytes"]))
 
         environment = read_environment(run_dir)
         if environment and not args.dry_run:
             conn.execute(
                 "INSERT OR REPLACE INTO benchmark_runs "
-                "(run_id, platform, run_date, commit_sha, branch, bdn_version, os, cpu, "
-                " logical_cores, physical_cores, sdk_version, runtime_version, jit) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (run_id, platform, run_date, commit_sha, branch, environment["bdn_version"],
-                 environment["os"], environment["cpu"], environment["logical_cores"],
-                 environment["physical_cores"], environment["sdk_version"],
-                 environment["runtime_version"], environment["jit"]))
+                "(run_id, platform, framework, run_date, commit_sha, branch, bdn_version, os, "
+                " cpu, logical_cores, physical_cores, sdk_version, runtime_version, jit) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (run_id, platform, framework, run_date, commit_sha, branch,
+                 environment["bdn_version"], environment["os"], environment["cpu"],
+                 environment["logical_cores"], environment["physical_cores"],
+                 environment["sdk_version"], environment["runtime_version"], environment["jit"]))
         elif not environment:
-            print(f"  [warn] {run_id}/{platform}: no machine-spec.md; environment not recorded",
-                  file=sys.stderr)
+            print(f"  [warn] {run_id}/{platform}/{framework}: no machine-spec.md; environment "
+                  f"not recorded", file=sys.stderr)
 
-        print(f"  [{'dry-run' if args.dry_run else 'ok'}] {run_id}/{platform}: {run_rows} row(s)")
+        # The versions of the libraries this run measured against, so a step in a competitor's
+        # trend line can be attributed to that competitor shipping a release rather than to a
+        # change in ours. Absent for runs recorded before update-benchmark-docs.ps1 captured it
+        # and never backfilled - the dashboard shows nothing rather than guessing.
+        packages = metadata.get("packages") or {}
+        packages_source = metadata.get("packagesSource")
+        if packages and not args.dry_run:
+            conn.executemany(
+                "INSERT OR REPLACE INTO benchmark_run_packages "
+                "(run_id, platform, framework, package_id, version, source) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                [(run_id, platform, framework, package_id, str(version), packages_source)
+                 for package_id, version in sorted(packages.items())])
+
+        print(f"  [{'dry-run' if args.dry_run else 'ok'}] {run_id}/{platform}/{framework}: "
+              f"{run_rows} row(s)")
         total_rows += run_rows
         total_runs += 1
 
@@ -170,7 +202,7 @@ def main():
     conn.close()
 
     verb = "Would insert" if args.dry_run else "Inserted/updated"
-    print(f"{verb} {total_rows} row(s) from {total_runs} run-platform(s) in {args.archive}")
+    print(f"{verb} {total_rows} row(s) from {total_runs} run(s) in {args.archive}")
     return 0
 
 

--- a/scripts/threading-benchmark-trends/markdown_parser.py
+++ b/scripts/threading-benchmark-trends/markdown_parser.py
@@ -35,6 +35,47 @@ import sys
 MEASUREMENT_PATTERN = re.compile(r"^([\d,]+\.?\d*)\s*(ns|μs|us|ms)$")
 CANCELLATION_COLUMN = "cancellationType"
 
+# BenchmarkDotNet keeps job characteristics in the preamble only while they are constant across
+# the report; the moment one varies it becomes a table column instead. So a run over a single
+# runtime says "Toolchain=net10.0" above the table and has no such column, while
+# `--runtimes net8.0 net10.0` drops the preamble line and grows a "Runtime" column.
+#
+# Both have to be understood, because both are the framework the row executed on - and the
+# alternative is worse than missing it. Parameters here are identified by exclusion, so an
+# unrecognized "Runtime" column would be treated as a [Params] axis: it would land in param_label,
+# split every series in two, and offer itself as a contention axis for the scaling chart.
+#
+# Ordered most specific first. "Job" is the fallback because BenchmarkDotNet uses it as the
+# catch-all label when several characteristics vary at once, in which case its value is a job id
+# ("Job-ABCDEF") rather than a runtime and normalize_framework leaves it alone.
+FRAMEWORK_COLUMNS = ("Runtime", "Job")
+
+# BenchmarkDotNet's display names for runtimes -> the target framework moniker used everywhere
+# else in this pipeline (the archive path, run.json, -Framework). ".NET 10.0" and "net10.0" are
+# the same thing recorded twice in two spellings, and the database should only know one.
+_FRAMEWORK_DISPLAY = re.compile(r"^\.NET (?P<fw>Framework )?(?P<version>\d+(?:\.\d+){1,2})$")
+
+
+def normalize_framework(value: str | None) -> str | None:
+    """'.NET 10.0' -> 'net10.0', '.NET Framework 4.8' -> 'net48', 'net10.0' -> 'net10.0'.
+
+    Anything unrecognized is returned unchanged rather than dropped: a value this does not know
+    is still a truthful distinction between rows, and silently collapsing it would merge runs
+    that are not the same.
+    """
+    if not value:
+        return None
+    value = value.strip()
+    match = _FRAMEWORK_DISPLAY.match(value)
+    if not match:
+        return value
+    version = match.group("version")
+    # .NET Framework monikers drop the dots entirely (4.8 -> net48, 4.6.2 -> net462); .NET
+    # Core-era ones keep the single dot and never have a third component (10.0 -> net10.0).
+    if match.group("fw"):
+        return "net" + version.replace(".", "")
+    return "net" + ".".join(version.split(".")[:2])
+
 # Everything BenchmarkDotNet emits that measures rather than parameterizes. Parameters are
 # identified by exclusion rather than by a whitelist of known names: a whitelist silently drops
 # any [Params] axis nobody remembered to add to it, and because param_label is part of the
@@ -159,6 +200,14 @@ def parse_markdown_table(content: str, source_label: str = "<content>", normaliz
 
         cancellation = fields.get(CANCELLATION_COLUMN, "").strip() or "None"
 
+        # Present only when the report covers more than one runtime; a single-runtime run leaves
+        # this None and the caller substitutes the framework the run directory names.
+        framework = None
+        for column in FRAMEWORK_COLUMNS:
+            if fields.get(column, "").strip():
+                framework = normalize_framework(fields[column])
+                break
+
         # Every parameter column, in the order the report lists them, composed into one label.
         # A benchmark with two axes (e.g. KeyCount x Iterations) needs both here: param_label is
         # part of the primary key, so a label naming only one of them makes every value of the
@@ -166,7 +215,8 @@ def parse_markdown_table(content: str, source_label: str = "<content>", normaliz
         params = [
             (col, fields[col].strip())
             for col in header_cells[1:]
-            if col not in METRIC_COLUMNS and col != CANCELLATION_COLUMN and fields.get(col, "").strip()
+            if col not in METRIC_COLUMNS and col != CANCELLATION_COLUMN
+            and col not in FRAMEWORK_COLUMNS and fields.get(col, "").strip()
         ]
         param_label = ", ".join(f"{col}={value}" for col, value in params) or None
 
@@ -194,6 +244,7 @@ def parse_markdown_table(content: str, source_label: str = "<content>", normaliz
             "family": family,
             "variant": variant,
             "cancellation": cancellation,
+            "framework": framework,
             "param_label": param_label,
             "param_value": param_value,
             "mean_ns": mean_ns,
@@ -232,6 +283,7 @@ def parse_machine_spec(text: str) -> dict:
         "bdn_version": None, "os": None, "cpu": None,
         "logical_cores": None, "physical_cores": None,
         "sdk_version": None, "runtime_version": None, "jit": None,
+        "framework": None,
     }
 
     match = _BDN_LINE.search(text)
@@ -254,5 +306,17 @@ def parse_machine_spec(text: str) -> dict:
     if match:
         spec["runtime_version"] = match.group("runtime")
         spec["jit"] = match.group("jit")
+
+    # "Job=.NET 10.0  Runtime=.NET 10.0  Toolchain=net10.0" - present only while the job is
+    # constant across the report, which is exactly when the table carries no Runtime column.
+    # Toolchain is already a target framework moniker; Runtime is the display name and needs
+    # normalizing. Every run recorded so far carries both.
+    match = re.search(r"Toolchain=(\S+)", text)
+    if match:
+        spec["framework"] = match.group(1)
+    else:
+        match = re.search(r"Runtime=(\.NET(?: Framework)? \d+\.\d+)", text)
+        if match:
+            spec["framework"] = normalize_framework(match.group(1))
 
     return spec

--- a/scripts/threading-benchmark-trends/schema.sql
+++ b/scripts/threading-benchmark-trends/schema.sql
@@ -32,12 +32,22 @@ CREATE TABLE IF NOT EXISTS benchmark_results (
     family      TEXT    NOT NULL,  -- e.g. 'AsyncLock', 'AsyncBarrier' (the primitive/type compared)
     variant     TEXT    NOT NULL,  -- e.g. 'Pooled (ValueTask)', 'Nito', 'Lock.EnterScope'
     cancellation TEXT   NOT NULL DEFAULT 'None', -- 'None' or 'NotCancelled' (CancellationToken state)
+    -- The target framework the row executed on, e.g. 'net10.0', 'net8.0', 'net48'. Part of the
+    -- primary key: the same commit measured on the same machine under two frameworks is two
+    -- distinct results, and without this they would overwrite each other. NOT NULL rather than
+    -- nullable because SQLite treats NULLs in a key as distinct, so a nullable key column
+    -- silently appends a duplicate row on every rebuild instead of replacing - the bug that
+    -- inflated this database from 4,718 rows to 6,413 when param_label was left nullable.
+    -- No DEFAULT for the same reason: the importer always knows the framework (the archive path
+    -- names it), so a missing value means something upstream broke and should fail loudly rather
+    -- than be labelled with whatever was current when this file was written.
+    framework   TEXT    NOT NULL,
     param_label TEXT,              -- e.g. '10' (contention level; NULL for non-parameterized benchmarks)
     param_value INTEGER,           -- 10 (for numeric sort/filter; NULL alongside label)
     mean_ns     REAL    NOT NULL,
     stddev_ns   REAL,              -- usually NULL: ThreadingConfig hides the StdDev/Error columns
     allocated_bytes REAL,
-    PRIMARY KEY (run_id, platform, class_name, method, family, variant, cancellation, param_label)
+    PRIMARY KEY (run_id, platform, framework, class_name, method, family, variant, cancellation, param_label)
 );
 
 -- Powers "all variants of one family/contention-level over time" and "one variant across
@@ -70,7 +80,42 @@ CREATE TABLE IF NOT EXISTS benchmark_runs (
     sdk_version     TEXT,           -- e.g. '11.0.100-preview.5.26302.115'
     runtime_version TEXT,           -- host runtime, e.g. '10.0.10'
     jit             TEXT,           -- e.g. 'X64 RyuJIT x86-64-v4'
-    PRIMARY KEY (run_id, platform)
+    framework       TEXT NOT NULL,  -- target framework, e.g. 'net10.0' - see benchmark_results
+    PRIMARY KEY (run_id, platform, framework)
 );
 
 CREATE INDEX IF NOT EXISTS idx_runs_runtime ON benchmark_runs(runtime_version);
+CREATE INDEX IF NOT EXISTS idx_runs_framework ON benchmark_runs(framework);
+
+-- One row per (run, platform, package): the versions of the libraries the run measured against.
+--
+-- benchmark_runs answers "what machine and runtime", this answers "what did we compare to". A
+-- competitor's line steps when that competitor ships a new version just as readily as when our
+-- code changes, and until this table existed the two were indistinguishable in a trend chart -
+-- AsyncKeyedLock went 7.1.8 -> 8.0.0 -> 8.0.1 -> 8.0.2 across the recorded history, and
+-- Cryptography's BouncyCastle went 2.6.2 -> 2.7.0 in #210, with nothing in the recorded data to
+-- show for any of it.
+--
+-- Its own table rather than columns on benchmark_runs because the set of packages is neither
+-- fixed nor small, and it changes as competitors are added and dropped.
+--
+-- Populated from the `packages` block of each run's run.json. `source` records where that block
+-- came from: 'project.assets.json' is the resolved restore graph, recorded at run time and
+-- authoritative; 'Directory.Packages.props' is the declared central pin, recovered from git for
+-- runs made before the resolved graph was captured. Central pinning makes the two agree in
+-- practice, but declared is a minimum and resolved is a fact, so they are not interchangeable.
+CREATE TABLE IF NOT EXISTS benchmark_run_packages (
+    run_id      TEXT NOT NULL,
+    platform    TEXT NOT NULL,  -- matches benchmark_runs.platform
+    package_id  TEXT NOT NULL,  -- NuGet id, e.g. 'AsyncKeyedLock'
+    version     TEXT NOT NULL,  -- e.g. '8.0.2'
+    source      TEXT,           -- 'project.assets.json' or 'Directory.Packages.props'
+    -- Keyed by framework as well, because the resolved graph genuinely differs between them:
+    -- several competitors are referenced only for some target frameworks (Cryptography's Blake3
+    -- packages are net8.0+ only, Threading's KeyedSemaphores and ProtoPromise exclude net48), so
+    -- one run's package set is not the other's.
+    framework   TEXT NOT NULL,
+    PRIMARY KEY (run_id, platform, framework, package_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_packages_id ON benchmark_run_packages(package_id);

--- a/scripts/update-benchmark-docs.ps1
+++ b/scripts/update-benchmark-docs.ps1
@@ -23,6 +23,9 @@ param(
     [Parameter(HelpMessage = "Commit the benchmarked binaries were built from. Defaults to HEAD; pass it explicitly when recording a run after the fact, or when HEAD has moved on since the run.")]
     [string]$CodeCommit,
 
+    [Parameter(HelpMessage = "Target framework the benchmarks ran under. Must match run-benchmarks.ps1 -Framework, since the competitor package versions are read from that framework's resolved dependency graph.")]
+    [string]$TargetFramework = "net10.0",
+
     [Parameter(HelpMessage = "Dry run - show actions without executing")]
     [switch]$DryRun
 )
@@ -35,6 +38,9 @@ $RepoRoot = Split-Path $PSScriptRoot
 $packageConfigurations = @{
     "Threading" = [ordered]@{
         SourceDir = "tests/Threading/BenchmarkDotNet.Artifacts/results"
+        # NuGet's restore output for the benchmark project, read to record which version of each
+        # competitor library produced the numbers. See Get-BenchmarkPackageVersions.
+        AssetsFile = "tests/Threading/obj/project.assets.json"
         # Recorded runs live on the `benchmarks` branch, not in docfx: the published view is the
         # SQLite-backed dashboard, whose database is generated from that branch at build time. The
         # default is a sibling worktree, so pass -DestDir if yours is elsewhere:
@@ -75,6 +81,7 @@ $packageConfigurations = @{
 
     "Cryptography" = [ordered]@{
         SourceDir = "tests/Security/Cryptography/BenchmarkDotNet.Artifacts/results"
+        AssetsFile = "tests/Security/Cryptography/obj/project.assets.json"
         # Recorded runs live on the `benchmarks` branch, not in docfx - see the Threading entry
         # above for why. Default is a sibling worktree; pass -DestDir if yours is elsewhere.
         DestDir   = "../foundation-bench/cryptography"
@@ -418,6 +425,93 @@ function Get-PlatformIdFromMachineSpec {
     return "$osSlug-$archSlug-$cpuSlug"
 }
 
+# Reads the versions of the third-party libraries the benchmarks measured against.
+#
+# The machine spec already pins the hardware and the runtime, but a competitor's line can also
+# step because that competitor shipped a new version - BouncyCastle went 2.6.2 -> 2.7.0 in #210,
+# and nothing in a recorded run said so. Without this, such a step is indistinguishable from a
+# regression in our own code, which is the one thing the trend charts exist to detect.
+#
+# Read from NuGet's restore output rather than Directory.Packages.props, because that is the
+# resolved graph - what was actually loaded - and central pinning declares a *minimum*. The two
+# agree today; they stop agreeing the moment a version is unavailable or floats.
+#
+# Restricted to the benchmark project's own direct references: transitive closure would add
+# hundreds of framework packages that say nothing about a measurement. autoReferenced entries
+# (ILLink and friends) are SDK-injected rather than chosen, and CryptoHives.Foundation.* is our
+# own code, already identified by codeCommit.
+function Get-BenchmarkPackageVersions {
+    param(
+        [string]$AssetsPath,
+        [string]$Framework
+    )
+
+    if (-not (Test-Path $AssetsPath)) {
+        Write-Host "  [warn] $AssetsPath not found; package versions not recorded." -ForegroundColor Yellow
+        return $null
+    }
+
+    $assets = Get-Content -Raw -LiteralPath $AssetsPath | ConvertFrom-Json
+
+    $declared = $assets.project.frameworks.$Framework
+    $resolved = $assets.targets.$Framework
+    if (-not $declared -or -not $resolved) {
+        Write-Host "  [warn] $AssetsPath has no '$Framework' target; package versions not recorded." -ForegroundColor Yellow
+        return $null
+    }
+
+    # targets entries are keyed "PackageId/1.2.3"; split on the last slash so ids containing one
+    # (there are none today, but the format allows it) survive.
+    $resolvedVersions = @{}
+    foreach ($key in $resolved.PSObject.Properties.Name) {
+        $slash = $key.LastIndexOf('/')
+        if ($slash -gt 0) {
+            $resolvedVersions[$key.Substring(0, $slash)] = $key.Substring($slash + 1)
+        }
+    }
+
+    $versions = [ordered]@{}
+    foreach ($id in ($declared.dependencies.PSObject.Properties.Name | Sort-Object)) {
+        if ($declared.dependencies.$id.autoReferenced) { continue }
+        if ($id -like 'CryptoHives.Foundation.*') { continue }
+        if ($resolvedVersions.ContainsKey($id)) {
+            $versions[$id] = $resolvedVersions[$id]
+        }
+    }
+
+    if ($versions.Count -eq 0) { return $null }
+    return $versions
+}
+
+# The target framework the reports were produced under, taken from the machine-spec preamble.
+#
+# Preferred over the -TargetFramework parameter because it is what BenchmarkDotNet actually used
+# rather than what the caller believes was used, and the two can disagree - passing
+# -Framework net10.0 -Runtimes net8.0 builds for one and measures on the other. The parameter is
+# still the fallback: BenchmarkDotNet drops the "Job=... Toolchain=..." line from the preamble as
+# soon as a job characteristic varies across the report, which is exactly the multi-runtime case,
+# and there the run has no single framework to name the directory with.
+function Get-FrameworkFromMachineSpec {
+    param([string]$MachineSpec)
+
+    if ($MachineSpec -match 'Toolchain=(\S+)') {
+        return $Matches[1]
+    }
+
+    # No Toolchain line: fall back to the runtime display name, e.g. "Runtime=.NET Framework 4.8".
+    if ($MachineSpec -match 'Runtime=(\.NET(?: Framework)? \d+(?:\.\d+){1,2})') {
+        $version = $Matches[1]
+        if ($version -match '^\.NET Framework (.+)$') {
+            return "net" + ($Matches[1] -replace '\.', '')
+        }
+        if ($version -match '^\.NET (\d+)\.(\d+)') {
+            return "net$($Matches[1]).$($Matches[2])"
+        }
+    }
+
+    return $null
+}
+
 function Test-PlatformIdFormat {
     param([string]$Value)
 
@@ -453,14 +547,9 @@ $machineSpec = $null
 $machineSpecExtracted = $false
 $destinationRoot = $DestDir
 $resolvedDestDir = $null
+$resolvedFramework = $null
 
 Ensure-Directory -Path $destinationRoot -DryRunMode:$DryRun
-
-if (-not [string]::IsNullOrWhiteSpace($PlatformId)) {
-    Assert-PlatformId -Value $PlatformId -SourceLabel "-PlatformId"
-    $resolvedDestDir = Join-Path $destinationRoot $PlatformId
-    Ensure-Directory -Path $resolvedDestDir -DryRunMode:$DryRun
-}
 
 Write-Host "Destination root: $destinationRoot"
 if ($PlatformId) {
@@ -485,10 +574,26 @@ foreach ($mapping in $benchmarkMappings) {
             if (-not $PlatformId) {
                 $PlatformId = Get-PlatformIdFromMachineSpec -MachineSpec $machineSpec
                 Assert-PlatformId -Value $PlatformId -SourceLabel "machine specification"
-                $resolvedDestDir = Join-Path $destinationRoot $PlatformId
-                Ensure-Directory -Path $resolvedDestDir -DryRunMode:$DryRun
                 Write-Host "  [INFO] Derived platform identifier: $PlatformId" -ForegroundColor Cyan
+            } else {
+                Assert-PlatformId -Value $PlatformId -SourceLabel "-PlatformId"
             }
+
+            # The framework is its own level below the platform, so the same commit measured on
+            # the same machine under net8.0 and net10.0 is two runs rather than one overwriting
+            # the other - which is what happened before this level existed, silently and file by
+            # file, since every report name is the same for both.
+            $resolvedFramework = Get-FrameworkFromMachineSpec -MachineSpec $machineSpec
+            if (-not $resolvedFramework) {
+                $resolvedFramework = $TargetFramework
+                Write-Host "  [INFO] No single framework in the machine spec (a multi-runtime run?); using -TargetFramework $TargetFramework" -ForegroundColor Cyan
+            } elseif ($resolvedFramework -ne $TargetFramework) {
+                Write-Host "  [WARN] Reports were produced under '$resolvedFramework' but -TargetFramework is '$TargetFramework'. Recording as '$resolvedFramework'; pass the matching -TargetFramework so the package versions come from the right graph." -ForegroundColor Yellow
+            }
+
+            $resolvedDestDir = Join-Path (Join-Path $destinationRoot $PlatformId) $resolvedFramework
+            Ensure-Directory -Path $resolvedDestDir -DryRunMode:$DryRun
+            Write-Host "  [INFO] Recording under $PlatformId/$resolvedFramework" -ForegroundColor Cyan
         }
 
         if (-not $resolvedDestDir) {
@@ -555,12 +660,28 @@ if ($machineSpec -and $resolvedDestDir) {
         $CodeCommit = (git -C $RepoRoot rev-parse HEAD).Trim()
     }
 
+    $assetsFile = Join-Path $RepoRoot $selectedConfig.AssetsFile
+    $packageVersions = Get-BenchmarkPackageVersions -AssetsPath $assetsFile -Framework $TargetFramework
+
     $runJsonFile = Join-Path $resolvedDestDir "run.json"
     $runMetadata = [ordered]@{
         codeCommit = $CodeCommit
         recordedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
         package    = $Project.ToLowerInvariant()
         platform   = $PlatformId
+        framework  = $resolvedFramework
+    }
+
+    if ($packageVersions) {
+        # The graph the versions came from, which is -TargetFramework and not necessarily the
+        # framework the run executed on. Recorded separately from `framework` so the two are
+        # never silently conflated: a run built for net10.0 but measured on net8.0 resolved its
+        # packages against net10.0, and the record should say so.
+        $runMetadata.packagesFramework = $TargetFramework
+        # Provenance matters: runs recorded before this existed are backfilled from
+        # Directory.Packages.props, which declares rather than resolves. Say which one this is.
+        $runMetadata.packagesSource = "project.assets.json"
+        $runMetadata.packages = $packageVersions
     }
     $runJsonContent = ($runMetadata | ConvertTo-Json -Depth 3) + "`n"
 
@@ -578,6 +699,9 @@ Write-Host " Benchmark documentation updated!"
 Write-Host " Copied: $copied, Missing: $missing"
 if ($PlatformId) {
     Write-Host " Platform: $PlatformId"
+}
+if ($resolvedFramework) {
+    Write-Host " Framework: $resolvedFramework"
 }
 Write-Host "========================================"
 Write-Host ""


### PR DESCRIPTION
## Description

A recorded benchmark run said which commit and which machine produced its numbers, but not what it compared them against, nor under which target framework. Both gaps turn a third party shipping a release into something indistinguishable from a regression in this repository.

**Third-party library versions.** `update-benchmark-docs.ps1` now reads the benchmark project's resolved NuGet graph (`obj/project.assets.json`) and writes a `packages` block into `run.json` — resolved rather than declared, because central pinning states a minimum and the restore graph states a fact. `scripts/backfill-run-packages.py` recovers the same information for existing runs from the central pins at each run's own code commit, stamped `packagesSource="Directory.Packages.props"` so the weaker provenance stays visible.

That immediately surfaced drift nothing could previously show:

| Package | Moved | Between |
|---|---|---|
| `Microsoft.VisualStudio.Threading` | 17.14.15 → 18.7.23 | two adjacent Threading runs |
| `Blake3` | 2.2.0 → 2.2.1 → 3.0.2 | across the Cryptography history |
| `NaCl.Core` | 2.1.0 → 2.2.0 | April → July |

A major-version jump on a competitor between two adjacent runs is exactly the case that otherwise reads as our own regression. `BouncyCastle.Cryptography` is 2.6.2 in every run on record — #210 took it to 2.7.0, so the next Cryptography run is the first that will show it.

Both dashboards name the version in each point's tooltip, and Table mode's comparison lists the libraries that moved between the two runs and marks the affected `Δ Mean` cells with `‡`, because a delta is only evidence about our code when the other side held still.

**Target framework.** The run archive gains a framework level, `<package>/<commit>/<platform>/<framework>/`. Without it a second framework silently destroyed the first: the destination was derived from OS, architecture and CPU alone, and every report file has the same name under `net8.0` as under `net10.0`. `framework` is now part of the primary key of all three tables — including `benchmark_run_packages`, since the resolved graph genuinely differs per framework (the Blake3 packages are net8.0+, `KeyedSemaphores` and `ProtoPromise` exclude net48).

It is taken from the report's `Runtime` column when a run covers several runtimes, and from the run directory when it covers one. The first case also fixes a live bug: parameters are identified by exclusion, so the `Runtime` column BenchmarkDotNet adds as soon as a job characteristic varies would have been read as a `[Params]` axis — splitting every series and offering itself as a contention axis to the scaling chart.

Both dashboards gained a Framework selector under Platform, threaded through every query, the run pickers and the URL hash. It stays hidden while only one framework exists. Table mode can now compare `net8.0` against `net10.0` at the same commit on the same machine, exactly as it already compares two platforms.

**Also here:** the docfx workflow claimed to trigger on pushes to `benchmarks`. It never did and never could — for push events GitHub only runs workflows present in the pushed ref, and that orphan branch carries no `.github/` at all. Across the workflow's entire run history every trigger came from `main`. The dead branch and path entries are removed and the mechanism that does work is documented: `gh workflow run docfx.yml` after recording a run, which is what `workflow_dispatch` was always for. The same wrong claim is corrected in both `benchmarks.md` pages and the archive README. And `scripts/publish-ghpages.ps1` builds and publishes the site locally for when Actions are unavailable — it adds the `.nojekyll` the Actions path doesn't need, and replaces the branch with a single orphan commit each time rather than accumulating ~13 MB of SQLite per publish.

Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [x] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [x] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

Deliberately all unchecked: no compiled code is touched. This is entirely Python/PowerShell tooling, the two dashboard pages, docs and the workflow, so there is no public API to document, nothing for the AOT analyzers to see, and the build and test suites were not run as part of this change. What *was* verified is below, and CI will cover the rest.

## Notes for reviewers

**Merge order.** This needs the `benchmarks` branch at `23a665c`, already pushed. The two archive layouts are mutually incompatible by design — the old importer finds no `run.json` in the new tree, the new one finds no framework directories in the old — so there was a window where a docs build would have produced 0 rows. It never opened: that push could not trigger the workflow, for the reason described above. The first build to see both is the one this merge triggers, and it should be green. If it ever did produce 0 rows, the "verify the trends databases have data" guard fails the job and leaves the live site on its last good build rather than publishing empty dashboards.

**Verification.**

- Rebuilds reproduce **4,718** and **23,198** rows exactly, before and after, with zero empty `framework` values and no orphaned package rows.
- A synthetic second framework proves the collision is gone: 4,718 + 870 = **5,588** rows, two `benchmark_runs` entries for one commit + machine, and `AsyncKeyedLock` correctly kept apart at 8.0.2 (net10.0) and 8.0.1 (net8.0).
- The multi-runtime report path lifts `Runtime` into `framework` and leaves `param_label` clean (`Iterations=10`, not `Runtime=.NET 8.0, Iterations=10`).
- `normalize_framework` checked across `.NET 10.0`→`net10.0`, `.NET 11.0`→`net11.0`, `.NET Framework 4.6.2`→`net462`, `.NET Framework 4.8.1`→`net481`; unknown values pass through unchanged rather than being dropped.
- Every `VARIANT_PACKAGES` mapping resolves against real data — no typos in either direction; 1,929/4,718 Threading and 7,808/23,198 Cryptography rows now carry a version, the rest being ours or BCL types that move with the runtime `benchmark_runs` already records.
- Both dashboards pass `node --check`; the new tooltip and comparison logic passes assertions in Node covering unmapped variants and unknown runs.
- Every one of the 41 migrated runs took its framework from the `Toolchain=net10.0` line already present in its own `machine-spec.md`. Nothing is guessed.

**Backfilled versions are declared, not resolved.** Central pinning makes the two agree in practice, but they are not the same claim, so `benchmark_run_packages.source` records which it is and the dashboard says so under the table. Runs recorded from now on carry the resolved graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


