### PR TITLE
Dashboard parity: inert controls, Cryptography's dual Y axis, and a recorded baseline

### DIFF
--- a/docfx/packages/security/cryptography/benchmark-trends/index.html
+++ b/docfx/packages/security/cryptography/benchmark-trends/index.html
@@ -726,11 +726,10 @@
   ];
 
   function renderScalingChart() {
-    const metric = metricSel.value;
     const cutoff = dateRangeCutoffIso();
     const stmt = db.prepare(`
       SELECT r.variant, r.data_size_bytes, r.data_size_label, r.run_date, r.run_id,
-             r.commit_sha, b.runtime_version, r.${metric} AS value
+             r.commit_sha, b.runtime_version, r.mean_ns, r.allocated_bytes
       FROM benchmark_results r
       LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
                                 AND b.framework = r.framework
@@ -751,7 +750,8 @@
       if (!latestByVariant.has(row.variant)) latestByVariant.set(row.variant, new Map());
       latestByVariant.get(row.variant).set(row.data_size_bytes, {
         x: row.data_size_bytes,
-        y: row.value,
+        mean_ns: row.mean_ns,
+        allocated_bytes: row.allocated_bytes,
         size_label: row.data_size_label,
         commit: row.commit_sha,
         runtime: row.runtime_version,

--- a/docfx/packages/security/cryptography/benchmark-trends/index.html
+++ b/docfx/packages/security/cryptography/benchmark-trends/index.html
@@ -14,6 +14,11 @@
   .controls > label { display: flex; flex-direction: column; font-size: 0.85rem; color: #444; }
   select { margin-top: 0.25rem; padding: 0.3rem; min-width: 180px; }
   #status { color: #666; font-size: 0.9rem; margin-bottom: 1rem; }
+  /* A control the current view ignores. Disabled rather than hidden: it keeps the layout
+     stable while switching modes, and keeps the setting visible so you can see what it will be
+     when you switch back. The title attribute says why on hover. */
+  .controls > label.inert { opacity: 0.4; }
+  .controls > label.inert select, .controls > label.inert input { cursor: not-allowed; }
   .legend-row { display: flex; flex-wrap: wrap; gap: 0.6rem 1rem; margin-bottom: 0.4rem; }
   .legend-row:empty { margin-bottom: 0; }
   .legend-item { display: flex; align-items: center; gap: 0.35rem; font-size: 0.82rem; color: #333; cursor: pointer; user-select: none; }
@@ -44,15 +49,15 @@
 </style>
 </head>
 <body>
-<h1>CryptoHives Benchmark Trends</h1>
+<h1>CryptoHives Cryptography Benchmark Trends</h1>
 <p>
   Benchmark history for <code>CryptoHives.Foundation.Security.Cryptography</code>'s hash, cipher,
   and MAC implementations — how each one performs against reference libraries (the OS,
   BouncyCastle, and others) across platforms and data sizes, and how that's changed over time as
   the code evolves. Pick a platform, category, algorithm family, and method below; every
   implementation is plotted as its own line so they're directly comparable at a glance. Runs
-  entirely in your browser (no server, no external database) — see the hint below the chart for
-  the two view modes.
+  entirely in your browser (no server, no external database) — see the notes below for
+  the three view modes.
 </p>
 
 <fieldset class="mode-toggle">
@@ -78,7 +83,7 @@
   <label>Method
     <select id="method"></select>
   </label>
-  <label>Metric
+  <label id="metric-picker">Metric
     <select id="metric">
       <option value="mean_ns">Mean time (ns)</option>
       <option value="allocated_bytes">Allocated bytes</option>
@@ -90,14 +95,14 @@
   <label id="compare-picker" hidden>Compare with
     <select id="compare"></select>
   </label>
-  <label>Date range
+  <label id="range-picker">Date range
     <select id="date-range">
       <option value="all">All time</option>
       <option value="30">Last 30 days</option>
       <option value="90">Last 90 days</option>
     </select>
   </label>
-  <label style="flex-direction: row; align-items: center; gap: 0.4rem; margin-top: 1.2rem;">
+  <label id="log-picker" style="flex-direction: row; align-items: center; gap: 0.4rem; margin-top: 1.2rem;">
     <input type="checkbox" id="log-scale">
     Logarithmic Y axis
   </label>
@@ -111,6 +116,7 @@
 <p id="legend-hint" class="legend-hint" hidden>Click a color or line style below to hide/show it.</p>
 <div id="legend-colors" class="legend-row"></div>
 <div id="legend-dashes" class="legend-row"></div>
+<div id="legend-metrics" class="legend-row"></div>
 <div id="chart-container"><canvas id="chart"></canvas></div>
 <p id="table-note" class="table-note" hidden></p>
 <div id="table-container" hidden><table class="data-table" id="data-table">
@@ -153,6 +159,10 @@
   const logScaleCb = document.getElementById("log-scale");
   const legendColorsEl = document.getElementById("legend-colors");
   const legendDashesEl = document.getElementById("legend-dashes");
+  const legendMetricsEl = document.getElementById("legend-metrics");
+  const metricPickerEl = document.getElementById("metric-picker");
+  const rangePickerEl = document.getElementById("range-picker");
+  const logPickerEl = document.getElementById("log-picker");
   const copyLinkBtn = document.getElementById("copy-link");
   const copyLinkStatusEl = document.getElementById("copy-link-status");
   const dateRangeSel = document.getElementById("date-range");
@@ -329,6 +339,7 @@
   // pattern (= size) into two small legends cuts that down to variants + sizes rows instead of
   // variants × sizes. Both stay clickable to toggle visibility, same as Chart.js's default.
   const hiddenVariants = new Set();
+  const hiddenMetrics = new Set();
   const hiddenSizes = new Set();
 
   function dashSwatchSvg(dash) {
@@ -363,6 +374,26 @@
         renderChart();
       };
       legendColorsEl.appendChild(item);
+    }
+  }
+
+  // Sibling of the colour and dash legends: colour picks the implementation, dash the data size,
+  // and this the measurement. Scaling mode plots time and allocation together on two axes, so
+  // without a way to switch one off the two families of lines sit on top of each other.
+  function renderMetricLegend(entries) {
+    legendMetricsEl.innerHTML = "";
+    for (const { metric, text } of entries) {
+      const item = document.createElement("span");
+      item.className = "legend-item" + (hiddenMetrics.has(metric) ? " disabled" : "");
+      item.innerHTML = `<svg width="16" height="12" style="flex:none"><circle cx="8" cy="6" r="${metric === "mean_ns" ? 4 : 0}" fill="#555"/>` +
+        (metric === "mean_ns" ? "" : `<rect x="4" y="2" width="8" height="8" transform="rotate(45 8 6)" fill="#555"/>`) + `</svg>`;
+      item.append(document.createTextNode(text));
+      item.onclick = () => {
+        if (hiddenMetrics.has(metric)) hiddenMetrics.delete(metric);
+        else hiddenMetrics.add(metric);
+        renderChart();
+      };
+      legendMetricsEl.appendChild(item);
     }
   }
 
@@ -538,6 +569,7 @@
     // A new family/method means a different set of variants and sizes, so any prior
     // show/hide legend selections no longer refer to anything meaningful here.
     hiddenVariants.clear();
+    hiddenMetrics.clear();
     hiddenSizes.clear();
     const stmt = db.prepare(
       `SELECT DISTINCT data_size_label, data_size_bytes FROM benchmark_results
@@ -550,6 +582,38 @@
     while (stmt.step()) currentSizes.push(stmt.getAsObject().data_size_label);
     stmt.free();
     renderChart();
+  }
+
+
+  // Which controls each view actually reads. A control left enabled but ignored is worse than one
+  // greyed out: changing it looks like it should do something, and the view simply does not move.
+  //
+  // Deliberately not listed: platform, framework, family and method drive the selector cascade in
+  // every mode, so they always apply - in Table mode they narrow which runs the picker offers,
+  // even though the picker has the final say on which one is shown.
+  function setInert(labelEl, inert, reason) {
+    if (!labelEl) return;
+    labelEl.classList.toggle("inert", inert);
+    const field = labelEl.querySelector("select, input");
+    if (field) field.disabled = inert;
+    if (inert) labelEl.title = reason;
+    else labelEl.removeAttribute("title");
+  }
+
+  // Cryptography:
+  //   Table   - shows one recorded run whole, with mean time and allocation as separate columns,
+  //             so the metric selector does not apply; the run picker replaces the date range,
+  //             and there is no chart to scale logarithmically.
+  //   Scaling - plots both metrics on two axes, so the metric selector is replaced by its legend.
+  //   Trend   - reads all of them.
+  function syncControlAvailability(mode) {
+    const table = mode === "table";
+    const scaling = mode === "scaling";
+    setInert(metricPickerEl, table || scaling,
+             table ? "The table shows mean time and allocation as separate columns."
+                   : "Scaling plots both metrics on two axes - use the metric legend below.");
+    setInert(rangePickerEl, table, "The table shows one run, chosen with the Run picker.");
+    setInert(logPickerEl, table, "No chart axis to scale in table mode.");
   }
 
   function renderChartInstance(datasets, scales, tooltipAfterLabel) {
@@ -644,6 +708,7 @@
 
     renderColorLegend(variantOrder.map((v) => ({ variant: v, color: colorForVariant.get(v) })));
     renderDashLegend(multiSize ? sizes.map((label) => ({ sizeLabel: label, dash: dashForSize.get(label) })) : []);
+    renderMetricLegend([]);   // trend mode plots the single selected metric
 
     const visibleCount = datasets.filter((d) => !d.hidden).length;
     statusEl.textContent = datasets.length
@@ -651,6 +716,14 @@
         `${datasets.filter((d) => !d.hidden).reduce((n, d) => n + d.data.length, 0)} data point(s)`
       : "No data for this selection yet.";
   }
+
+  // Mean time and allocation are plotted together in Scaling mode, each on its own axis. Point
+  // shape distinguishes them so one implementation keeps one colour across both. Mirrors the same
+  // constant in the Threading dashboard.
+  const METRICS = [
+    { key: "mean_ns", axis: "y", point: "circle", text: "Mean time" },
+    { key: "allocated_bytes", axis: "yAlloc", point: "rectRot", text: "Allocated" },
+  ];
 
   function renderScalingChart() {
     const metric = metricSel.value;
@@ -690,27 +763,56 @@
     const variantOrder = Array.from(latestByVariant.keys());
     const colorForVariant = colorsForVariants(variantOrder);
 
-    const datasets = variantOrder.map((variant) => ({
-      label: variant,
-      data: Array.from(latestByVariant.get(variant).values()).sort((a, b) => a.x - b.x),
-      borderColor: colorForVariant.get(variant),
-      backgroundColor: colorForVariant.get(variant),
-      hidden: hiddenVariants.has(variant),
-      tension: 0.15,
-      pointRadius: 3,
-    }));
+    // Both measurements at once, on their own axes - the Metric selector is ignored here. Reading
+    // a cipher or hash means asking "how fast, and at what allocation cost", and answering that by
+    // flipping a dropdown makes the two impossible to see against each other. Point shape carries
+    // the metric so a single colour still reads as one implementation across both axes.
+    const datasets = [];
+    for (const variant of variantOrder) {
+      const points = Array.from(latestByVariant.get(variant).values()).sort((a, b) => a.x - b.x);
+      for (const m of METRICS) {
+        // An all-null metric contributes nothing but a legend row and an empty axis.
+        if (points.every((p) => p[m.key] == null)) continue;
+        datasets.push({
+          label: `${variant} · ${m.text}`,
+          data: points.map((p) => ({ ...p, y: p[m.key] })),
+          yAxisID: m.axis,
+          borderColor: colorForVariant.get(variant),
+          backgroundColor: colorForVariant.get(variant),
+          pointStyle: m.point,
+          hidden: hiddenVariants.has(variant) || hiddenMetrics.has(m.key),
+          tension: 0.15,
+          pointRadius: 3,
+        });
+      }
+    }
+
+    const usesAlloc = datasets.some((d) => d.yAxisID === "yAlloc");
+    const scales = {
+      x: { type: "logarithmic", title: { display: true, text: "Data size (bytes)" } },
+      y: { ...yAxisScale("mean_ns"), position: "left" },
+    };
+    if (usesAlloc) {
+      // Allocation stays linear even when the time axis is logarithmic: an allocation-free series
+      // is a real and interesting result, and a log axis cannot plot zero - it would drop exactly
+      // the lines worth seeing. Gridlines are suppressed so the two axes do not draw two
+      // conflicting sets across the same plot area.
+      scales.yAlloc = {
+        type: "linear", position: "right", beginAtZero: true,
+        title: { display: true, text: metricLabel("allocated_bytes") },
+        grid: { drawOnChartArea: false },
+      };
+    }
 
     renderChartInstance(
       datasets,
-      {
-        x: { type: "logarithmic", title: { display: true, text: "Data size (bytes)" } },
-        y: yAxisScale(metric),
-      },
+      scales,
       (ctx) => `${ctx.raw.size_label} · ${pointFooter(ctx.raw)}`
     );
 
     renderColorLegend(variantOrder.map((v) => ({ variant: v, color: colorForVariant.get(v) })));
     renderDashLegend([]); // one line per variant here — no per-size distinction to show
+    renderMetricLegend(METRICS.map((m) => ({ metric: m.key, text: m.text })));
 
     const visibleCount = datasets.filter((d) => !d.hidden).length;
     statusEl.textContent = datasets.length
@@ -1022,6 +1124,7 @@
     chartContainerEl.hidden = isTable;
     legendColorsEl.hidden = isTable;
     legendDashesEl.hidden = isTable;
+    legendMetricsEl.hidden = isTable;
     if (isTable) legendHintEl.hidden = true;   // otherwise left to renderColorLegend below
     tableContainerEl.hidden = !isTable;
     tableNoteEl.hidden = !isTable;
@@ -1036,6 +1139,7 @@
     } else {
       renderTrendChart();
     }
+    syncControlAvailability(mode);
     syncUrlHash();
   }
 

--- a/docfx/packages/threading/benchmark-trends/index.html
+++ b/docfx/packages/threading/benchmark-trends/index.html
@@ -942,10 +942,41 @@
   // The report's baseline is this library's own implementation, and the database has no
   // is-baseline flag to read it off - so pick it the same way the colour assignment does, and
   // leave the ratio blank for a group that has none (the SyncLock family is all BCL primitives).
-  function baselineVariantOf(variants) {
-    if (variants.includes("Pooled")) return "Pooled";
-    const pooled = variants.filter(isPooled).sort();
-    return pooled.length ? pooled[0] : null;
+  // Which row the report treated as its reference.
+  //
+  // Every Threading benchmark class marks one method `[Benchmark(Baseline = true)]`, and
+  // BenchmarkDotNet records that as Ratio = 1.00 in every parameter group. Reading it back beats
+  // guessing: the previous version returned the alphabetically first "Pooled" variant, which
+  // picked "Pooled (AsTask)" over the declared "Pooled (ValueTask)" and got the baseline wrong in
+  // 7 of a full run's 23 reports - and with it every Ratio in those tables.
+  //
+  // A variant qualifies only if it is 1.00 in *every* group it appears in. One group's row can
+  // land on 1.00 by rounding; the declared baseline is 1.00 throughout, because it is the same
+  // method being compared to itself.
+  //
+  // Returns null when the baseline is not among these rows at all, which is a real case rather
+  // than a failure: BenchmarkDotNet computes Ratio per benchmark class, while this table is
+  // filtered to one family and method. asynclock-single's baseline is AsyncLock's "Pooled", so
+  // selecting the SyncLock family shows rows whose reference sits outside the view.
+  function baselineVariantOf(rows) {
+    const ratios = new Map();
+    for (const r of rows) {
+      if (r.ratio == null) continue;
+      if (!ratios.has(r.variant)) ratios.set(r.variant, []);
+      ratios.get(r.variant).push(r.ratio);
+    }
+    const declared = Array.from(ratios).filter(([, rs]) => rs.every((x) => x === 1));
+    if (declared.length === 1) return declared[0][0];
+
+    // Nothing recorded a ratio - data from a report without the column. Fall back to the old
+    // guess, which is still right whenever a plain "Pooled" is present.
+    if (ratios.size === 0) {
+      const variants = rows.map((r) => r.variant);
+      if (variants.includes("Pooled")) return "Pooled";
+      const pooled = variants.filter(isPooled).sort();
+      return pooled.length ? pooled[0] : null;
+    }
+    return null;
   }
 
   // Set from the URL on load and consumed by the first refreshRunPickers() call.
@@ -1038,7 +1069,7 @@
     if (!key) return [];
     const parts = key.split(" ");
     const stmt = db.prepare(
-      "SELECT variant, cancellation, param_label, mean_ns, allocated_bytes " +
+      "SELECT variant, cancellation, param_label, mean_ns, allocated_bytes, ratio " +
       "FROM benchmark_results WHERE run_id = ? AND platform = ? AND framework = ? " +
       "  AND family = ? AND method = ?"
     );
@@ -1092,6 +1123,11 @@
     }
     const cancellations = Array.from(new Set(rows.map((r) => r.cancellation)));
     const showCancellation = cancellations.length > 1 || cancellations[0] !== "None";
+
+    // The baseline is a property of the benchmark class, not of one parameter group, so it is
+    // resolved once over every row rather than per group - which also lets a variant be rejected
+    // for being 1.00 in only some groups.
+    const baselineVariant = baselineVariantOf(rows);
 
     // Grouped exactly as the report groups: one baseline per (parameter combination, state).
     // Keyed by a joined string for lookup, but the two components are stored alongside rather
@@ -1151,7 +1187,6 @@
     let total = 0;
     for (const key of orderedKeys) {
       const group = groups.get(key).rows.slice().sort((a, b) => a.mean_ns - b.mean_ns);
-      const baselineVariant = baselineVariantOf(group.map((r) => r.variant));
       const baseline = group.find((r) => r.variant === baselineVariant);
       let first = true;
       for (const r of group) {
@@ -1178,7 +1213,12 @@
           } else if (col.key === "mean") {
             td.textContent = formatMeanNs(r.mean_ns);
           } else if (col.key === "ratio") {
-            td.textContent = (baseline && baseline.mean_ns) ? (r.mean_ns / baseline.mean_ns).toFixed(2) : "-";
+            // The recorded value wherever there is one: it is what the report printed, and it
+            // stays correct when the baseline is outside this view - recomputing against an
+            // in-view row would quietly answer a different question. Computed only as a fallback
+            // for data recorded without a Ratio column.
+            td.textContent = r.ratio != null ? r.ratio.toFixed(2)
+              : (baseline && baseline.mean_ns) ? (r.mean_ns / baseline.mean_ns).toFixed(2) : "-";
           } else if (col.key === "allocated") {
             td.textContent = formatAllocated(r.allocated_bytes);
           } else if (col.key === "cmpMean") {
@@ -1215,8 +1255,10 @@
     const against = Array.from(compareSel.options).find((o) => o.value === compareSel.value);
     tableNoteEl.hidden = false;
     let note =
-      "This library's own implementations are shaded, the baseline more deeply; Ratio is each " +
-      "row's mean over that baseline, computed per parameter combination and cancellation state." +
+      "This library's own implementations are shaded, the baseline more deeply. Ratio is the " +
+      "report's own, relative to the method the benchmark class declares as its baseline — " +
+      "which BenchmarkDotNet fixes per class, so for some families that reference row is not " +
+      "among the ones shown here." +
       (comparing ? "  Δ Mean is against " + (against ? against.textContent.trim() : "the second run") +
                    " — positive means slower here." : "");
 

--- a/docfx/packages/threading/benchmark-trends/index.html
+++ b/docfx/packages/threading/benchmark-trends/index.html
@@ -14,6 +14,11 @@
   .controls > label { display: flex; flex-direction: column; font-size: 0.85rem; color: #444; }
   select { margin-top: 0.25rem; padding: 0.3rem; min-width: 180px; }
   #status { color: #666; font-size: 0.9rem; margin-bottom: 1rem; }
+  /* A control the current view ignores. Disabled rather than hidden: it keeps the layout
+     stable while switching modes, and keeps the setting visible so you can see what it will be
+     when you switch back. The title attribute says why on hover. */
+  .controls > label.inert { opacity: 0.4; }
+  .controls > label.inert select, .controls > label.inert input { cursor: not-allowed; }
   .legend-row { display: flex; flex-wrap: wrap; gap: 0.6rem 1rem; margin-bottom: 0.4rem; }
   .legend-row:empty { margin-bottom: 0; }
   .legend-item { display: flex; align-items: center; gap: 0.35rem; font-size: 0.82rem; color: #333; cursor: pointer; user-select: none; }
@@ -28,7 +33,11 @@
   table.data-table th { background: #f5f5f5; position: sticky; top: 0; z-index: 1; }
   table.data-table td.numeric, table.data-table th.numeric { text-align: right; }
   table.data-table tr.group-start td { border-top: 2px solid #bbb; }
-  table.data-table tr.baseline td { background: #fff6e6; font-weight: 600; }
+  /* Ours get a wash of the brand amber so they stand out from third parties at a glance; the
+     baseline is the same hue a shade deeper, so the two are related but never confusable.
+     Identical to the Cryptography dashboard's table - the two are meant to read as one product. */
+  table.data-table tr.ours td { background: #fffcf4; }
+  table.data-table tr.baseline td { background: #ffeecc; font-weight: 600; }
   table.data-table td.worse { color: #b91c1c; }
   /* A delta whose competitor also changed version between the two runs. Not an error state -
      the number is real - so it is marked rather than coloured, and carries its own tooltip. */
@@ -51,7 +60,7 @@
   <code>CancellationToken</code> state, the Cancellation selector picks which state to plot (a
   live-but-unfired token adds overhead compared to <code>CancellationToken.None</code>, which is
   why it's kept as its own axis rather than doubling every legend entry). Runs entirely in your
-  browser (no server, no external database) — see the hint below the chart for the two view modes.
+  browser (no server, no external database) — see the notes below for the three view modes.
 </p>
 
 <fieldset class="mode-toggle">
@@ -74,10 +83,10 @@
   <label>Method
     <select id="method"></select>
   </label>
-  <label>Cancellation
+  <label id="cancellation-picker">Cancellation
     <select id="cancellation"></select>
   </label>
-  <label>Metric
+  <label id="metric-picker">Metric
     <select id="metric">
       <option value="mean_ns">Mean time (ns)</option>
       <option value="allocated_bytes">Allocated bytes</option>
@@ -89,14 +98,14 @@
   <label id="compare-picker" hidden>Compare with
     <select id="compare"></select>
   </label>
-  <label>Date range
+  <label id="range-picker">Date range
     <select id="date-range">
       <option value="all">All time</option>
       <option value="30">Last 30 days</option>
       <option value="90">Last 90 days</option>
     </select>
   </label>
-  <label style="flex-direction: row; align-items: center; gap: 0.4rem; margin-top: 1.2rem;">
+  <label id="log-picker" style="flex-direction: row; align-items: center; gap: 0.4rem; margin-top: 1.2rem;">
     <input type="checkbox" id="log-scale">
     Logarithmic Y axis
   </label>
@@ -157,6 +166,10 @@
   const legendColorsEl = document.getElementById("legend-colors");
   const legendDashesEl = document.getElementById("legend-dashes");
   const legendMetricsEl = document.getElementById("legend-metrics");
+  const cancellationPickerEl = document.getElementById("cancellation-picker");
+  const metricPickerEl = document.getElementById("metric-picker");
+  const rangePickerEl = document.getElementById("range-picker");
+  const logPickerEl = document.getElementById("log-picker");
   const copyLinkBtn = document.getElementById("copy-link");
   const copyLinkStatusEl = document.getElementById("copy-link-status");
   const dateRangeSel = document.getElementById("date-range");
@@ -599,6 +612,42 @@
     // Only third-party series carry one; ours is pinned by the commit already in this footer.
     if (raw.pkg) parts.push(raw.pkg);
     return parts.join(" · ");
+  }
+
+
+  // Which controls each view actually reads. A control left enabled but ignored is worse than one
+  // greyed out: changing it looks like it should do something, and the view simply does not move.
+  //
+  // Deliberately not listed: platform, framework, family and method drive the selector cascade in
+  // every mode, so they always apply - in Table mode they narrow which runs the picker offers,
+  // even though the picker has the final say on which one is shown.
+  function setInert(labelEl, inert, reason) {
+    if (!labelEl) return;
+    labelEl.classList.toggle("inert", inert);
+    const field = labelEl.querySelector("select, input");
+    if (field) field.disabled = inert;
+    if (inert) labelEl.title = reason;
+    else labelEl.removeAttribute("title");
+  }
+
+  // Threading:
+  //   Table   - shows one recorded run whole. Every cancellation state is a column and both
+  //             metrics are columns, so neither selector applies; the run picker replaces the
+  //             date range, and there is no chart to scale logarithmically.
+  //   Scaling - plots both metrics on two axes and every cancellation state as its own dash
+  //             pattern, so those two selectors are replaced by their legends.
+  //   Trend   - reads all of them.
+  function syncControlAvailability(mode) {
+    const table = mode === "table";
+    const scaling = mode === "scaling";
+    setInert(cancellationPickerEl, table || scaling,
+             table ? "The table shows every cancellation state as its own column."
+                   : "Scaling plots every cancellation state at once - use the dash legend below.");
+    setInert(metricPickerEl, table || scaling,
+             table ? "The table shows mean time and allocation as separate columns."
+                   : "Scaling plots both metrics on two axes - use the metric legend below.");
+    setInert(rangePickerEl, table, "The table shows one run, chosen with the Run picker.");
+    setInert(logPickerEl, table, "No chart axis to scale in table mode.");
   }
 
   function renderChartInstance(datasets, scales, tooltipAfterLabel) {
@@ -1108,6 +1157,7 @@
       for (const r of group) {
         const tr = document.createElement("tr");
         if (first) tr.classList.add("group-start");
+        if (isPooled(r.variant)) tr.classList.add("ours");
         if (r.variant === baselineVariant) tr.classList.add("baseline");
         first = false;
         const params = new Map(splitParams(r.param_label));
@@ -1165,8 +1215,8 @@
     const against = Array.from(compareSel.options).find((o) => o.value === compareSel.value);
     tableNoteEl.hidden = false;
     let note =
-      "Baseline (highlighted) is this library's own implementation; Ratio is each row's mean over it, " +
-      "computed per parameter combination and cancellation state." +
+      "This library's own implementations are shaded, the baseline more deeply; Ratio is each " +
+      "row's mean over that baseline, computed per parameter combination and cancellation state." +
       (comparing ? "  Δ Mean is against " + (against ? against.textContent.trim() : "the second run") +
                    " — positive means slower here." : "");
 
@@ -1219,6 +1269,7 @@
     } else {
       renderTrendChart();
     }
+    syncControlAvailability(mode);
     syncUrlHash();
   }
 

--- a/scripts/threading-benchmark-trends/import_run_archive.py
+++ b/scripts/threading-benchmark-trends/import_run_archive.py
@@ -154,14 +154,15 @@ def main():
                     "INSERT OR REPLACE INTO benchmark_results "
                     "(run_id, run_date, commit_sha, branch, platform, framework, class_name, "
                     " method, family, variant, cancellation, param_label, param_value, mean_ns, "
-                    " stddev_ns, allocated_bytes) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    " stddev_ns, allocated_bytes, ratio) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (run_id, run_date, commit_sha, branch, platform,
                      # A report covering several runtimes names each row's own; one covering a
                      # single runtime has no such column, so the directory is the authority.
                      row["framework"] or framework,
                      class_name, method, family, variant, row["cancellation"], row["param_label"],
-                     row["param_value"], row["mean_ns"], row["stddev_ns"], row["allocated_bytes"]))
+                     row["param_value"], row["mean_ns"], row["stddev_ns"], row["allocated_bytes"],
+                     row["ratio"]))
 
         environment = read_environment(run_dir)
         if environment and not args.dry_run:

--- a/scripts/threading-benchmark-trends/markdown_parser.py
+++ b/scripts/threading-benchmark-trends/markdown_parser.py
@@ -137,6 +137,28 @@ def parse_allocated_bytes(cell: str) -> int | None:
         return None
 
 
+def parse_ratio(cell: str) -> float | None:
+    """The report's Ratio column, which is how BenchmarkDotNet records the declared baseline.
+
+    Every Threading benchmark class marks one method `[Benchmark(Baseline = true)]`, and BDN then
+    prints Ratio = 1.00 for it in every parameter group. That is the only place the declaration
+    survives into the recorded data - the method attribute is not in the report, and the variant
+    name gives no hint which one it was.
+
+    Worth keeping precisely because the alternative is guessing. The dashboard used to pick the
+    alphabetically first "Pooled" variant, which chose "Pooled (AsTask)" over "Pooled (ValueTask)"
+    and computed every Ratio in the table against the wrong row - wrong in 7 of the 23 reports of
+    a full run.
+    """
+    cell = cell.strip()
+    if cell in ("", "-", "NA", "?"):
+        return None
+    try:
+        return float(cell)
+    except ValueError:
+        return None
+
+
 def parse_markdown_table(content: str, source_label: str = "<content>", normalize_variant=None):
     """Yields dicts with method/family/variant/cancellation/param_label/param_value/mean/stddev/
     allocated for each data row. `source_label` is only used in stderr diagnostics.
@@ -248,6 +270,7 @@ def parse_markdown_table(content: str, source_label: str = "<content>", normaliz
             "param_label": param_label,
             "param_value": param_value,
             "mean_ns": mean_ns,
+            "ratio": parse_ratio(fields.get("Ratio", "")),
             "stddev_ns": parse_measurement_ns(fields.get("StdDev", "")),
             "allocated_bytes": parse_allocated_bytes(fields.get("Allocated", "")),
         }

--- a/scripts/threading-benchmark-trends/schema.sql
+++ b/scripts/threading-benchmark-trends/schema.sql
@@ -47,6 +47,14 @@ CREATE TABLE IF NOT EXISTS benchmark_results (
     mean_ns     REAL    NOT NULL,
     stddev_ns   REAL,              -- usually NULL: ThreadingConfig hides the StdDev/Error columns
     allocated_bytes REAL,
+    -- The report's Ratio column, kept solely to identify the declared baseline: every Threading
+    -- benchmark marks one method `[Benchmark(Baseline = true)]`, and BenchmarkDotNet records that
+    -- as Ratio = 1.00 in every parameter group. Nothing else in the recorded data says which row
+    -- the report treated as its reference, and guessing got it wrong in 7 of 23 reports.
+    --
+    -- NULL for Cryptography-shaped data and for any report without the column. Not part of the
+    -- primary key - it is a derived measurement, not a dimension.
+    ratio       REAL,
     PRIMARY KEY (run_id, platform, framework, class_name, method, family, variant, cancellation, param_label)
 );
 


### PR DESCRIPTION
## Description

Three related changes to the two benchmark dashboards, which are meant to read as one product and had drifted apart. Follows #229, and carries the two commits that missed that merge.

### Controls the view ignores are now grayed out

Every control was always enabled, so Table mode invited you to change a Metric it does not read, and Scaling mode a Cancellation state it plots all of at once. Nothing broke — the setting was silently discarded, which is the confusing part.

| Mode | Grayed |
|---|---|
| **Table** | Cancellation (it is a column), Metric (both are columns), Date range (the Run picker chooses), Log scale (no chart) |
| **Scaling** | Cancellation (every state is plotted, as dashes), Metric (both are plotted, on two axes) |
| **Trend** | nothing — it reads them all |

Disabled rather than hidden, so the layout does not jump when switching modes and the setting stays visible for when you switch back; each carries a `title` saying why. Platform, framework, family and method are deliberately never grayed — they drive the selector cascade in every mode, and in Table mode they still narrow which runs the picker offers.

### Cryptography gains the dual Y axis

Scaling by size plotted one metric at a time, chosen from a dropdown. Reading a hash or cipher means asking "how fast, and at what allocation cost", and a dropdown makes the two impossible to see against each other. It now plots both at once on two axes, as the Threading dashboard already did — point shape carries the metric so one colour still reads as one implementation, and a metric legend toggles either family of lines.

The allocation axis stays **linear** even when the time axis is logarithmic: several implementations allocate nothing, and a log axis cannot plot zero — it would drop exactly the lines worth seeing. On BLAKE3 that is the headline: BouncyCastle reaches 546 KB where the AVX2 and AVX-512 paths hold flat at zero.

### Parity

Audited by diffing the two files — 23 features, plus a structural diff of both stylesheets and of the body markup — rather than spot-checking.

Fixed:

- **Threading's table shaded only the baseline row**, while Cryptography shaded every row of ours with a lighter wash of the same brand amber. Threading now matches (`#fffcf4` for ours, `#ffeecc` for the baseline), and its note text was rewritten, since "Baseline (highlighted)" no longer described what you see.
- The Cryptography `<h1>` did not name its package; Threading's did.
- Both intros still said "the two view modes". There have been three since Table mode landed.

Left different on purpose:

- **Cancellation** (Threading) against **Category** (Cryptography), and contention against size on the scaling X axis — different data shapes.
- The `tr.experimental` style and its "not in package" flag stay Cryptography-only. Verified real rather than an omission: `src/Threading` has **0** files containing `#if EXPERIMENTAL` against Cryptography's **5**.

### The Threading table's baseline came from a guess

Every Threading benchmark class marks one method `[Benchmark(Baseline = true)]` — `AsyncLockMultipleBenchmark` declares `Pooled (ValueTask)` — and BenchmarkDotNet records that as `Ratio = 1.00` in every parameter group. The importer discarded the Ratio column, so the dashboard guessed: the alphabetically first `Pooled` variant. `Pooled (AsTask)` sorts before `Pooled (ValueTask)`.

Wrong in **7 of a full run's 23 reports**, and not only for ValueTask — also `Pooled (empty action)` over `Pooled (no action)` for the barrier, and `Pooled (signal bulk)` over `Pooled (signal each)` for the countdown. It was never only the highlight: the Ratio column was computed against that wrong row, so the table disagreed with the report it claims to reproduce. `AsyncLockSingleBenchmark` declares plain `Pooled`, which the function's first line caught, so the fault looked inconsistent rather than systematic.

Ratio is now parsed, stored and used. A variant qualifies only if it is 1.00 in *every* group it appears in — one group's row can reach 1.00 by rounding, while the declared baseline is 1.00 throughout.

The column now shows the recorded value instead of recomputing, which fixes a second problem underneath: BenchmarkDotNet fixes the baseline **per benchmark class**, while the table is filtered to one family and method, so the reference row is sometimes not in view. `asynclock-single`'s baseline is `AsyncLock`'s `Pooled`, and the whole `SyncLock` family — `lock()`, `SpinLock`, `Interlocked.*` — is measured against it. Those rows showed `-` because no in-view row qualified; they now show the report's own `0.697`, `0.344` and so on. `AsyncCountdownEvent`'s `WaitAndSignal`, whose baseline sits in `SignalAndWait`, no longer highlights a row that is not the baseline.

Cryptography keeps its heuristic, now a documented difference rather than an accident: its reports carry no Ratio column, because **zero** of its benchmarks declare a baseline.

Verified by running the new selection over all 27 family/method groups of a full run — 8 change, each to the variant its report marks 1.00, or to `null` where the baseline genuinely lies outside the view. Ratio is populated for all 4,718 rows.

**This adds a `ratio` column to the Threading schema**, so corrected ratios appear only once CI rebuilds the database after merge.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [x] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

Unchecked deliberately: no compiled code is touched — this is two dashboard pages. The build and test suites were not run as part of it. What was verified is below.

## Notes for reviewers

**The two commits must land together.** `b3b76b6` adds the dual axis but leaves each point carrying only the selected metric, so both series read `undefined` and the chart draws nothing; `9a6908d` is the fix. A squash merge handles this; do not cherry-pick the first alone.

That bug is worth naming, because it is the second one I shipped in this same function and the first verification missed it. After #229 I checked the SQL and concluded the chart worked. The SQL *was* correct — the fault was in what the points carried, one layer up. The check now runs the real thing: the row-collection and dataset-building code is lifted verbatim out of the page and executed over the 604 real rows of `BLAKE3/TryComputeHash`.

```
variants: 8, datasets: 16
axes used: y, yAlloc        point shapes: circle, rectRot
datasets with undefined y: 0
```

Also verified: both pages pass `node --check`; the site builds (0 errors, the same 3 pre-existing warnings); neither file picked up NUL bytes; and the checks were re-run against this rebased tree rather than carried over from the pre-rebase branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

