### PR TITLE
Fix Scaling by size, which returned nothing for every family

### DIFF
--- a/docfx/packages/security/cryptography/benchmark-trends/index.html
+++ b/docfx/packages/security/cryptography/benchmark-trends/index.html
@@ -656,11 +656,13 @@
     const metric = metricSel.value;
     const cutoff = dateRangeCutoffIso();
     const stmt = db.prepare(`
-      SELECT r.variant, r.data_size_bytes, r.data_size_label, r.run_date, r.commit_sha,
-             b.runtime_version, r.${metric} AS value
+      SELECT r.variant, r.data_size_bytes, r.data_size_label, r.run_date, r.run_id,
+             r.commit_sha, b.runtime_version, r.${metric} AS value
       FROM benchmark_results r
       LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
-      WHERE r.platform = ? AND r.category = ? AND r.family = ? AND r.method = ?
+                                AND b.framework = r.framework
+      WHERE r.platform = ? AND r.framework = ? AND r.category = ? AND r.family = ?
+        AND r.method = ?
         ${cutoff ? "AND r.run_date >= ?" : ""}
       ORDER BY r.variant, r.data_size_bytes, r.run_date
     `);


### PR DESCRIPTION
## Description

**Regression from #228, currently live.** Scaling by size returns nothing on the Cryptography dashboard — for every category, family and method, not only BLAKE3, which is simply where it was noticed.

#228 added `frameworkSel.value` to the scaling query's `bind()` but never added `AND r.framework = ?` to its `WHERE`. Four placeholders, five bound values, so every parameter shifts one position left:

| Column | Matched against |
|---|---|
| `platform` | `windows-x64-amd-ryzen-5-7600x` ✓ |
| `category` | `net10.0` ✗ |
| `family` | `Hash` ✗ |
| `method` | `BLAKE3` ✗ |

Nothing matches, so every series is empty. On the published page `AND r.framework = ?` appears exactly once — in the trend query — while the scaling query still carries the four-placeholder form.

Two smaller faults in the same statement, both introduced alongside it:

- `r.run_id` was never selected, yet `packageLabel(row.variant, row.run_id, …)` reads it. It was `undefined`, so the library version silently vanished from every scaling tooltip.
- The join to `benchmark_runs` omitted `AND b.framework = r.framework`, which would have multiplied rows once a second target framework is recorded.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [x] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

Unchecked deliberately: the change is six lines of SQL inside one dashboard page. No compiled code is touched, so the build and test suites were not run as part of it. The page passes `node --check`, and the query verification above is what actually covers this.

## Notes for reviewers

One statement in `docfx/packages/security/cryptography/benchmark-trends/index.html`. Worth merging ahead of the check suite if you would rather not leave the live dashboard broken — nothing here can affect the library or the packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

