### PR TITLE
Correct the documentation against what the libraries actually do

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -439,7 +439,11 @@ FodyWeavers.xsd
 # DocFX generated documentation
 !docfx/packages/*
 docfx/_site/
-docfx/api/
+# Everything under api/ is generated from the XML doc comments, except the hand-written landing
+# page. Ignoring the contents rather than the directory is what makes that exception possible -
+# git cannot re-include a file whose parent directory is excluded.
+docfx/api/*
+!docfx/api/index.md
 
 # macOS 
 .DS_Store   

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The **CryptoHives Open Source Initiative** is maintained by **The Keepers of the
 
 - 📖 **[Full Documentation](https://cryptohives.github.io/Foundation/)** — guides, API reference, examples
 - 🚀 [Getting Started Guide](https://cryptohives.github.io/Foundation/getting-started.html)
-- 📦 [Package Documentation](https://cryptohives.github.io/Foundation/packages/index.html)
-- 📚 [API Reference](https://cryptohives.github.io/Foundation/api/index.html)
+- 📦 [Package Documentation](https://cryptohives.github.io/Foundation/packages/index.html) — what each package gives you, with links to its guides
+- 📚 [API Reference](https://cryptohives.github.io/Foundation/api/index.html) — every public namespace, generated from the source
 - ⏱️ **Live benchmark dashboards** — [Cryptography](https://cryptohives.github.io/Foundation/packages/security/cryptography/benchmarks.html) · [Threading](https://cryptohives.github.io/Foundation/packages/threading/benchmarks.html)
 
 ---
@@ -59,6 +59,7 @@ Pooled buffer management for transformation pipelines and high-frequency I/O:
 Async-compatible synchronization primitives built on `ObjectPool` and `ValueTask<T>`, designed to keep `Task` / `TaskCompletionSource<T>` allocations off the hot path.
 
 - `AsyncLock` — mutual exclusion
+- `AsyncKeyedLock<TKey>` — per-key mutual exclusion
 - `AsyncSemaphore` — counting semaphore
 - `AsyncAutoResetEvent` / `AsyncManualResetEvent`
 - `AsyncReaderWriterLock`
@@ -117,13 +118,13 @@ Measured with BenchmarkDotNet across a range of payload sizes, comparing our man
 │     Memory         │   │      Threading        │   │  Security.Cryptography     │
 ├────────────────────┤   ├───────────────────────┤   ├────────────────────────────┤
 │ ArrayPool-         │   │ AsyncLock             │   │ Hash                       │
-│    MemoryStream    │   │ AsyncSemaphore        │   │  SHA-2 · SHA-3             │
-│ ArrayPool-         │   │ AsyncAutoResetEvent   │   │  SHAKE · cSHAKE            │
-│    BufferWriter<T> │   │ AsyncManualResetEvent │   │  TurboSHAKE · KT128/256    │
-│ ReadOnlySequence-  │   │ AsyncReaderWriterLock │   │  ParallelHash (SP 800-185) │
-│    MemoryStream    │   │ AsyncBarrier          │   │  KMAC128 · KMAC256         │
-│ ISegmentOwner<T>   │   │ AsyncCountdownEvent   │   │  Keccak · BLAKE2 · BLAKE3  │
-│  PooledSegment     │   │                       │   │  Ascon · Regional · Legacy │
+│    MemoryStream    │   │ AsyncKeyedLock<TKey>  │   │  SHA-2 · SHA-3             │
+│ ArrayPool-         │   │ AsyncSemaphore        │   │  SHAKE · cSHAKE            │
+│    BufferWriter<T> │   │ AsyncAutoResetEvent   │   │  TurboSHAKE · KT128/256    │
+│ ReadOnlySequence-  │   │ AsyncManualResetEvent │   │  ParallelHash (SP 800-185) │
+│    MemoryStream    │   │ AsyncReaderWriterLock │   │  KMAC128 · KMAC256         │
+│ ISegmentOwner<T>   │   │ AsyncBarrier          │   │  Keccak · BLAKE2 · BLAKE3  │
+│  PooledSegment     │   │ AsyncCountdownEvent   │   │  Ascon · Regional · Legacy │
 │  AllocatedSegment  │   │ IValueTaskSource<T>   │   │                            │
 │  EmptySegment      │   │    backed by          │   │ MAC                        │
 │                    │   │   ObjectPool<T>       │   │  HMAC · KMAC               │

--- a/docfx/api/index.md
+++ b/docfx/api/index.md
@@ -1,0 +1,39 @@
+# API Reference
+
+Generated reference documentation for every public type in the CryptoHives .NET Foundation
+packages. The namespaces below mirror the package layout — pick one to browse its types, or use the
+search box for a specific type or member.
+
+This page is hand-written and lives at `docfx/api/index.md`; everything else under `api/` is
+generated from the XML documentation comments in `src/` when the site is built.
+
+## CryptoHives.Foundation.Memory
+
+| Namespace | Contents |
+|-----------|----------|
+| [CryptoHives.Foundation.Memory.Buffers](xref:CryptoHives.Foundation.Memory.Buffers) | `ArrayPoolMemoryStream`, `ArrayPoolBufferWriter<T>`, `ReadOnlySequenceMemoryStream`, and the `ISegmentOwner<T>` strategies |
+| [CryptoHives.Foundation.Memory.Pools](xref:CryptoHives.Foundation.Memory.Pools) | `ObjectOwner<T>`, `ObjectPools`, `PoolFactory` |
+
+## CryptoHives.Foundation.Threading
+
+| Namespace | Contents |
+|-----------|----------|
+| [CryptoHives.Foundation.Threading.Async.Pooled](xref:CryptoHives.Foundation.Threading.Async.Pooled) | `AsyncLock`, `AsyncKeyedLock<TKey>`, `AsyncSemaphore`, `AsyncAutoResetEvent`, `AsyncManualResetEvent`, `AsyncCountdownEvent`, `AsyncBarrier`, `AsyncReaderWriterLock` |
+| [CryptoHives.Foundation.Threading.Pools](xref:CryptoHives.Foundation.Threading.Pools) | The `IValueTaskSource<T>` pooling infrastructure behind every primitive |
+| [CryptoHives.Foundation.Threading.Analyzers](xref:CryptoHives.Foundation.Threading.Analyzers) | The Roslyn analyzers shipped in the separate Analyzers package |
+
+## CryptoHives.Foundation.Security.Cryptography
+
+| Namespace | Contents |
+|-----------|----------|
+| [CryptoHives.Foundation.Security.Cryptography.Hash](xref:CryptoHives.Foundation.Security.Cryptography.Hash) | SHA-1/2/3, SHAKE and cSHAKE, TurboSHAKE and KT, BLAKE2/3, Ascon, ParallelHash, and the regional and legacy hashes |
+| [CryptoHives.Foundation.Security.Cryptography.Cipher](xref:CryptoHives.Foundation.Security.Cryptography.Cipher) | AES and the AEAD modes, ChaCha20 family, Ascon-AEAD128, and the regional block ciphers |
+| [CryptoHives.Foundation.Security.Cryptography.Mac](xref:CryptoHives.Foundation.Security.Cryptography.Mac) | HMAC, KMAC, AES-CMAC, AES-GMAC, Poly1305 |
+| [CryptoHives.Foundation.Security.Cryptography.Kdf](xref:CryptoHives.Foundation.Security.Cryptography.Kdf) | HKDF, KBKDF, Concat KDF, PBKDF2 |
+| [CryptoHives.Foundation.Security.Cryptography.Rng](xref:CryptoHives.Foundation.Security.Cryptography.Rng) | Random number generation over OS entropy |
+
+## See also
+
+- [Package documentation](../packages/index.md) — guides and examples per package
+- [Getting Started](../getting-started.md)
+- [Porting Guide](../porting-to-cryptohives.md)

--- a/docfx/getting-started.md
+++ b/docfx/getting-started.md
@@ -14,7 +14,7 @@ dotnet add package CryptoHives.Foundation.Memory
 
 ### [Threading Package](packages/threading/index.md)
 
-`ValueTask`-based async synchronization primitives with pooled waiter objects: `AsyncLock`, `AsyncAutoResetEvent`, `AsyncManualResetEvent`, `AsyncBarrier`, `AsyncReaderWriterLock`, `AsyncSemaphore`, and `AsyncCountdownEvent`.
+`ValueTask`-based async synchronization primitives with pooled waiter objects: `AsyncLock`, `AsyncKeyedLock<TKey>`, `AsyncAutoResetEvent`, `AsyncManualResetEvent`, `AsyncBarrier`, `AsyncReaderWriterLock`, `AsyncSemaphore`, and `AsyncCountdownEvent`. Every acquisition takes an optional `CancellationToken` and an optional timeout.
 
 ```bash
 dotnet add package CryptoHives.Foundation.Threading
@@ -35,6 +35,13 @@ Roslyn analyzers for `ValueTask` misuse. Install this alongside the Threading pa
 ```bash
 dotnet add package CryptoHives.Foundation.Threading.Analyzers
 ```
+
+## Benchmarks
+
+Every published measurement for the Threading and Cryptography packages is browsable in an
+interactive dashboard — one recorded run as a table, trends over time, and scaling curves, all
+running client-side in the browser: [Threading](packages/threading/benchmarks.md) ·
+[Cryptography](packages/security/cryptography/benchmarks.md).
 
 ## Porting existing code
 

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -41,7 +41,9 @@ Async synchronization primitives built for low allocation and high throughput.
 - An optional Roslyn analyzer package that catches common `ValueTask` misuse at compile time
 - Full `CancellationToken` support across every wait/lock primitive
 - `IValueTaskSource<T>`-based implementations backed by `ObjectPool<T>`, so waiter objects get recycled instead of allocated
+- Optional timeout on every acquisition, with a timer allocated only once a call actually has to wait
 - `AsyncLock` for async mutual exclusion, with scoped locking via the `IDisposable` pattern
+- `AsyncKeyedLock<TKey>` for per-key exclusion, where unrelated keys never block each other
 - `AsyncAutoResetEvent` and `AsyncManualResetEvent`, complementing the existing `Task`-based equivalents
 - `AsyncBarrier` as an async-aware replacement for the .NET barrier
 - Pooled `AsyncReaderWriterLock`, `AsyncSemaphore`, and `AsyncCountdownEvent`, all with async wait support
@@ -59,6 +61,7 @@ Specification-based implementations of hash algorithms, MACs, ciphers, and key d
 - SHAKE and cSHAKE extendable-output functions (XOF) for variable-length output
 - TurboSHAKE and KangarooTwelve (KT128/KT256), the high-performance XOFs
 - KMAC (Keccak Message Authentication Code) for authenticated hashing
+- ParallelHash (SP 800-185), with an incremental variant for streaming input
 - Ascon lightweight hashing and AEAD (NIST SP 800-232) for constrained environments
 - BLAKE2b, BLAKE2s, and BLAKE3, with keyed modes
 - Keccak-256/384/512 for Ethereum compatibility
@@ -72,6 +75,28 @@ Specification-based implementations of hash algorithms, MACs, ciphers, and key d
 - Cross-platform consistency with no dependency on OS crypto APIs
 
 [Explore the Security.Cryptography package →](packages/security/cryptography/index.md)
+
+## Benchmarks
+
+Both the Threading and the Cryptography package are measured with BenchmarkDotNet against the
+reference implementations people actually use — the OS-provided algorithms, BouncyCastle,
+Nito.AsyncEx, Microsoft.VisualStudio.Threading and others — and every recorded run is published.
+
+The results are browsable rather than pasted into a table: each page embeds an interactive
+dashboard that loads the run history as a small SQLite database in your browser, with no server
+involved. It offers three views — one run reproduced as a table, with a second run comparable
+against it; a trend over time per commit; and a scaling curve over data size or contention level.
+Every point names the commit, the .NET runtime and the reference library version it was measured
+against, so a step in a line can be attributed rather than guessed at.
+
+- [Threading benchmarks](packages/threading/benchmarks.md) — contended and uncontended acquisition
+  across the async primitives, per-waiter allocation included
+- [Cryptography benchmarks](packages/security/cryptography/benchmarks.md) — hash, cipher and MAC
+  throughput across data sizes, including the separate SIMD paths, plus per-instance memory
+  footprint tables
+
+Runs are archived per commit and per machine, so results measured on any contributor's hardware can
+appear side by side rather than only those from a fixed set of CI hosts.
 
 ## Platform Support
 

--- a/docfx/packages/index.md
+++ b/docfx/packages/index.md
@@ -1,0 +1,26 @@
+# Packages
+
+The CryptoHives .NET Foundation is a set of independent NuGet packages — take only the one you need.
+All of them target `net462`, `netstandard2.0`, `netstandard2.1`, `net8.0` and `net10.0`
+(the cryptography package adds `net472`), and none of them depend on each other.
+
+| Package | What it gives you | NuGet |
+|---------|-------------------|-------|
+| [Memory](memory/index.md) | Pooled buffers and streams on top of `ArrayPool<T>`: `ArrayPoolMemoryStream`, `ArrayPoolBufferWriter<T>`, `ReadOnlySequenceMemoryStream`, and RAII ownership helpers | [CryptoHives.Foundation.Memory](https://www.nuget.org/packages/CryptoHives.Foundation.Memory) |
+| [Threading](threading/index.md) | `ValueTask`-based async synchronization primitives with pooled waiters: `AsyncLock`, `AsyncKeyedLock<TKey>`, `AsyncSemaphore`, the events, the barrier, the countdown, and the reader-writer lock | [CryptoHives.Foundation.Threading](https://www.nuget.org/packages/CryptoHives.Foundation.Threading) |
+| [Threading.Analyzers](threading.analyzers/index.md) | Roslyn analyzers that catch `ValueTask` misuse at compile time. Ships separately — install it alongside the Threading package | [CryptoHives.Foundation.Threading.Analyzers](https://www.nuget.org/packages/CryptoHives.Foundation.Threading.Analyzers) |
+| [Security.Cryptography](security/cryptography/index.md) | Fully managed hash, MAC, KDF and cipher implementations written from the specifications, with no OS crypto dependency | [CryptoHives.Foundation.Security.Cryptography](https://www.nuget.org/packages/CryptoHives.Foundation.Security.Cryptography) |
+
+## Where to start
+
+- New here? The [Getting Started guide](../getting-started.md) installs each package and shows a first example.
+- Migrating existing code? The [Porting Guide](../porting-to-cryptohives.md) maps BCL types onto these ones step by step.
+- Looking for a specific type? The [API reference](../api/index.md) lists every public namespace.
+- Wondering how fast it is? The benchmark dashboards for
+  [Threading](threading/benchmarks.md) and [Cryptography](security/cryptography/benchmarks.md)
+  publish every recorded run, measured against the reference implementations.
+
+## See also
+
+- [Cryptographic specifications and test vectors](security/cryptography/specs/README.md)
+- [Source repository](https://github.com/CryptoHives/Foundation)

--- a/docfx/packages/security/cryptography/benchmark-trends/index.html
+++ b/docfx/packages/security/cryptography/benchmark-trends/index.html
@@ -12,6 +12,10 @@
   fieldset.mode-toggle label { font-size: 0.9rem; display: flex; align-items: center; gap: 0.3rem; }
   .controls { display: flex; gap: 1rem; flex-wrap: wrap; margin: 1rem 0 1.5rem; align-items: flex-start; }
   .controls > label { display: flex; flex-direction: column; font-size: 0.85rem; color: #444; }
+  /* The `hidden` attribute has to beat the rule above: the UA stylesheet's [hidden] { display: none }
+     loses to any author rule that sets display, so a picker hidden from JS stayed on screen — and in
+     the chart modes it read as a control that simply did nothing. */
+  .controls > label[hidden] { display: none; }
   select { margin-top: 0.25rem; padding: 0.3rem; min-width: 180px; }
   #status { color: #666; font-size: 0.9rem; margin-bottom: 1rem; }
   /* A control the current view ignores. Disabled rather than hidden: it keeps the layout
@@ -141,14 +145,13 @@
   </p>
 
   <p class="hint">
-  The chart modes plot one point per recorded run. Hovering a point gives the commit, the value,
-  the .NET runtime it was measured on, and the version of the reference library where one
-  applies. <strong>Trend over time</strong> plots every recorded data size for the current
-  filters; the line-style legend hides individual sizes. <strong>Scaling by size</strong> plots
-  data size on the X axis using each implementation's most recent run, drawing both metrics
-  together: mean time is read from the left axis and allocation from the right, with point shape
-  distinguishing the two. The Metric selector applies to <strong>Trend over time</strong>, and is
-  disabled in the other two views.</p>
+  Hovering a point gives the commit, the value, the .NET runtime it was measured on, and the
+  version of the reference library where one applies. <strong>Trend over time</strong> plots one
+  point per recorded run, for every recorded data size under the current filters; the line-style
+  legend hides individual sizes, and Metric and Date range apply here. <strong>Scaling by
+  size</strong> plots data size on the X axis for a single run — the newest by default, any
+  recorded one through the Run picker — drawing both metrics together: mean time is read from the
+  left axis and allocation from the right, with point shape distinguishing the two.</p>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
@@ -497,12 +500,12 @@
     params.set("range", dateRangeSel.value);
     params.set("mode", currentMode());
     params.set("log", logScaleCb.checked ? "1" : "0");
-    // Only in table mode, where which run is on screen is the whole point of the link. In the
-    // chart modes the run set is derived from the filters, so recording it would pin a link to a
-    // run that a later import may push out of view.
-    if (currentMode() === "table") {
+    // Only in the two single-run views, where which run is on screen is the whole point of the
+    // link. Trend derives its run set from the filters, so recording one there would pin a link to
+    // a run that a later import may push out of view. The comparison is table-only.
+    if (currentMode() !== "trend") {
       if (runSel.value) params.set("run", runSel.value);
-      if (compareSel.value) params.set("compare", compareSel.value);
+      if (currentMode() === "table" && compareSel.value) params.set("compare", compareSel.value);
     }
     const newHash = "#" + params.toString();
     if (location.hash !== newHash) history.replaceState(null, "", newHash);
@@ -616,7 +619,9 @@
   //   Table   - shows one recorded run whole, with mean time and allocation as separate columns,
   //             so the metric selector does not apply; the run picker replaces the date range,
   //             and there is no chart to scale logarithmically.
-  //   Scaling - plots both metrics on two axes, so the metric selector is replaced by its legend.
+  //   Scaling - plots both metrics on two axes, so the metric selector is replaced by its legend,
+  //             and draws one run chosen with the run picker, which leaves the date range nothing
+  //             to narrow.
   //   Trend   - reads all of them.
   function syncControlAvailability(mode) {
     const table = mode === "table";
@@ -624,7 +629,9 @@
     setInert(metricPickerEl, table || scaling,
              table ? "The table shows mean time and allocation as separate columns."
                    : "Scaling plots both metrics on two axes - use the metric legend below.");
-    setInert(rangePickerEl, table, "The table shows one run, chosen with the Run picker.");
+    setInert(rangePickerEl, table || scaling,
+             table ? "The table shows one run, chosen with the Run picker."
+                   : "Scaling plots one run, chosen with the Run picker.");
     setInert(logPickerEl, table, "No chart axis to scale in table mode.");
   }
 
@@ -737,42 +744,45 @@
     { key: "allocated_bytes", axis: "yAlloc", point: "rectRot", text: "Allocated" },
   ];
 
+  // One recorded run's size curve, chosen with the Run picker — the newest by default, which is
+  // what this view used to show and all it used to be able to show. Reading a scaling curve means
+  // reading one snapshot: rows stitched together from whichever run happened to be each series'
+  // latest would put a variant measured months ago on the same axes as one measured yesterday and
+  // present the pair as a comparison.
   function renderScalingChart() {
-    const cutoff = dateRangeCutoffIso();
-    const stmt = db.prepare(`
-      SELECT r.variant, r.data_size_bytes, r.data_size_label, r.run_date, r.run_id,
-             r.commit_sha, b.runtime_version, r.mean_ns, r.allocated_bytes
-      FROM benchmark_results r
-      LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
-                                AND b.framework = r.framework
-      WHERE r.platform = ? AND r.framework = ? AND r.category = ? AND r.family = ?
-        AND r.method = ?
-        ${cutoff ? "AND r.run_date >= ?" : ""}
-      ORDER BY r.variant, r.data_size_bytes, r.run_date
-    `);
-    stmt.bind([platformSel.value, frameworkSel.value, categorySel.value, familySel.value,
-               methodSel.value, ...(cutoff ? [cutoff] : [])]);
-
-    // ORDER BY run_date ASC means the last row seen for a given (variant, size) is the most
-    // recent recorded run within the selected date range — exactly the one we want for a
-    // "current scaling" snapshot (or a rewind, if a shorter range is selected).
-    const latestByVariant = new Map();
-    while (stmt.step()) {
-      const row = stmt.getAsObject();
-      if (!latestByVariant.has(row.variant)) latestByVariant.set(row.variant, new Map());
-      latestByVariant.get(row.variant).set(row.data_size_bytes, {
-        x: row.data_size_bytes,
-        mean_ns: row.mean_ns,
-        allocated_bytes: row.allocated_bytes,
-        size_label: row.data_size_label,
-        commit: row.commit_sha,
-        runtime: row.runtime_version,
-        pkg: packageLabel(row.variant, row.run_id, platformSel.value, frameworkSel.value),
-      });
+    const runValue = runSel.value;
+    const [runId, runPlatform, runFramework] = (runValue || "").split(" ");
+    const rowsByVariant = new Map();
+    if (runValue) {
+      const stmt = db.prepare(`
+        SELECT r.variant, r.data_size_bytes, r.data_size_label, r.run_id,
+               r.commit_sha, b.runtime_version, r.mean_ns, r.allocated_bytes
+        FROM benchmark_results r
+        LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
+                                  AND b.framework = r.framework
+        WHERE r.run_id = ? AND r.platform = ? AND r.framework = ?
+          AND r.category = ? AND r.family = ? AND r.method = ?
+        ORDER BY r.variant, r.data_size_bytes
+      `);
+      stmt.bind([runId, runPlatform, runFramework, categorySel.value, familySel.value,
+                 methodSel.value]);
+      while (stmt.step()) {
+        const row = stmt.getAsObject();
+        if (!rowsByVariant.has(row.variant)) rowsByVariant.set(row.variant, new Map());
+        rowsByVariant.get(row.variant).set(row.data_size_bytes, {
+          x: row.data_size_bytes,
+          mean_ns: row.mean_ns,
+          allocated_bytes: row.allocated_bytes,
+          size_label: row.data_size_label,
+          commit: row.commit_sha,
+          runtime: row.runtime_version,
+          pkg: packageLabel(row.variant, row.run_id, runPlatform, runFramework),
+        });
+      }
+      stmt.free();
     }
-    stmt.free();
 
-    const variantOrder = Array.from(latestByVariant.keys());
+    const variantOrder = Array.from(rowsByVariant.keys());
     const colorForVariant = colorsForVariants(variantOrder);
 
     // Both measurements at once, on their own axes - the Metric selector is ignored here. Reading
@@ -781,7 +791,7 @@
     // the metric so a single colour still reads as one implementation across both axes.
     const datasets = [];
     for (const variant of variantOrder) {
-      const points = Array.from(latestByVariant.get(variant).values()).sort((a, b) => a.x - b.x);
+      const points = Array.from(rowsByVariant.get(variant).values()).sort((a, b) => a.x - b.x);
       for (const m of METRICS) {
         // An all-null metric contributes nothing but a legend row and an empty axis.
         if (points.every((p) => p[m.key] == null)) continue;
@@ -826,9 +836,11 @@
     renderDashLegend([]); // one line per variant here — no per-size distinction to show
     renderMetricLegend(METRICS.map((m) => ({ metric: m.key, text: m.text })));
 
+    const chosen = Array.from(runSel.options).find((o) => o.value === runValue);
     const visibleCount = datasets.filter((d) => !d.hidden).length;
     statusEl.textContent = datasets.length
-      ? `${visibleCount} of ${datasets.length} variant(s) shown, most recent run per size`
+      ? `${visibleCount} of ${datasets.length} series shown, from ` +
+        (chosen ? chosen.textContent.trim() : "the selected run")
       : "No data for this selection yet.";
   }
 
@@ -883,7 +895,13 @@
   // Every (run, platform) carrying rows for the current selection, newest first. Both pickers are
   // filled from this, which is what makes "the same commit on two machines" fall out for free:
   // those share a run_id and differ only in platform.
-  function availableRuns() {
+  //
+  // Scaling mode passes scoped=true and gets only the platform and framework already selected
+  // above: there the cascade decides which machine is on screen and the run picker only decides
+  // when, so offering another machine's runs would put the two selectors in disagreement. Table
+  // mode deliberately offers all of them — two machines side by side is what its compare column
+  // is for.
+  function availableRuns(scoped) {
     const stmt = db.prepare(
       "SELECT DISTINCT r.run_id, r.platform, r.framework, r.run_date, r.commit_sha, " +
       "       b.runtime_version " +
@@ -891,9 +909,11 @@
       "LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform " +
       "                          AND b.framework = r.framework " +
       "WHERE r.category = ? AND r.family = ? AND r.method = ? " +
+      (scoped ? "  AND r.platform = ? AND r.framework = ? " : "") +
       "ORDER BY r.run_date DESC, r.platform, r.framework"
     );
-    stmt.bind([categorySel.value, familySel.value, methodSel.value]);
+    stmt.bind([categorySel.value, familySel.value, methodSel.value,
+               ...(scoped ? [platformSel.value, frameworkSel.value] : [])]);
     const runs = [];
     while (stmt.step()) runs.push(stmt.getAsObject());
     stmt.free();
@@ -910,8 +930,8 @@
     return date + " · " + run.platform + fw + " · " + sha + rt;
   }
 
-  function refreshRunPickers() {
-    const runs = availableRuns();
+  function refreshRunPickers(mode) {
+    const runs = availableRuns(mode === "scaling");
     const previousRun = runSel.value;
     const previousCompare = compareSel.value;
 
@@ -923,8 +943,15 @@
       runSel.appendChild(opt);
     }
     // Default to the newest run on the platform already selected above, so switching into table
-    // mode shows the data the charts were showing rather than jumping to another machine.
-    const preferred = runs.find((r) => r.platform === platformSel.value
+    // mode shows the data the charts were showing rather than jumping to another machine. Ahead of
+    // that, keep the same commit if the new platform also recorded it: switching platform on a
+    // pinned run asks "and what does this commit do over there", which is the comparison the
+    // archive keys runs by commit to make possible - not "show me something newer".
+    const previousRunId = previousRun.split(" ")[0];
+    const preferred = runs.find((r) => r.run_id === previousRunId
+                                   && r.platform === platformSel.value
+                                   && r.framework === frameworkSel.value)
+                   || runs.find((r) => r.platform === platformSel.value
                                    && r.framework === frameworkSel.value)
                    || runs.find((r) => r.platform === platformSel.value)
                    || runs[0];
@@ -1133,6 +1160,7 @@
   function renderChart() {
     const mode = currentMode();
     const isTable = mode === "table";
+    const isScaling = mode === "scaling";
 
     chartContainerEl.hidden = isTable;
     legendColorsEl.hidden = isTable;
@@ -1141,13 +1169,15 @@
     if (isTable) legendHintEl.hidden = true;   // otherwise left to renderColorLegend below
     tableContainerEl.hidden = !isTable;
     tableNoteEl.hidden = !isTable;
-    runPickerEl.hidden = !isTable;
+    // Both single-run views need the run picker; only the table can hold two runs at once.
+    runPickerEl.hidden = !(isTable || isScaling);
     comparePickerEl.hidden = !isTable;
 
     if (isTable) {
-      refreshRunPickers();
+      refreshRunPickers(mode);
       renderTableView();
-    } else if (mode === "scaling") {
+    } else if (isScaling) {
+      refreshRunPickers(mode);
       renderScalingChart();
     } else {
       renderTrendChart();
@@ -1201,9 +1231,10 @@
     dateRangeSel.onchange = renderChart;
     logScaleCb.onchange = renderChart;
     modeRadios.forEach((r) => (r.onchange = renderChart));
-    // Changing the run also rebuilds the comparison list, since the shown run must not appear as
-    // its own comparison.
-    runSel.onchange = () => { refreshRunPickers(); renderTableView(); syncUrlHash(); };
+    // Straight through renderChart so the run picker drives whichever single-run view is showing —
+    // the table or the scaling chart. It rebuilds the comparison list on the way (the shown run
+    // must not appear as its own comparison) and keeps the just-chosen run selected.
+    runSel.onchange = renderChart;
     compareSel.onchange = () => { renderTableView(); syncUrlHash(); };
     copyLinkBtn.onclick = async () => {
       try {

--- a/docfx/packages/security/cryptography/benchmarks.md
+++ b/docfx/packages/security/cryptography/benchmarks.md
@@ -2,10 +2,11 @@
 
 BenchmarkDotNet measurements for `CryptoHives.Foundation.Security.Cryptography` are published through the
 interactive benchmark trends dashboard below rather than static per-platform pages. The dashboard loads a small
-SQLite database client-side (no server) and lets you pick platform, category, algorithm family, method, and data
-size, plotting every matching implementation as its own line — including a size-scaling view and multi-size trend
-comparisons. Because `platform` is a free-form value in the database, results from any contributor's machine can
-appear side by side, not just a fixed set of CI hosts.
+SQLite database client-side (no server) and lets you pick platform, category, algorithm family and method,
+plotting every matching implementation as its own line — including a size-scaling view and multi-size trend
+comparisons. The single-run views — the table and the scaling chart — take any recorded run from the Run picker,
+not just the newest. Because `platform` is a free-form value in the database, results from any contributor's
+machine can appear side by side, not just a fixed set of CI hosts.
 
 <iframe src="benchmark-trends/index.html" style="width:100%; height:900px; border:1px solid var(--border-color, #ddd); border-radius:6px;" loading="lazy" title="Cryptography benchmark trends dashboard"></iframe>
 
@@ -13,90 +14,105 @@ appear side by side, not just a fixed set of CI hosts.
 
 ## Memory Footprint
 
-The following tables show the per-instance memory footprint (internal state + buffers) and any static lookup tables shared across all instances. These are the raw data sizes; actual managed object overhead adds ~16–40 bytes per object and ~24 bytes per array on 64-bit runtimes.
+The following tables show the per-instance memory footprint (internal state + buffers) and any
+static lookup tables shared across all instances. These are the raw data sizes measured by walking
+each instance's fields on x64 .NET 10; actual managed object overhead adds ~16-40 bytes per object
+and ~24 bytes per array on 64-bit runtimes.
+
+Two things are worth knowing before reading the numbers. A block cipher's state lives in the
+transform it creates, not in the `SymmetricAlgorithm` object (which is a ~60 B shell), so the cipher
+table measures the transform. And a few algorithms buffer their whole input rather than absorbing it
+block by block - those are marked *+ input* and are the only ones whose footprint is not constant.
 
 ### Hash Algorithms
 
 | Algorithm | Instance State | Block Size | Static Tables | Notes |
 |-----------|---------------|-----------|---------------|-------|
-| SHA-224 | 96 B | 64 B | 256 B | uint[8] state + byte[64] buffer |
-| SHA-256 | 96 B | 64 B | 256 B | uint[8] state + byte[64] buffer |
-| SHA-384 | 192 B | 128 B | 640 B | ulong[8] state + byte[128] buffer |
-| SHA-512 | 192 B | 128 B | 640 B | ulong[8] state + byte[128] buffer |
-| SHA-512/224 | 192 B | 128 B | 640 B | SHA-512 core with truncated output |
-| SHA-512/256 | 192 B | 128 B | 640 B | SHA-512 core with truncated output |
-| SHA3-224 | 336 B | 144 B | 192 B | 200 B Keccak state + byte[rate] buffer |
-| SHA3-256 | 336 B | 136 B | 192 B | 200 B Keccak state + byte[rate] buffer |
-| SHA3-384 | 304 B | 104 B | 192 B | 200 B Keccak state + byte[rate] buffer |
-| SHA3-512 | 272 B | 72 B | 192 B | 200 B Keccak state + byte[rate] buffer |
-| SHAKE128 | 368 B | 168 B | 192 B | Keccak XOF, variable output |
-| SHAKE256 | 336 B | 136 B | 192 B | Keccak XOF, variable output |
-| cSHAKE128 | 368 B+ | 168 B | 192 B | + encoded function/customization |
-| cSHAKE256 | 336 B+ | 136 B | 192 B | + encoded function/customization |
-| TurboSHAKE128 | 368 B | 168 B | 192 B | Reduced-round Keccak |
-| TurboSHAKE256 | 336 B | 136 B | 192 B | Reduced-round Keccak |
-| KT128 | 368 B | 168 B | 192 B | KangarooTwelve |
-| KT256 | 336 B | 136 B | 192 B | KangarooTwelve |
-| Keccak-256 | 336 B | 136 B | 192 B | Ethereum compatible |
-| Keccak-384 | 304 B | 104 B | 192 B | Ethereum compatible |
-| Keccak-512 | 272 B | 72 B | 192 B | Ethereum compatible |
-| BLAKE2b | 216 B | 128 B | 256 B | ulong[8] state + byte[128] buffer + key |
-| BLAKE2s | 120 B | 64 B | 192 B | uint[8] state + byte[64] buffer + key |
-| BLAKE3 | 3,072 B | 64 B | — | Merkle tree: 1 KB chunk buffer + 1.7 KB CV stack |
+| SHA-224 | 128 B | 64 B | 256 B | uint[8] state + byte[64] buffer, both pooled (the state bucket rounds up to 16 words) |
+| SHA-256 | 128 B | 64 B | 256 B | uint[8] state + byte[64] buffer, both pooled |
+| SHA-384 | 256 B | 128 B | 640 B | ulong[8] state + byte[128] buffer, both pooled |
+| SHA-512 | 256 B | 128 B | 640 B | ulong[8] state + byte[128] buffer, both pooled |
+| SHA-512/224 | 256 B | 128 B | 640 B | SHA-512 core with truncated output |
+| SHA-512/256 | 256 B | 128 B | 640 B | SHA-512 core with truncated output |
+| SHA3-224 | 352 B | 144 B | 3.6 KB | 208 B Keccak state + byte[rate] buffer |
+| SHA3-256 | 344 B | 136 B | 3.6 KB | 208 B Keccak state + byte[rate] buffer |
+| SHA3-384 | 312 B | 104 B | 3.6 KB | 208 B Keccak state + byte[rate] buffer |
+| SHA3-512 | 280 B | 72 B | 3.6 KB | 208 B Keccak state + byte[rate] buffer |
+| SHAKE128 | 376 B | 168 B | 3.6 KB | Keccak XOF, variable output |
+| SHAKE256 | 344 B | 136 B | 3.6 KB | Keccak XOF, variable output |
+| cSHAKE128 | 376 B+ | 168 B | 3.6 KB | + encoded function/customization |
+| cSHAKE256 | 344 B+ | 136 B | 3.6 KB | + encoded function/customization |
+| TurboSHAKE128 | 376 B | 168 B | 3.6 KB | Reduced-round Keccak |
+| TurboSHAKE256 | 344 B | 136 B | 3.6 KB | Reduced-round Keccak |
+| KT128 | 632 B + input | 168 B | 3.6 KB | KangarooTwelve: a TurboSHAKE128 (376 B) plus a pooled buffer holding the whole message |
+| KT256 | 600 B + input | 136 B | 3.6 KB | KangarooTwelve: a TurboSHAKE256 (344 B) plus the same buffer |
+| Keccak-256 | 344 B | 136 B | 3.6 KB | Ethereum compatible |
+| Keccak-384 | 312 B | 104 B | 3.6 KB | Ethereum compatible |
+| Keccak-512 | 280 B | 72 B | 3.6 KB | Ethereum compatible |
+| BLAKE2b | 216 B | 128 B | — | ulong[8] state + byte[128] buffer + counters; a key adds up to 64 B |
+| BLAKE2s | 120 B | 64 B | 640 B | uint[8] state + byte[64] buffer + counters; tables are SIMD gather indices |
+| BLAKE3 | 3,072 B | 64 B | — | Merkle tree: 1 KB chunk buffer + 1.7 KB CV stack + root/squeeze state |
 | Ascon-Hash256 | 48 B | 8 B | — | 5 × ulong state + byte[8] buffer |
 | Ascon-XOF128 | 48 B | 8 B | — | 5 × ulong state + byte[8] buffer |
-| RIPEMD-160 | 84 B | 64 B | — | uint[5] state + byte[64] buffer |
+| RIPEMD-160 | 84 B | 64 B | 1.25 KB | uint[5] state + byte[64] buffer; 4 × int[80] schedule tables |
 | SM3 | 96 B | 64 B | — | 8 × uint state + byte[64] buffer |
-| Whirlpool | 128 B | 64 B | 16.3 KB | ulong[8] state + byte[64] buffer; 8 T-tables |
-| Streebog | 256 B | 64 B | 16.5 KB | 3 × ulong[8] state + byte[64] buffer; 8 T-tables |
-| Kupyna-256 | 192 B | 64 B | 16 KB | ulong[8] state + scratch + byte[64]; 8 T-tables |
-| Kupyna-512 | 384 B | 128 B | 16 KB | ulong[16] state + scratch + byte[128]; 8 T-tables |
-| LSH-256 | 384 B | 128 B | 832 B | CV + submsg registers + byte[128] buffer |
-| LSH-512 | 768 B | 256 B | 1.8 KB | CV + submsg registers + byte[256] buffer |
+| Whirlpool | 128 B | 64 B | 16.3 KB | ulong[8] state + byte[64] buffer; 8 T-tables + S-box + round constants |
+| Streebog | 256 B | 64 B | 17.6 KB | 3 × ulong[8] state + byte[64] buffer; 8 T-tables + Pi/A + a Vector512 CV table |
+| Kupyna-256 | 320 B | 64 B | 16.1 KB | 4 × ulong[8] (state, two temporaries, scratch) + byte[64]; 8 T-tables |
+| Kupyna-512 | 640 B | 128 B | 16.1 KB | 4 × ulong[16] (state, two temporaries, scratch) + byte[128]; 8 T-tables |
+| LSH-256 | 384 B | 128 B | 992 B | CV + submsg registers + byte[128] buffer; step constants + IVs |
+| LSH-512 | 768 B | 256 B | 2.3 KB | CV + submsg registers + byte[256] buffer; step constants + IVs |
 | SHA-1 | 404 B | 64 B | — | uint[5] state + uint[80] W + byte[64] |
-| MD5 | 80 B | 64 B | 512 B | uint[4] state + byte[64] buffer |
+| MD5 | 80 B | 64 B | 768 B | uint[4] state + byte[64] buffer; K/S/G tables |
+| IncrementalParallelHash | 40 B + input | configurable | 3.6 KB | buffers the message in a `MemoryStream`; the underlying SHAKE is created at finalize |
 
 ### Cipher Algorithms
 
+Measured on the transform, which is where the round keys and chaining state live.
+
 | Algorithm | Instance State | Block Size | Static Tables | Notes |
 |-----------|---------------|-----------|---------------|-------|
-| AES-128 (ECB/CBC/CTR) | 288 B | 16 B | 10.5 KB | Fixed: uint[44] keys + IV + counter + feedback; T-tables |
-| AES-192 (ECB/CBC/CTR) | 288 B | 16 B | 10.5 KB | Fixed: uint[52] keys (shared fixed buffer) |
-| AES-256 (ECB/CBC/CTR) | 288 B | 16 B | 10.5 KB | Fixed: uint[60] keys (shared fixed buffer) |
-| AES-GCM-128 | ~640 B | 16 B | 10.6 KB | Round keys + H + Shoup table + H-powers (CLMUL) |
-| AES-GCM-192 | ~680 B | 16 B | 10.6 KB | Larger round key schedule |
-| AES-GCM-256 | ~720 B | 16 B | 10.6 KB | Largest round key schedule |
-| AES-CCM-128 | 240 B | 16 B | 10.5 KB | Fixed: uint[44] round keys |
-| AES-CCM-256 | 240 B | 16 B | 10.5 KB | Fixed: uint[60] round keys |
-| ChaCha20 | ~128 B | 64 B | 16 B | uint[16] state + keystream buffer |
-| ChaCha20-Poly1305 | ~192 B | 64 B | 16 B | ChaCha20 state + Poly1305 accumulator |
-| XChaCha20-Poly1305 | ~192 B | 64 B | 16 B | Same as ChaCha20-Poly1305 (HChaCha subkey) |
-| Ascon-AEAD-128 | 56 B | 16 B | — | 5 × ulong state + nonce; permutation-based |
-| SM4 (ECB/CBC/CTR) | 176 B | 16 B | 4 KB | uint[32] round keys + IV + feedback; S-box + CK table |
-| ARIA-128 (ECB/CBC/CTR) | 288 B | 16 B | 1 KB | byte[16×17] round keys + IV + feedback; 4 S-boxes |
-| ARIA-192 (ECB/CBC/CTR) | 288 B | 16 B | 1 KB | byte[16×15] round keys (shared buffer) |
-| ARIA-256 (ECB/CBC/CTR) | 288 B | 16 B | 1 KB | byte[16×17] round keys (shared buffer) |
-| Camellia-128 (ECB/CBC/CTR) | 320 B | 16 B | 4.5 KB | uint[52] subkeys + IV + feedback; 6 SP-boxes |
-| Camellia-192 (ECB/CBC/CTR) | 400 B | 16 B | 4.5 KB | uint[68] subkeys (shared SP-boxes) |
-| Camellia-256 (ECB/CBC/CTR) | 400 B | 16 B | 4.5 KB | uint[68] subkeys (shared SP-boxes) |
-| Kuznyechik (ECB/CBC/CTR) | 320 B | 16 B | 8 KB | byte[10×16] round keys + IV + feedback; LS/IL tables |
-| Kalyna-128 (ECB/CBC/CTR) | 320 B | 16 B | 5 KB | ulong[22] round keys + IV + feedback; 4 S-boxes + MDS |
-| Kalyna-256 (ECB/CBC/CTR) | 400 B | 16 B | 5 KB | ulong[30] round keys (shared S-boxes/MDS) |
-| Kalyna-512 (ECB/CBC/CTR) | ~816 B | 32 B | 5 KB | ulong[76] round keys + IV + feedback; 4 S-boxes + MDS |
-| SEED (ECB/CBC/CTR) | 192 B | 16 B | 4 KB | uint[32] round keys + IV + feedback; 4 SS-boxes |
+| AES-128/192/256 (ECB/CBC/CTR) | 288 B | 16 B | 8.5 KB | Fixed uint[60] keys (same buffer for every key size) + IV + counter + feedback; T-tables |
+| AES-GCM-128 | 645 B | 16 B | 8.6 KB | uint[44] round keys + H + 256 B Shoup table + 8 H-powers (CLMUL) |
+| AES-GCM-192 | 677 B | 16 B | 8.6 KB | uint[52] round keys, otherwise as above |
+| AES-GCM-256 | 709 B | 16 B | 8.6 KB | uint[60] round keys, otherwise as above |
+| AES-CCM-128/192/256 | 248 B | 16 B | 8.5 KB | Fixed uint[60] round keys for every key size |
+| ChaCha20 | 108 B | 64 B | 16 B | byte[32] key + byte[12] nonce + 64 B keystream buffer |
+| ChaCha20-Poly1305 | 32 B | 64 B | 16 B | Retains only the key; per-message state is stack-local |
+| XChaCha20-Poly1305 | 32 B | 64 B | 16 B | Retains only the key; the HChaCha subkey is derived per message |
+| Ascon-AEAD-128 | 16 B | 16 B | — | Retains only the key; the permutation state is per call |
+| SM4 (ECB/CBC/CTR) | 176 B | 16 B | 4.4 KB | Fixed uint[32] round keys + IV + counter + feedback; S-box + CK + 4 T-tables |
+| ARIA-128/192/256 (ECB/CBC/CTR) | 338 B | 16 B | 1 KB | byte[272] round keys (one size for all key lengths) + IV + counter + feedback; 4 S-boxes |
+| Camellia-128/192/256 (ECB/CBC/CTR) | 338 B | 16 B | 16 KB | ulong[34] subkeys (one size for all key lengths) + IV + counter + feedback; 8 SP tables |
+| Kuznyechik (ECB/CBC/CTR) | 222 B | 16 B | 1 KB | byte[160] round keys + IV + counter + feedback; Pi/Pi⁻¹ + iteration constants, no precomputed LS tables |
+| Kalyna-128/256 (ECB/CBC/CTR) | 1,298 B | 16 B | 35.3 KB | Fixed 1,216 B round-key buffer for every key size + IV + counter + feedback; 8 T-tables + 4 S-boxes and their inverses |
+| Kalyna-512 (ECB/CBC/CTR) | 1,346 B | 32 B | 35.3 KB | Same round-key buffer, 32 B chaining state |
+| SEED (ECB/CBC/CTR) | 190 B | 16 B | 4.1 KB | uint[32] round keys + IV + counter + feedback; 4 SS-boxes + KC |
 
 ### Message Authentication Codes (MAC)
 
 | Algorithm | Instance State | Block Size | Static Tables | Notes |
 |-----------|---------------|-----------|---------------|-------|
-| KMAC128 | 368 B+ | 168 B | 192 B | Keccak state + buffer + encoded key/customization |
-| KMAC256 | 336 B+ | 136 B | 192 B | Keccak state + buffer + encoded key/customization |
-| BLAKE2b (keyed) | 216 B | 128 B | 256 B | Same as BLAKE2b + key material |
-| BLAKE2s (keyed) | 120 B | 64 B | 192 B | Same as BLAKE2s + key material |
+| KMAC128 | 376 B+ | 168 B | 3.6 KB | Keccak state + buffer + encoded key/customization (440 B with a 32-byte key) |
+| KMAC256 | 344 B+ | 136 B | 3.6 KB | Keccak state + buffer + encoded key/customization (408 B with a 32-byte key) |
+| HMAC-SHA-256 | 448 B | 64 B | 256 B | Two SHA-256 instances + ipad/opad key blocks |
+| HMAC-SHA-512 | 824 B | 128 B | 640 B | Two SHA-512 instances + ipad/opad key blocks |
+| HMAC-SHA3-256 | 1,018 B | 136 B | 3.6 KB | Two SHA3-256 instances + ipad/opad key blocks |
+| Poly1305 | ~100 B | 16 B | — | 16 B block buffer + accumulator, r and s registers |
+| AES-CMAC | 316 B | 16 B | 8.5 KB | K1/K2 subkeys + MAC + buffer + 15 round-key vectors |
+| AES-GMAC | 646 B | 16 B | 8.6 KB | Same state as AES-GCM-128 |
+| BLAKE2b (keyed) | 216 B | 128 B | — | Same as BLAKE2b + key material |
+| BLAKE2s (keyed) | 120 B | 64 B | 640 B | Same as BLAKE2s + key material |
 | BLAKE3 (keyed) | 3,072 B | 64 B | — | Same as BLAKE3 with key words |
 
-> **Static tables** are shared across all instances of algorithms in the same family and are loaded once into memory. AES T-tables (10.5 KB) are shared by all AES-based algorithms (ECB, CBC, CTR, GCM, CCM). Keccak round constants (192 B) are shared by all SHA-3, SHAKE, cSHAKE, TurboSHAKE, KT, and KMAC instances. Algorithms marked "—" use no static lookup tables (permutation-based or constant-time by design).
-
+> **Static tables** are shared across all instances of algorithms in the same family and are loaded
+> once into memory. AES T-tables (8.5 KB) are shared by all AES-based algorithms (ECB, CBC, CTR, GCM,
+> CCM, CMAC, GMAC). The Keccak figure is 192 B of round constants plus ~3.5 KB of SIMD constant
+> vectors, built unconditionally when the type initializes — even on hardware with no AVX2 or
+> AVX-512 — and shared by all SHA-3, SHAKE, cSHAKE, TurboSHAKE, KT, ParallelHash and KMAC instances.
+> Tables declared as `ReadOnlySpan<byte>` (SM4, ARIA and Kalyna's S-boxes) live in the assembly image
+> rather than on the heap, but are counted here all the same. Algorithms marked "—" use no lookup
+> tables at all.
 
 ## Updating benchmark documentation
 

--- a/docfx/packages/security/cryptography/specs/README.md
+++ b/docfx/packages/security/cryptography/specs/README.md
@@ -1,6 +1,7 @@
 # Cryptographic Test Vectors
 
-This folder contains test vectors for cryptographic hash algorithms from official sources.
+This folder contains test vectors for the hash, MAC and cipher algorithms in this package, from
+official sources.
 
 ## Implementation Status
 
@@ -35,10 +36,13 @@ This folder contains test vectors for cryptographic hash algorithms from officia
 | cSHAKE256 | 256 bits | ✅ Implemented | `CShake256` |
 | KMAC128 | 128 bits | ✅ Implemented | `KMac128` |
 | KMAC256 | 256 bits | ✅ Implemented | `KMac256` |
+| ParallelHash128 | 128 bits | ✅ Implemented | `ParallelHash`, `IncrementalParallelHash` |
+| ParallelHash256 | 256 bits | ✅ Implemented | `ParallelHash`, `IncrementalParallelHash` |
 | TupleHash128 | 128 bits | ⬜ Not implemented | - |
 | TupleHash256 | 256 bits | ⬜ Not implemented | - |
-| ParallelHash128 | 128 bits | ⬜ Not implemented | - |
-| ParallelHash256 | 256 bits | ⬜ Not implemented | - |
+
+> **ParallelHash:** one-shot via `ParallelHash.ComputeHash128`/`ComputeHash256`, streaming via
+> `IncrementalParallelHash`. Test vectors: [ParallelHash-vectors.md](ParallelHash-vectors.md).
 
 ### RFC 9861 (TurboSHAKE and KangarooTwelve)
 
@@ -52,14 +56,15 @@ This folder contains test vectors for cryptographic hash algorithms from officia
 > **Note:** KT128 and KT256 (formerly KangarooTwelve and MarsupilamiFourteen) are defined in RFC 9861.
 > They use reduced-round Keccak (12 rounds) for ~2× faster performance than SHAKE.
 
-### NIST FIPS 207 (Ascon Lightweight Cryptography)
+### NIST SP 800-232 (Ascon Lightweight Cryptography)
 
 | Algorithm | Hash Size | Status | Class |
 |-----------|-----------|--------|-------|
 | Ascon-Hash256 | 256 bits | ✅ Implemented | `AsconHash256` |
 | Ascon-XOF128 | Variable | ✅ Implemented | `AsconXof128` |
 
-> **Note:** Ascon was selected as the NIST Lightweight Cryptography standard in 2023.
+> **Note:** Ascon was selected as the NIST Lightweight Cryptography standard in 2023 and
+> published as SP 800-232. See [NIST-SP-800-232.md](NIST-SP-800-232.md).
 > It is designed for constrained environments (IoT, embedded systems).
 
 ### Keccak (Original Algorithm)
@@ -103,7 +108,7 @@ This folder contains test vectors for cryptographic hash algorithms from officia
 |------|--------|----------------|-------------|
 | Hash | ✅ | `Blake3.Create()` | Standard cryptographic hashing |
 | Keyed Hash | ✅ | `Blake3.CreateKeyed(key)` | MAC with 32-byte key |
-| Derive Key | ✅ | `Blake3.CreateDeriveKey(context)` | Key derivation from context + input |
+| Derive Key | ⬜ | - | `Blake3Mode.DeriveKey` is declared but no constructor selects it |
 | XOF | ✅ | `Blake3.Create(outputBytes)` | Extendable output (any length) |
 
 ### RIPEMD Family
@@ -182,6 +187,8 @@ This folder contains test vectors for cryptographic hash algorithms from officia
 | HMAC-SHA-384 | SHA-384 | 48 bytes | ✅ Implemented | `HmacSha384` |
 | HMAC-SHA-512 | SHA-512 | 64 bytes | ✅ Implemented | `HmacSha512` |
 | HMAC-SHA3-256 | SHA3-256 | 32 bytes | ✅ Implemented | `HmacSha3_256` |
+| HMAC-SHA3-384 | SHA3-384 | 48 bytes | ✅ Implemented | `HmacSha3_384` |
+| HMAC-SHA3-512 | SHA3-512 | 64 bytes | ✅ Implemented | `HmacSha3_512` |
 | HMAC-SHA-1 | SHA-1 | 20 bytes | ✅ Implemented (legacy) | `HmacSha1` |
 | HMAC-MD5 | MD5 | 16 bytes | ✅ Implemented (legacy) | `HmacMd5` |
 
@@ -243,6 +250,7 @@ This folder contains test vectors for cryptographic hash algorithms from officia
 | Algorithm | Key Size | Status | Class |
 |-----------|----------|--------|-------|
 | AES-128-CCM | 128 bits | ✅ Implemented | `AesCcm128` |
+| AES-192-CCM | 192 bits | ✅ Implemented | `AesCcm192` |
 | AES-256-CCM | 256 bits | ✅ Implemented | `AesCcm256` |
 
 > **Hardware acceleration:** AES-NI on .NET 8+ for CTR and CBC-MAC block operations.
@@ -252,7 +260,7 @@ This folder contains test vectors for cryptographic hash algorithms from officia
 | Algorithm | Key Size | Status | Class |
 |-----------|----------|--------|-------|
 | ChaCha20 | 256 bits | ✅ Implemented | `ChaCha20` |
-| Poly1305 | 256 bits | ✅ Implemented | `Poly1305` |
+| Poly1305 | 256 bits | ✅ Implemented | `Poly1305Mac` |
 | ChaCha20-Poly1305 | 256 bits | ✅ Implemented | `ChaCha20Poly1305` |
 
 > **Hardware acceleration:** SSSE3 (single-block) and AVX2 (dual-block) on .NET 8+.
@@ -266,6 +274,43 @@ This folder contains test vectors for cryptographic hash algorithms from officia
 
 > **Note:** XChaCha20-Poly1305 extends ChaCha20-Poly1305 with a 24-byte nonce (vs 12-byte),
 > making random nonce generation safe for a practically unlimited number of messages.
+> There is no standalone `XChaCha20` stream cipher — only the AEAD construction.
+
+### NIST SP 800-232 (Ascon-AEAD128)
+
+| Algorithm | Key Size | Nonce Size | Status | Class |
+|-----------|----------|------------|--------|-------|
+| Ascon-AEAD128 | 128 bits | 128 bits | ✅ Implemented | `AsconAead128` |
+
+### Regional Block Ciphers
+
+| Algorithm | Key Size | Block Size | Mode | Standard | Status | Class |
+|-----------|----------|------------|------|----------|--------|-------|
+| SM4 | 128 bits | 128 bits | ECB/CBC/CTR | GB/T 32907-2016 (China) | ✅ Implemented | `Sm4` |
+| ARIA-128 | 128 bits | 128 bits | ECB/CBC/CTR | RFC 5794 (Korea) | ✅ Implemented | `Aria128` |
+| ARIA-192 | 192 bits | 128 bits | ECB/CBC/CTR | RFC 5794 (Korea) | ✅ Implemented | `Aria192` |
+| ARIA-256 | 256 bits | 128 bits | ECB/CBC/CTR | RFC 5794 (Korea) | ✅ Implemented | `Aria256` |
+| SEED | 128 bits | 128 bits | ECB/CBC/CTR | RFC 4269 (Korea) | ✅ Implemented | `Seed` |
+| Camellia-128 | 128 bits | 128 bits | ECB/CBC/CTR | RFC 3713 (Japan) | ✅ Implemented | `Camellia128` |
+| Camellia-192 | 192 bits | 128 bits | ECB/CBC/CTR | RFC 3713 (Japan) | ✅ Implemented | `Camellia192` |
+| Camellia-256 | 256 bits | 128 bits | ECB/CBC/CTR | RFC 3713 (Japan) | ✅ Implemented | `Camellia256` |
+| Kuznyechik | 256 bits | 128 bits | ECB/CBC/CTR | GOST R 34.12-2015 (Russia) | ✅ Implemented | `Kuznyechik` |
+| Kalyna-128/128 | 128 bits | 128 bits | ECB/CBC/CTR | DSTU 7624:2014 (Ukraine) | ✅ Implemented | `Kalyna128` |
+| Kalyna-128/256 | 256 bits | 128 bits | ECB/CBC/CTR | DSTU 7624:2014 (Ukraine) | ✅ Implemented | `Kalyna256` |
+| Kalyna-256/256, -256/512 | 256/512 bits | 256 bits | ECB/CBC/CTR | DSTU 7624:2014 (Ukraine) | ✅ Implemented | `Kalyna512` |
+
+> **Modes:** every block cipher here supports ECB (testing only), CBC and CTR. CFB and OFB exist as
+> `[Obsolete]` values on `CipherMode` and throw `NotSupportedException`; Kalyna's 512-bit block
+> variant, and the GCM/CCM/XTS/MGM modes the regional standards define, are not implemented.
+
+### Key Derivation Functions
+
+| Algorithm | Standard | Status | Class |
+|-----------|----------|--------|-------|
+| HKDF | RFC 5869 | ✅ Implemented | `Hkdf` |
+| KBKDF | NIST SP 800-108 | ✅ Implemented | `Kbkdf` |
+| Concat KDF | NIST SP 800-56A | ✅ Implemented | `ConcatKdf` |
+| PBKDF2 | RFC 8018 / NIST SP 800-132 | ✅ Implemented | `Pbkdf2` |
 
 ---
 
@@ -443,6 +488,7 @@ specs/
 ├── MD5-vectors.md         # MD5 test vectors (legacy)
 ├── HMAC-vectors.md        # HMAC-SHA-256/384/512 test vectors (RFC 4231)
 ├── CMAC-vectors.md        # AES-CMAC test vectors (SP 800-38B)
+├── ParallelHash-vectors.md # ParallelHash128/256 test vectors (SP 800-185)
 ├── AES-vectors.md         # AES ECB/GCM/CCM test vectors
 ├── ChaCha20-vectors.md    # ChaCha20, Poly1305, ChaCha20-Poly1305 test vectors
 └── XChaCha20-vectors.md   # XChaCha20-Poly1305 test vectors
@@ -451,7 +497,7 @@ specs/
 ## Usage
 
 These test vectors are used by the unit tests in `tests/Security/Cryptography/` to verify
-the correctness of our hash implementations against known good values from official sources.
+the correctness of our implementations against known good values from official sources.
 
 ## License
 

--- a/docfx/packages/threading/asyncautoresetevent.md
+++ b/docfx/packages/threading/asyncautoresetevent.md
@@ -1,4 +1,4 @@
-﻿# AsyncAutoResetEvent
+# AsyncAutoResetEvent
 
 ## Overview
 
@@ -376,6 +376,7 @@ await _event.WaitAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
 - [AsyncManualResetEvent](asyncmanualresetevent.md) - Manual-reset event variant
 - [AsyncReaderWriterLock](asyncreaderwriterlock.md) - Async reader-writer lock
 - [AsyncLock](asynclock.md) - Async mutual exclusion lock
+- [AsyncKeyedLock](asynckeyedlock.md) - Per-key async exclusion
 - [AsyncCountdownEvent](asynccountdownevent.md) - Async countdown event
 - [AsyncBarrier](asyncbarrier.md) - Async barrier synchronization primitive
 - [AsyncSemaphore](asyncsemaphore.md) - Async semaphore primitive

--- a/docfx/packages/threading/asyncbarrier.md
+++ b/docfx/packages/threading/asyncbarrier.md
@@ -1,4 +1,4 @@
-﻿# AsyncBarrier
+# AsyncBarrier
 
 A pooled, allocation-free async barrier that synchronizes multiple participants using ValueTask-based waiters.
 
@@ -317,6 +317,7 @@ catch (TimeoutException)
 - [AsyncManualResetEvent](asyncmanualresetevent.md) - Manual-reset event variant
 - [AsyncReaderWriterLock](asyncreaderwriterlock.md) - Async reader-writer lock
 - [AsyncLock](asynclock.md) - Async mutual exclusion lock
+- [AsyncKeyedLock](asynckeyedlock.md) - Per-key async exclusion
 - [AsyncCountdownEvent](asynccountdownevent.md) - Async countdown event
 - [AsyncSemaphore](asyncsemaphore.md) - Async semaphore primitive
 - [Benchmarks](benchmarks.md) - Benchmark description

--- a/docfx/packages/threading/asynccountdownevent.md
+++ b/docfx/packages/threading/asynccountdownevent.md
@@ -1,4 +1,4 @@
-﻿# AsyncCountdownEvent
+# AsyncCountdownEvent
 
 A pooled, allocation-free async countdown event that signals when a count reaches zero using ValueTask-based waiters.
 
@@ -252,6 +252,7 @@ catch (TimeoutException)
 - [AsyncManualResetEvent](asyncmanualresetevent.md) - Manual-reset event variant
 - [AsyncReaderWriterLock](asyncreaderwriterlock.md) - Async reader-writer lock
 - [AsyncLock](asynclock.md) - Async mutual exclusion lock
+- [AsyncKeyedLock](asynckeyedlock.md) - Per-key async exclusion
 - [AsyncBarrier](asyncbarrier.md) - Async barrier synchronization primitive
 - [AsyncSemaphore](asyncsemaphore.md) - Async semaphore primitive
 - [Benchmarks](benchmarks.md) - Benchmark description

--- a/docfx/packages/threading/asynclock.md
+++ b/docfx/packages/threading/asynclock.md
@@ -18,6 +18,8 @@ public sealed class AsyncLock : IResettable
 
 `AsyncLock` provides async mutual exclusion, similar to `SemaphoreSlim(1,1)` but optimized for the common async locking pattern. It returns a small value-type releaser that implements `IDisposable`/`IAsyncDisposable` so the lock can be released with a `using` pattern. The implementation uses pooled `IValueTaskSource` instances to minimize allocations in high-throughput scenarios and a local reusable waiter to avoid allocations for the first queued waiter.
 
+It guards one resource. When the thing being guarded is one of many — a row, an account, a tenant, a cache entry — use [`AsyncKeyedLock<TKey>`](asynckeyedlock.md) instead of a lock per key or a dictionary of locks: it serializes callers per key while letting unrelated keys run fully in parallel.
+
 ## Benefits
 
 - **Zero-allocation fast path**: When the lock is uncontended the operation completes synchronously without heap allocations.
@@ -314,6 +316,7 @@ using (await _lock1.LockAsync())
 ## See Also
 
 - [Threading Package Overview](index.md)
+- [AsyncKeyedLock](asynckeyedlock.md) - Per-key async exclusion; distinct keys never block each other
 - [AsyncAutoResetEvent](asyncautoresetevent.md) - Auto-reset event variant
 - [AsyncManualResetEvent](asyncmanualresetevent.md) - Manual-reset event variant
 - [AsyncReaderWriterLock](asyncreaderwriterlock.md) - Async reader-writer lock

--- a/docfx/packages/threading/asyncmanualresetevent.md
+++ b/docfx/packages/threading/asyncmanualresetevent.md
@@ -1,4 +1,4 @@
-﻿# AsyncManualResetEvent
+# AsyncManualResetEvent
 
 ## Overview
 
@@ -374,6 +374,7 @@ catch (TimeoutException)
 - [AsyncAutoResetEvent](asyncautoresetevent.md) - Auto-reset event variant
 - [AsyncReaderWriterLock](asyncreaderwriterlock.md) - Async reader-writer lock
 - [AsyncLock](asynclock.md) - Async mutual exclusion lock
+- [AsyncKeyedLock](asynckeyedlock.md) - Per-key async exclusion
 - [AsyncCountdownEvent](asynccountdownevent.md) - Async countdown event
 - [AsyncBarrier](asyncbarrier.md) - Async barrier synchronization primitive
 - [AsyncSemaphore](asyncsemaphore.md) - Async semaphore primitive

--- a/docfx/packages/threading/asyncreaderwriterlock.md
+++ b/docfx/packages/threading/asyncreaderwriterlock.md
@@ -1,4 +1,4 @@
-﻿# AsyncReaderWriterLock
+# AsyncReaderWriterLock
 
 A pooled, allocation-free async reader-writer lock that supports multiple concurrent readers or a single exclusive writer using ValueTask-based waiters with cancellation tokens.
 
@@ -194,6 +194,8 @@ Asynchronously acquires a writer lock, or throws `TimeoutException` if the timeo
 | `TimeSpan.Zero` and contested | No (immediate exception) |
 | Finite positive timeout | Yes — one instance, disposed on await |
 
+An already-cancelled token is checked before the zero timeout, on every acquisition method here and on `UpgradeToWriterLockAsync`: passing both a cancelled token and `TimeSpan.Zero` throws `OperationCanceledException` carrying that token, not a `TimeoutException`. This matches the other primitives in the package.
+
 ### Allocation Behavior
 
 Immediate lock acquisitions via the fast path are completely allocation-free using atomic operations. When the lock is contended, waiting without a timeout is allocation-free on .NET 6.0+ (using `UnsafeRegister` for cancellation), while older frameworks may allocate for cancellation registration. Specifying a finite timeout allocates a timer that is automatically disposed when the operation completes. Exception and task allocations occur only if a timeout actually elapses or cancellation is triggered; successful acquisitions are otherwise allocation-free. Pooled `IValueTaskSource<Releaser>` instances are reused to minimize allocation pressure across repeated lock operations.
@@ -334,6 +336,7 @@ catch (TimeoutException)
 - [AsyncAutoResetEvent](asyncautoresetevent.md) - Auto-reset event variant
 - [AsyncManualResetEvent](asyncmanualresetevent.md) - Manual-reset event variant
 - [AsyncLock](asynclock.md) - Async mutual exclusion lock
+- [AsyncKeyedLock](asynckeyedlock.md) - Per-key async exclusion
 - [AsyncCountdownEvent](asynccountdownevent.md) - Async countdown event
 - [AsyncBarrier](asyncbarrier.md) - Async barrier synchronization primitive
 - [AsyncSemaphore](asyncsemaphore.md) - Async semaphore primitive

--- a/docfx/packages/threading/asyncsemaphore.md
+++ b/docfx/packages/threading/asyncsemaphore.md
@@ -1,4 +1,4 @@
-﻿# AsyncSemaphore
+# AsyncSemaphore
 
 A pooled, allocation-free async semaphore that limits concurrent access using ValueTask-based waiters.
 
@@ -221,6 +221,7 @@ catch (TimeoutException)
 - [AsyncManualResetEvent](asyncmanualresetevent.md) - Manual-reset event variant
 - [AsyncReaderWriterLock](asyncreaderwriterlock.md) - Async reader-writer lock
 - [AsyncLock](asynclock.md) - Async mutual exclusion lock
+- [AsyncKeyedLock](asynckeyedlock.md) - Per-key async exclusion
 - [AsyncCountdownEvent](asynccountdownevent.md) - Async countdown event
 - [AsyncBarrier](asyncbarrier.md) - Async barrier synchronization primitive
 - [Benchmarks](benchmarks.md) - Benchmark description

--- a/docfx/packages/threading/benchmark-trends/index.html
+++ b/docfx/packages/threading/benchmark-trends/index.html
@@ -12,6 +12,10 @@
   fieldset.mode-toggle label { font-size: 0.9rem; display: flex; align-items: center; gap: 0.3rem; }
   .controls { display: flex; gap: 1rem; flex-wrap: wrap; margin: 1rem 0 1.5rem; align-items: flex-start; }
   .controls > label { display: flex; flex-direction: column; font-size: 0.85rem; color: #444; }
+  /* The `hidden` attribute has to beat the rule above: the UA stylesheet's [hidden] { display: none }
+     loses to any author rule that sets display, so a picker hidden from JS stayed on screen — and in
+     the chart modes it read as a control that simply did nothing. */
+  .controls > label[hidden] { display: none; }
   select { margin-top: 0.25rem; padding: 0.3rem; min-width: 180px; }
   #status { color: #666; font-size: 0.9rem; margin-bottom: 1rem; }
   /* A control the current view ignores. Disabled rather than hidden: it keeps the layout
@@ -144,17 +148,16 @@
   </p>
 
   <p class="hint">
-  The chart modes plot one point per recorded run. Hovering a point gives the commit, the value,
-  the .NET runtime it was measured on, and the version of the reference library where one
-  applies. <strong>Trend over time</strong> plots every recorded parameter combination for the
-  current filters; the line-style legend hides individual combinations.
-  <strong>Scaling by contention</strong> plots the benchmark's parameterized axis — queued
-  waiters for most classes, distinct keys or threads for the keyed locks — using each
-  implementation's most recent run. It draws every cancellation state and both metrics together:
-  color identifies the implementation, line style the cancellation state, mean time is read from
-  the left axis and allocation from the right. All three legends toggle. The Cancellation and
-  Metric selectors apply to <strong>Trend over time</strong>, and are disabled in the other two
-  views. Methods with no parameterized axis show a single point per implementation.</p>
+  Hovering a point gives the commit, the value, the .NET runtime it was measured on, and the
+  version of the reference library where one applies. <strong>Trend over time</strong> plots one
+  point per recorded run, for every recorded parameter combination under the current filters; the
+  line-style legend hides individual combinations, and Cancellation, Metric and Date range apply
+  here. <strong>Scaling by contention</strong> plots the benchmark's parameterized axis — queued
+  waiters for most classes, distinct keys or threads for the keyed locks — for a single run, the
+  newest by default and any recorded one through the Run picker. It draws every cancellation state
+  and both metrics together: color identifies the implementation, line style the cancellation
+  state, mean time is read from the left axis and allocation from the right. All three legends
+  toggle. Methods with no parameterized axis show a single point per implementation.</p>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
@@ -409,12 +412,12 @@
     params.set("range", dateRangeSel.value);
     params.set("mode", currentMode());
     params.set("log", logScaleCb.checked ? "1" : "0");
-    // Only in table mode, where which run is on screen is the whole point of the link. In the
-    // chart modes the run set is derived from the filters, so recording it would pin a link to a
-    // run that a later import may push out of view.
-    if (currentMode() === "table") {
+    // Only in the two single-run views, where which run is on screen is the whole point of the
+    // link. Trend derives its run set from the filters, so recording one there would pin a link to
+    // a run that a later import may push out of view. The comparison is table-only.
+    if (currentMode() !== "trend") {
       if (runSel.value) params.set("run", runSel.value);
-      if (compareSel.value) params.set("compare", compareSel.value);
+      if (currentMode() === "table" && compareSel.value) params.set("compare", compareSel.value);
     }
     const newHash = "#" + params.toString();
     if (location.hash !== newHash) history.replaceState(null, "", newHash);
@@ -642,7 +645,8 @@
   //             metrics are columns, so neither selector applies; the run picker replaces the
   //             date range, and there is no chart to scale logarithmically.
   //   Scaling - plots both metrics on two axes and every cancellation state as its own dash
-  //             pattern, so those two selectors are replaced by their legends.
+  //             pattern, so those two selectors are replaced by their legends; it draws one run
+  //             chosen with the run picker, which leaves the date range nothing to narrow.
   //   Trend   - reads all of them.
   function syncControlAvailability(mode) {
     const table = mode === "table";
@@ -653,7 +657,9 @@
     setInert(metricPickerEl, table || scaling,
              table ? "The table shows mean time and allocation as separate columns."
                    : "Scaling plots both metrics on two axes - use the metric legend below.");
-    setInert(rangePickerEl, table, "The table shows one run, chosen with the Run picker.");
+    setInert(rangePickerEl, table || scaling,
+             table ? "The table shows one run, chosen with the Run picker."
+                   : "Scaling plots one run, chosen with the Run picker.");
     setInert(logPickerEl, table, "No chart axis to scale in table mode.");
   }
 
@@ -777,51 +783,56 @@
     { key: "allocated_bytes", axis: "yAlloc", point: "rectRot", text: "Allocated" },
   ];
 
+  // One recorded run's contention curve, chosen with the Run picker - the newest by default, which
+  // is what this view used to show and all it used to be able to show. Reading a scaling curve
+  // means reading one snapshot: rows stitched together from whichever run happened to be each
+  // series' latest would put a variant measured months ago on the same axes as one measured
+  // yesterday and present the pair as a comparison.
   function renderScalingChart() {
-    const cutoff = dateRangeCutoffIso();
+    const runValue = runSel.value;
+    const [runId, runPlatform, runFramework] = (runValue || "").split(" ");
     // Some methods (e.g. AsyncRWLock's WriterLock) aren't contention-parameterized at all - every
     // row has a NULL param_label. Requiring "param_label IS NOT NULL" unconditionally would leave
     // those with zero rows and an empty chart; fall back to the NULL-param rows instead, same as
     // renderTrendChart already does, so every method plots something in both view modes.
     const hasRealParams = currentParams.length > 0;
     const paramClause = hasRealParams ? "AND r.param_label IS NOT NULL" : "AND r.param_label IS NULL";
-    const stmt = db.prepare(`
-      SELECT r.variant, r.cancellation, r.param_value, r.param_label, r.run_date, r.run_id,
-             r.commit_sha, b.runtime_version, r.mean_ns, r.allocated_bytes
-      FROM benchmark_results r
-      LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
-      WHERE r.platform = ? AND r.framework = ? AND r.family = ? AND r.method = ? ${paramClause}
-        ${cutoff ? "AND r.run_date >= ?" : ""}
-      ORDER BY r.variant, r.cancellation, r.param_value, r.run_date
-    `);
-    stmt.bind([platformSel.value, frameworkSel.value, familySel.value, methodSel.value,
-               ...(cutoff ? [cutoff] : [])]);
 
-    // ORDER BY run_date ASC means the last row seen for a given (variant, cancellation, level) is
-    // the most recent recorded run within the selected date range - exactly the one we want for a
-    // "current scaling" snapshot (or a rewind, if a shorter range is selected). When there's no
-    // real contention level, every row's param_value is NULL, so key on a single fixed bucket (0)
-    // instead - there's only ever one point per series in that case anyway.
-    const latest = new Map();      // "variant\u001fcancellation" -> Map(x -> row)
+    // When there's no real contention level, every row's param_value is NULL, so key on a single
+    // fixed bucket (0) instead - there's only ever one point per series in that case anyway.
+    const rowsByKey = new Map();   // "variant\u001fcancellation" -> Map(x -> row)
     const variantOrder = [];
     const cancellations = [];
-    while (stmt.step()) {
-      const row = stmt.getAsObject();
-      const x = hasRealParams ? row.param_value : 0;
-      const key = `${row.variant}\u001f${row.cancellation}`;
-      if (!latest.has(key)) latest.set(key, new Map());
-      latest.get(key).set(x, row);
-      if (!variantOrder.includes(row.variant)) variantOrder.push(row.variant);
-      if (!cancellations.includes(row.cancellation)) cancellations.push(row.cancellation);
+    if (runValue) {
+      const stmt = db.prepare(`
+        SELECT r.variant, r.cancellation, r.param_value, r.param_label, r.run_id,
+               r.commit_sha, b.runtime_version, r.mean_ns, r.allocated_bytes
+        FROM benchmark_results r
+        LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform
+                                  AND b.framework = r.framework
+        WHERE r.run_id = ? AND r.platform = ? AND r.framework = ?
+          AND r.family = ? AND r.method = ? ${paramClause}
+        ORDER BY r.variant, r.cancellation, r.param_value
+      `);
+      stmt.bind([runId, runPlatform, runFramework, familySel.value, methodSel.value]);
+      while (stmt.step()) {
+        const row = stmt.getAsObject();
+        const x = hasRealParams ? row.param_value : 0;
+        const key = `${row.variant}\u001f${row.cancellation}`;
+        if (!rowsByKey.has(key)) rowsByKey.set(key, new Map());
+        rowsByKey.get(key).set(x, row);
+        if (!variantOrder.includes(row.variant)) variantOrder.push(row.variant);
+        if (!cancellations.includes(row.cancellation)) cancellations.push(row.cancellation);
+      }
+      stmt.free();
     }
-    stmt.free();
 
     const DASH_PATTERNS = [[], [6, 3], [2, 2], [8, 3, 2, 3], [1, 3]];
     const dashFor = new Map(cancellations.map((c, i) => [c, DASH_PATTERNS[i % DASH_PATTERNS.length]]));
     const multiCancellation = cancellations.length > 1;
 
     const datasets = [];
-    for (const [key, byX] of latest) {
+    for (const [key, byX] of rowsByKey) {
       const [variant, cancellation] = key.split("\u001f");
       const points = Array.from(byX.values()).sort((a, b) => a.x - b.x);
       for (const metric of METRICS) {
@@ -838,7 +849,7 @@
             param_label: hasRealParams ? r.param_label : "single scenario",
             commit: r.commit_sha,
             runtime: r.runtime_version,
-            pkg: packageLabel(variant, r.run_id, platformSel.value, frameworkSel.value),
+            pkg: packageLabel(variant, r.run_id, runPlatform, runFramework),
           })),
           yAxisID: metric.axis,
           borderColor: familyColors.get(variant),
@@ -901,9 +912,11 @@
              .map((m) => ({ metric: m.key, text: m.text }))
     );
 
+    const chosen = Array.from(runSel.options).find((o) => o.value === runValue);
     const visibleCount = datasets.filter((d) => !d.hidden).length;
     statusEl.textContent = datasets.length
-      ? `${visibleCount} of ${datasets.length} series shown` + (hasRealParams ? "" : " (single scenario)")
+      ? `${visibleCount} of ${datasets.length} series shown` + (hasRealParams ? "" : " (single scenario)") +
+        ", from " + (chosen ? chosen.textContent.trim() : "the selected run")
       : "No data for this selection yet.";
   }
 
@@ -1000,7 +1013,13 @@
   // Every (run, platform) carrying rows for the current family+method, newest first. Both pickers
   // are filled from this, which is what makes "macOS vs Windows at the same commit" fall out for
   // free: those two share a run_id and differ only in platform.
-  function availableRuns() {
+  //
+  // Scaling mode passes scoped=true and gets only the platform and framework already selected
+  // above: there the cascade decides which machine is on screen and the run picker only decides
+  // when, so offering another machine's runs would put the two selectors in disagreement. Table
+  // mode deliberately offers all of them - two machines side by side is what its compare column
+  // is for.
+  function availableRuns(scoped) {
     const stmt = db.prepare(
       "SELECT DISTINCT r.run_id, r.platform, r.framework, r.run_date, r.commit_sha, " +
       "       b.runtime_version " +
@@ -1008,9 +1027,11 @@
       "LEFT JOIN benchmark_runs b ON b.run_id = r.run_id AND b.platform = r.platform " +
       "                          AND b.framework = r.framework " +
       "WHERE r.family = ? AND r.method = ? " +
+      (scoped ? "  AND r.platform = ? AND r.framework = ? " : "") +
       "ORDER BY r.run_date DESC, r.platform, r.framework"
     );
-    stmt.bind([familySel.value, methodSel.value]);
+    stmt.bind([familySel.value, methodSel.value,
+               ...(scoped ? [platformSel.value, frameworkSel.value] : [])]);
     const runs = [];
     while (stmt.step()) runs.push(stmt.getAsObject());
     stmt.free();
@@ -1027,8 +1048,8 @@
     return date + " · " + run.platform + fw + " · " + sha + rt;
   }
 
-  function refreshRunPickers() {
-    const runs = availableRuns();
+  function refreshRunPickers(mode) {
+    const runs = availableRuns(mode === "scaling");
     const previousRun = runSel.value;
     const previousCompare = compareSel.value;
 
@@ -1040,8 +1061,15 @@
       runSel.appendChild(opt);
     }
     // Default to the newest run on the platform already selected above, so switching into table
-    // mode shows the data the charts were showing rather than jumping to another machine.
-    const preferred = runs.find((r) => r.platform === platformSel.value
+    // mode shows the data the charts were showing rather than jumping to another machine. Ahead of
+    // that, keep the same commit if the new platform also recorded it: switching platform on a
+    // pinned run asks "and what does this commit do over there", which is the comparison the
+    // archive keys runs by commit to make possible - not "show me something newer".
+    const previousRunId = previousRun.split(" ")[0];
+    const preferred = runs.find((r) => r.run_id === previousRunId
+                                   && r.platform === platformSel.value
+                                   && r.framework === frameworkSel.value)
+                   || runs.find((r) => r.platform === platformSel.value
                                    && r.framework === frameworkSel.value)
                    || runs.find((r) => r.platform === platformSel.value)
                    || runs[0];
@@ -1297,6 +1325,7 @@
   function renderChart() {
     const mode = currentMode();
     const isTable = mode === "table";
+    const isScaling = mode === "scaling";
 
     chartContainerEl.hidden = isTable;
     legendColorsEl.hidden = isTable;
@@ -1305,13 +1334,15 @@
     if (isTable) legendHintEl.hidden = true;   // otherwise left to renderColorLegend below
     tableContainerEl.hidden = !isTable;
     tableNoteEl.hidden = !isTable;
-    runPickerEl.hidden = !isTable;
+    // Both single-run views need the run picker; only the table can hold two runs at once.
+    runPickerEl.hidden = !(isTable || isScaling);
     comparePickerEl.hidden = !isTable;
 
     if (isTable) {
-      refreshRunPickers();
+      refreshRunPickers(mode);
       renderTableView();
-    } else if (mode === "scaling") {
+    } else if (isScaling) {
+      refreshRunPickers(mode);
       renderScalingChart();
     } else {
       renderTrendChart();
@@ -1368,9 +1399,10 @@
     dateRangeSel.onchange = renderChart;
     logScaleCb.onchange = renderChart;
     modeRadios.forEach((r) => (r.onchange = renderChart));
-    // The run picker drives which run the table shows; changing it also rebuilds the comparison
-    // list, since the currently-shown run must not appear as its own comparison.
-    runSel.onchange = () => { refreshRunPickers(); renderTableView(); syncUrlHash(); };
+    // Straight through renderChart so the run picker drives whichever single-run view is showing -
+    // the table or the scaling chart. It rebuilds the comparison list on the way (the shown run
+    // must not appear as its own comparison) and keeps the just-chosen run selected.
+    runSel.onchange = renderChart;
     compareSel.onchange = () => { renderTableView(); syncUrlHash(); };
     copyLinkBtn.onclick = async () => {
       try {

--- a/docfx/packages/threading/benchmarks.md
+++ b/docfx/packages/threading/benchmarks.md
@@ -8,7 +8,7 @@ BenchmarkDotNet is used for microbenchmarks. Benchmarks live under `tests/Thread
 
 ### Viewing Benchmark Results
 
-Published results live in the interactive benchmark trends dashboard below rather than static per-platform pages. The dashboard loads a small SQLite database client-side (no server) and lets you pick platform, primitive family, and operation, plotting every matching implementation as its own line — including a scaling-by-contention view and trend-over-time comparisons. Because `platform` is a free-form value in the database, results from any contributor's machine can appear side by side, not just a fixed set of CI hosts.
+Published results live in the interactive benchmark trends dashboard below rather than static per-platform pages. The dashboard loads a small SQLite database client-side (no server) and lets you pick platform, primitive family, and operation, plotting every matching implementation as its own line — including a scaling-by-contention view and trend-over-time comparisons. The single-run views — the table and the scaling chart — take any recorded run from the Run picker, not just the newest. Because `platform` is a free-form value in the database, results from any contributor's machine can appear side by side, not just a fixed set of CI hosts.
 
 <iframe src="benchmark-trends/index.html" style="width:100%; height:900px; border:1px solid var(--border-color, #ddd); border-radius:6px;" loading="lazy" title="Threading benchmark trends dashboard"></iframe>
 

--- a/docfx/packages/threading/index.md
+++ b/docfx/packages/threading/index.md
@@ -102,6 +102,38 @@ public async Task AccessSharedResourceAsync(CancellationToken ct)
 }
 ```
 
+### AsyncKeyedLock
+
+```csharp
+private readonly AsyncKeyedLock<string> _locksByAccount = new AsyncKeyedLock<string>();
+
+public async Task UpdateAccountAsync(string accountId, CancellationToken ct)
+{
+    using (await _locksByAccount.LockAsync(accountId, ct))
+    {
+        // Serialized per account - operations on other accounts run in parallel
+        await ApplyChangesAsync(accountId);
+    }
+}
+```
+
+`TryLock` acquires only if the key is free right now. It never waits and never allocates, which
+suits opportunistic work that can be skipped when someone else already holds the key:
+
+```csharp
+public void RefreshIfIdle(string accountId)
+{
+    if (_locksByAccount.TryLock(accountId, out var releaser))
+    {
+        using (releaser)
+        {
+            RefreshCache(accountId);
+        }
+    }
+    // Held by someone else - skip; the refresh will happen on their release
+}
+```
+
 ### AsyncAutoResetEvent
 
 ```csharp
@@ -154,6 +186,29 @@ public async Task AccessLimitedResourceAsync(CancellationToken ct)
     {
         // Max 3 concurrent tasks can access this section
         await AccessResourceAsync();
+    }
+    finally
+    {
+        _semaphore.Release();
+    }
+}
+
+// Shed load instead of queueing indefinitely: give up after two seconds
+public async Task<bool> TryAccessAsync(CancellationToken ct)
+{
+    try
+    {
+        await _semaphore.WaitAsync(TimeSpan.FromSeconds(2), ct);
+    }
+    catch (TimeoutException)
+    {
+        return false; // no permit came free in time
+    }
+
+    try
+    {
+        await AccessResourceAsync();
+        return true;
     }
     finally
     {
@@ -219,11 +274,48 @@ public async Task WriteAsync(CancellationToken ct)
         await WriteDataAsync();
     }
 }
+
+// Writer that would rather fail fast than block a request thread behind long readers
+public async Task<bool> TryWriteAsync(CancellationToken ct)
+{
+    try
+    {
+        using (await _rwLock.WriterLockAsync(TimeSpan.FromMilliseconds(250), ct))
+        {
+            await WriteDataAsync();
+            return true;
+        }
+    }
+    catch (TimeoutException)
+    {
+        return false;
+    }
+}
 ```
 
 ## Timeout Support
 
-Every synchronization primitive accepts an optional timeout, so you can attempt a non-blocking acquire or build timeout-based retry logic instead of waiting indefinitely:
+Every wait and every acquisition takes an optional timeout, as an overload that sits in front of the `CancellationToken`:
+
+| Primitive | Method taking a timeout |
+|-----------|-------------------------|
+| `AsyncLock` | `LockAsync(TimeSpan, CancellationToken)` |
+| `AsyncKeyedLock<TKey>` | `LockAsync(TKey, TimeSpan, CancellationToken)` — plus `TryLock(TKey, out Releaser)`, which never waits at all |
+| `AsyncSemaphore` | `WaitAsync(TimeSpan, CancellationToken)` |
+| `AsyncAutoResetEvent` | `WaitAsync(TimeSpan, CancellationToken)` |
+| `AsyncManualResetEvent` | `WaitAsync(TimeSpan, CancellationToken)` |
+| `AsyncCountdownEvent` | `WaitAsync(TimeSpan, CancellationToken)` |
+| `AsyncBarrier` | `SignalAndWaitAsync(TimeSpan, CancellationToken)` |
+| `AsyncReaderWriterLock` | `ReaderLockAsync` / `UpgradeableReaderLockAsync` / `WriterLockAsync(TimeSpan, CancellationToken)`, and `UpgradeToWriterLockAsync(TimeSpan, CancellationToken)` on an upgradeable releaser |
+
+The semantics are the same across every primitive:
+
+- Elapsing throws `TimeoutException`; the wait is abandoned and nothing is acquired.
+- `Timeout.InfiniteTimeSpan` waits indefinitely, exactly like the overload without a timeout.
+- `TimeSpan.Zero` is an immediate attempt — it either succeeds or throws right away.
+- Any other negative value throws `ArgumentOutOfRangeException`.
+- An already-cancelled token wins over a zero timeout: you get `OperationCanceledException`, which carries the token, rather than a `TimeoutException` that names neither.
+- The timer costs nothing until it is needed. Nothing is allocated when the primitive is available immediately, when the timeout is infinite, or when a zero timeout fails outright — only a genuine wait on a finite timeout allocates one, and it is disposed when the `ValueTask` is awaited.
 
 ```csharp
 // Non-blocking attempt using TimeSpan.Zero
@@ -237,6 +329,27 @@ try
 catch (TimeoutException)
 {
     // Lock not immediately available
+}
+```
+
+```csharp
+// Per-key timeout: a slow tenant delays only callers working on that tenant
+private readonly AsyncKeyedLock<string> _locksByTenant = new AsyncKeyedLock<string>();
+
+public async Task<bool> TryImportAsync(string tenantId, CancellationToken ct)
+{
+    try
+    {
+        using (await _locksByTenant.LockAsync(tenantId, TimeSpan.FromSeconds(5), ct))
+        {
+            await ImportAsync(tenantId);
+            return true;
+        }
+    }
+    catch (TimeoutException)
+    {
+        return false; // another import for this tenant is still running
+    }
 }
 ```
 

--- a/docfx/porting-to-cryptohives.md
+++ b/docfx/porting-to-cryptohives.md
@@ -25,7 +25,7 @@ mapping below, leave it unchanged and record it in the "Unmapped" report at the 
    `ValueTask`/`ValueTask<T>`. It may be awaited **exactly once** and must never be stored
    in a field, awaited twice, `.Result`-ed, or passed to `Task.WhenAll`/`WhenAny`. The
    `CryptoHives.Foundation.Threading.Analyzers` package enforces this — **add it and treat
-   its diagnostics as the source of truth** (see §2.4).
+   its diagnostics as the source of truth** (see §2.5).
 4. Match surrounding code style: nullable is enabled, warnings are errors in this repo;
    any code you add must compile clean under `TreatWarningsAsErrors=true`.
 
@@ -77,7 +77,9 @@ If the target project uses Central Package Management (`Directory.Packages.props
 | `CountdownEvent` awaited async | `AsyncCountdownEvent` | |
 | `Barrier` awaited async | `AsyncBarrier` | |
 | `ReaderWriterLockSlim` awaited async | `AsyncReaderWriterLock` | |
-| `Nito.AsyncEx.AsyncLock`, `NeoSmart.AsyncLock`, `AsyncKeyedLock` (single-key) | `AsyncLock` | Verify the source did not rely on reentrancy. |
+| `Dictionary<TKey, SemaphoreSlim>` / a registry of one lock per key | `AsyncKeyedLock<TKey>` | Distinct keys never block each other; released keys stay cached, so repeat acquisitions allocate nothing. |
+| `AsyncKeyedLock` (the third-party package), `KeyedSemaphores`, `AsyncDuplicateLock` | `AsyncKeyedLock<TKey>` | Same per-key semantics, without the striping some libraries use. |
+| `Nito.AsyncEx.AsyncLock`, `NeoSmart.AsyncLock`, `AsyncKeyedLock` used without keys | `AsyncLock` | Verify the source did not rely on reentrancy. |
 
 ### 2.2 `AsyncLock` — exact usage
 
@@ -139,9 +141,39 @@ Note: there is **no** `SemaphoreSlim`-style bool-returning `WaitAsync(timeout)`.
 pattern `if (await sem.WaitAsync(timeout)) { … }` must be rewritten to try/catch on
 `TimeoutException`, or use a `CancellationToken`.
 
-### 2.4 Enforce correctness with the analyzer
+### 2.4 `AsyncKeyedLock<TKey>` — exact usage
 
-After porting, build. The analyzer emits (see `CLAUDE.md` for the full table):
+```csharp
+private readonly AsyncKeyedLock<string> _locks = new();
+
+public async Task UpdateAsync(string id, CancellationToken ct)
+{
+    using (await _locks.LockAsync(id, ct))      // other ids proceed in parallel
+    {
+        await MutateAsync(id);
+    }
+}
+```
+
+Signatures actually present:
+
+- `AsyncKeyedLock(IEqualityComparer<TKey>? comparer = null, IGetPooledManualResetValueTaskSource<Releaser>? pool = null, int maxIdleEntries = 128, int maxRetainedWaiters = 128)`
+- `ValueTask<Releaser> LockAsync(TKey key, CancellationToken cancellationToken = default)`
+- `ValueTask<Releaser> LockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default)`
+- `bool TryLock(TKey key, out Releaser releaser)` — never waits and never allocates
+- `bool IsInUse(TKey key)` / `int Count { get; }` — best-effort diagnostics, not synchronization
+
+Rules:
+- **Not reentrant**, exactly like `AsyncLock`: re-acquiring the same key on one call stack deadlocks.
+- Hold **one instance** for the lifetime of the component. A new instance per call gets its own
+  registry and serializes nothing.
+- `maxIdleEntries` bounds key cardinality and `maxRetainedWaiters` bounds simultaneous contention;
+  past either the lock still works, it just stops being allocation-free.
+
+### 2.5 Enforce correctness with the analyzer
+
+After porting, build. The analyzer emits (full descriptions:
+<https://cryptohives.github.io/Foundation/packages/threading.analyzers/index.html>):
 
 | ID | Meaning — fix |
 |---|---|
@@ -149,11 +181,14 @@ After porting, build. The analyzer emits (see `CLAUDE.md` for the full table):
 | CHT002 (Warn) | `.GetAwaiter().GetResult()` on `ValueTask` — make the caller async and `await`. |
 | CHT003 (Warn) | `ValueTask` stored in a field — don't; await it locally. |
 | CHT005 (Warn) | `.Result` on a `ValueTask` — `await` instead. |
+| CHT007 (Info) | `AsTask()` stored before the primitive signals — await the `ValueTask` directly. |
 | CHT008 (Warn) | `ValueTask` not awaited/consumed. |
 | CHT009 (Info) | `SemaphoreSlim(1,1)` — switch to `AsyncLock`. |
 | CHT010 (Warn) | `ValueTask` captured in a lambda/closure. |
+| CHT011 (Warn) | `async` method only forwards an awaited `ValueTask` — return it directly. |
+| CHT012 (Info) | `async` `ValueTask` wrapper boxes a state machine when it suspends. |
 
-Resolve every CHT00x before considering the async phase done. Do not suppress them to make
+Resolve every CHT0xx before considering the async phase done. Do not suppress them to make
 the build pass unless a human explicitly approves a specific instance.
 
 ---
@@ -268,7 +303,7 @@ if (seg.TrySetSegment(offset: 16, length: 64))
 // AllocatedSegment<T> — wraps an existing GC-managed array, no pool
 byte[] raw = new byte[256];
 using ISegmentOwner<byte> alloc = AllocatedSegment<byte>.Create(raw);
-Process(alloc.Segment.AsSpan());
+Process(alloc);
 // only the wrapper is cleared on Dispose; the array itself is unchanged
 
 // EmptySegment<T> — null-object sentinel
@@ -384,7 +419,7 @@ do not "upgrade" it silently.
 Work phase by phase; build + test after each:
 
 1. **Wire packages** (§1). Restore/build.
-2. **Async** (§2): swap primitives, add the analyzer, drive CHT00x to zero.
+2. **Async** (§2): swap primitives, add the analyzer, drive CHT0xx to zero.
 3. **Memory** (§3): swap buffer/stream/pool patterns; verify every new type is `using`-scoped.
 4. **Hashing** (§4): swap hash implementations; confirm identical digests.
 

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -5,6 +5,7 @@
 - name: Porting Guide
   href: porting-to-cryptohives.md
 - name: Packages
+  href: packages/index.md
   items:
     - name: Memory
       href: packages/memory/index.md
@@ -17,7 +18,13 @@
           href: packages/security/index.md
         - name: Cryptography
           href: packages/security/cryptography/index.md
+- name: Benchmarks
+  items:
+    - name: Threading
+      href: packages/threading/benchmarks.md
+    - name: Cryptography
+      href: packages/security/cryptography/benchmarks.md
 - name: API Documentation
-  href: api/
+  href: api/index.md
 - name: Impressum
   href: impressum.md

--- a/src/Memory/README.md
+++ b/src/Memory/README.md
@@ -88,11 +88,13 @@ await DeserializeFromStreamAsync(stream, ct).ConfigureAwait(false);
 
 ```csharp
 using CryptoHives.Foundation.Memory.Pools;
+using Microsoft.Extensions.ObjectPool;
 
-var pool = ObjectPools.Create<MyExpensiveObject>();
+// Any Microsoft.Extensions.ObjectPool pool works; PoolFactory has ready-made ones
+ObjectPool<MyExpensiveObject> pool = ObjectPool.Create<MyExpensiveObject>();
 
 using var owner = new ObjectOwner<MyExpensiveObject>(pool);
-MyExpensiveObject obj = owner.Object;
+MyExpensiveObject obj = owner.PooledObject;
 
 // Use obj...
 
@@ -131,7 +133,7 @@ ISegmentOwner<byte> none = EmptySegment<byte>.Instance;
 | Resource | Link |
 |----------|------|
 | Full package documentation | [cryptohives.github.io/Foundation/packages/memory](https://cryptohives.github.io/Foundation/packages/memory/index.html) |
-| API reference | [cryptohives.github.io/Foundation/api](https://cryptohives.github.io/Foundation/api/index.html) |
+| API reference | [cryptohives.github.io/…/api/…Memory.Buffers](https://cryptohives.github.io/Foundation/api/CryptoHives.Foundation.Memory.Buffers.html) |
 | Source repository | [github.com/CryptoHives/Foundation](https://github.com/CryptoHives/Foundation) |
 
 ---

--- a/src/Security/Cryptography/PORTING.md
+++ b/src/Security/Cryptography/PORTING.md
@@ -3,8 +3,8 @@
 Machine-readable usage + porting guide for coding assistants. All APIs below are verified
 against the shipped source. Do not invent members. Human-oriented docs live in `README.md`.
 
-- **Package:** `CryptoHives.Foundation.Security.Cryptography` (published as a `-beta`
-  pre-release; API surface may still change)
+- **Package:** `CryptoHives.Foundation.Security.Cryptography` (0.x — the API is pre-1.0
+  and may still change between minor versions)
 - **Root namespace:** `CryptoHives.Foundation.Security.Cryptography` with sub-namespaces
   `.Hash`, `.Mac`, `.Kdf`, `.Cipher`
 - **What it is:** fully managed, deterministic, cross-platform implementations of hashes,

--- a/src/Security/Cryptography/README.md
+++ b/src/Security/Cryptography/README.md
@@ -11,7 +11,7 @@ An open, community-driven collection of cryptography and performance libraries f
 
 Fully managed, OS-independent implementations of hash, MAC, KDF, and cipher algorithms for .NET, written directly from NIST/RFC/ISO specifications and checked against official test vectors.
 
-No OS crypto dependency means deterministic results on every platform. Where the hardware supports it, AES-NI, PCLMULQDQ, VPCLMULQDQ, SSE2, SSSE3, and AVX2 intrinsics are used automatically.
+No OS crypto dependency means deterministic results on every platform. Where the hardware supports it, intrinsics are used automatically — AES-NI, PCLMULQDQ/VPCLMULQDQ, SSE2, SSSE3, AVX2 and AVX-512 on x86/x64; ARM AES, ARM SHA-1/SHA-2, PMULL and NEON on Arm64.
 
 ---
 
@@ -27,7 +27,7 @@ dotnet add package CryptoHives.Foundation.Security.Cryptography
 
 - **OS-independent** — identical results on Windows, Linux, macOS, and anywhere else .NET runs
 - **Standards-based** — implemented from NIST, RFC, and ISO specifications; validated against official test vectors
-- **Hardware-accelerated** — automatic AES-NI, AVX2, SSSE3 dispatch, with a scalar fallback always available
+- **Hardware-accelerated** — automatic dispatch across AES-NI/AVX2/AVX-512 and the Arm64 crypto and NEON paths, with a scalar fallback always available
 - **Allocation-free hot paths** — `Span<byte>`-based APIs, friendly to `stackalloc`
 - **XOF streaming** — `IExtendableOutput` (`Absorb` / `Squeeze` / `Reset`) on all XOF algorithms
 - **`HashAlgorithm` compatible** — drop-in for anything consuming `System.Security.Cryptography.HashAlgorithm`
@@ -75,7 +75,7 @@ blake3.TryComputeHash(data, hash, out _);
 using CryptoHives.Foundation.Security.Cryptography.Hash;
 
 // Variable-length output via IExtendableOutput
-using var shake = Shake256.Create(outputLength: 64);
+using var shake = Shake256.Create(outputBytes: 64);
 shake.Absorb(context);
 shake.Absorb(message);
 
@@ -91,13 +91,17 @@ using CryptoHives.Foundation.Security.Cryptography.Mac;
 
 using var hmac = new HmacSha256(key);
 Span<byte> tag = stackalloc byte[32];
-hmac.TryComputeHash(message, tag, out _);
+
+hmac.Update(message);      // call as often as needed
+hmac.Finalize(tag);        // writes the 32-byte tag
+hmac.Reset();              // reuse the instance for the next message
 ```
 
 ### Authenticated Encryption (`AES-GCM`)
 
 ```csharp
 using CryptoHives.Foundation.Security.Cryptography.Cipher;
+using System.Security.Cryptography;   // for CryptographicException
 
 using var aesGcm = new AesGcm256(key);
 
@@ -121,9 +125,9 @@ if (!aesGcm.Decrypt(nonce, ciphertext, tag, recovered, associatedData))
 using CryptoHives.Foundation.Security.Cryptography.Hash;
 
 using var cshake = CShake128.Create(
-    functionName: "MyApp"u8,
-    customization: "v1"u8,
-    outputLength: 32);
+    outputBytes: 32,
+    functionName: "MyApp"u8.ToArray(),
+    customization: "v1"u8.ToArray());
 
 cshake.Absorb(input);
 Span<byte> derived = stackalloc byte[32];
@@ -140,9 +144,9 @@ cshake.Squeeze(derived);
 | Hash algorithms guide | [cryptohives.github.io/…/hash-algorithms](https://cryptohives.github.io/Foundation/packages/security/cryptography/hash-algorithms.html) |
 | Cipher algorithms guide | [cryptohives.github.io/…/cipher-algorithms](https://cryptohives.github.io/Foundation/packages/security/cryptography/cipher-algorithms.html) |
 | XOF mode guide | [cryptohives.github.io/…/xof-mode](https://cryptohives.github.io/Foundation/packages/security/cryptography/xof-mode.html) |
-| Hash benchmarks | [cryptohives.github.io/…/benchmarks-hash](https://cryptohives.github.io/Foundation/packages/security/cryptography/benchmarks-hash.html) |
-| Cipher benchmarks | [cryptohives.github.io/…/benchmarks-cipher](https://cryptohives.github.io/Foundation/packages/security/cryptography/benchmarks-cipher.html) |
-| API reference | [cryptohives.github.io/Foundation/api](https://cryptohives.github.io/Foundation/api/index.html) |
+| Benchmarks (interactive dashboard) | [cryptohives.github.io/…/benchmarks](https://cryptohives.github.io/Foundation/packages/security/cryptography/benchmarks.html) |
+| MAC algorithms guide | [cryptohives.github.io/…/mac-algorithms](https://cryptohives.github.io/Foundation/packages/security/cryptography/mac-algorithms.html) |
+| API reference | [cryptohives.github.io/…/api/…Cryptography.Hash](https://cryptohives.github.io/Foundation/api/CryptoHives.Foundation.Security.Cryptography.Hash.html) |
 | Source repository | [github.com/CryptoHives/Foundation](https://github.com/CryptoHives/Foundation) |
 
 ---

--- a/src/Threading.Analyzers/README.md
+++ b/src/Threading.Analyzers/README.md
@@ -41,7 +41,7 @@ Or as a development-only dependency (no runtime reference):
 | [CHT007](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT007.html) | Info | `AsTask()` stored before signaling (causes a performance hit) |
 | [CHT008](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT008.html) | Warning | `ValueTask` not awaited or consumed |
 | [CHT009](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT009.html) | Info | `SemaphoreSlim(1, 1)` used as an async lock; consider `AsyncLock` instead |
-| [CHT010](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT010.html) | Error | `ValueTask` captured in a lambda/closure |
+| [CHT010](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT010.html) | Warning | `ValueTask` captured in a lambda/closure |
 | [CHT011](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT011.html) | Warning | `async` method only forwards an awaited `ValueTask` |
 | [CHT012](https://cryptohives.github.io/Foundation/packages/threading.analyzers/CHT012.html) | Info | `async` `ValueTask` wrapper boxes a state machine when it suspends |
 

--- a/src/Threading/PORTING.md
+++ b/src/Threading/PORTING.md
@@ -26,7 +26,9 @@ Use these when an `await` must happen inside a critical section, or to remove
 | `CountdownEvent` (async) | `AsyncCountdownEvent` | |
 | `Barrier` (async) | `AsyncBarrier` | |
 | `ReaderWriterLockSlim` (async) | `AsyncReaderWriterLock` | |
-| `Nito.AsyncEx.AsyncLock`, `NeoSmart.AsyncLock`, single-key `AsyncKeyedLock` | `AsyncLock` | Verify no reentrancy. |
+| `Dictionary<TKey, SemaphoreSlim>` / one lock per key | `AsyncKeyedLock<TKey>` | Distinct keys never block each other. Not reentrant. |
+| `AsyncKeyedLock` (third-party), `KeyedSemaphores`, `AsyncDuplicateLock` | `AsyncKeyedLock<TKey>` | |
+| `Nito.AsyncEx.AsyncLock`, `NeoSmart.AsyncLock`, `AsyncKeyedLock` used without keys | `AsyncLock` | Verify no reentrancy. |
 
 ---
 
@@ -42,6 +44,18 @@ sealed class AsyncLock {
     readonly struct Releaser : IDisposable, IAsyncDisposable; // Dispose() releases the lock
 }
 
+// AsyncKeyedLock<TKey> — per-key exclusion, NOT reentrant. Distinct keys run in parallel.
+sealed class AsyncKeyedLock<TKey> where TKey : notnull {
+    AsyncKeyedLock(IEqualityComparer<TKey>? comparer = null, …, int maxIdleEntries = 128,
+                   int maxRetainedWaiters = 128);
+    ValueTask<Releaser> LockAsync(TKey key, CancellationToken cancellationToken = default);
+    ValueTask<Releaser> LockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default);
+    bool TryLock(TKey key, out Releaser releaser);   // never waits, never allocates
+    bool IsInUse(TKey key);                          // best-effort diagnostic
+    int  Count { get; }                              // keys currently held or awaited
+    readonly struct Releaser : IDisposable, IAsyncDisposable; // Dispose() releases that key
+}
+
 // AsyncSemaphore
 sealed class AsyncSemaphore {
     AsyncSemaphore(int initialCount, bool runContinuationAsynchronously = true, …);
@@ -53,7 +67,7 @@ sealed class AsyncSemaphore {
 }
 
 // AsyncManualResetEvent / AsyncAutoResetEvent
-new AsyncManualResetEvent(initialState: false);  // Set() releases ALL waiters, stays set until Reset()
+new AsyncManualResetEvent(set: false);           // Set() releases ALL waiters, stays set until Reset()
 new AsyncAutoResetEvent(initialState: false);    // Set() releases ONE waiter, auto-resets
 //   .Set(); .Reset(); ValueTask WaitAsync(CancellationToken); ValueTask WaitAsync(TimeSpan, CancellationToken);
 
@@ -112,7 +126,7 @@ public async Task FetchAsync(CancellationToken ct)
 
 1. Add `CryptoHives.Foundation.Threading` and the `…Threading.Analyzers` package.
 2. Swap primitives per the table above; keep the `using`-based release pattern.
-3. Build and drive every `CHT001`–`CHT010` diagnostic to zero (do not suppress without human
+3. Build and drive every `CHT001`–`CHT012` diagnostic to zero (do not suppress without human
    approval). Run existing tests.
 4. Report: `file:line` → old type → new type; plus any reentrant locks / bool-timeout waits
    left unported for human review.

--- a/src/Threading/README.md
+++ b/src/Threading/README.md
@@ -157,7 +157,7 @@ public async Task<Item> DequeueAsync(CancellationToken ct)
 ### Broadcast — `AsyncManualResetEvent`
 
 ```csharp
-private readonly AsyncManualResetEvent _ready = new(initialState: false);
+private readonly AsyncManualResetEvent _ready = new(set: false);
 
 public async Task InitializeAsync()
 {
@@ -231,7 +231,7 @@ var evt = new AsyncAutoResetEvent(
 2. **Avoid calling `AsTask()` before the primitive signals.** With `RunContinuationsAsynchronously=true` (the default), storing the result of `AsTask()` too early causes a severe performance hit. Await the `ValueTask` directly wherever you can.
 3. **Always await or discard a waiter.** If it's left unconsumed, the underlying `IValueTaskSource` never makes it back to the pool.
 
-The bundled **Threading.Analyzers** package enforces these rules at compile time.
+The separate **Threading.Analyzers** package enforces these rules at compile time.
 
 ---
 
@@ -240,7 +240,7 @@ The bundled **Threading.Analyzers** package enforces these rules at compile time
 | Resource | Link |
 |----------|------|
 | Full package documentation | [cryptohives.github.io/Foundation/packages/threading](https://cryptohives.github.io/Foundation/packages/threading/index.html) |
-| API reference | [cryptohives.github.io/Foundation/api](https://cryptohives.github.io/Foundation/api/index.html) |
+| API reference | [cryptohives.github.io/…/api/…Threading.Async.Pooled](https://cryptohives.github.io/Foundation/api/CryptoHives.Foundation.Threading.Async.Pooled.html) |
 | Benchmarks | [cryptohives.github.io/Foundation/packages/threading/benchmarks](https://cryptohives.github.io/Foundation/packages/threading/benchmarks.html) |
 | Threading.Analyzers | [cryptohives.github.io/Foundation/packages/threading.analyzers](https://cryptohives.github.io/Foundation/packages/threading.analyzers/index.html) |
 | Source repository | [github.com/CryptoHives/Foundation](https://github.com/CryptoHives/Foundation) |


### PR DESCRIPTION
## Description

Benchmark dashboards
- Scaling by size now plots the run chosen in the Run picker rather than stitching together whichever run happened to be each series' latest, which could put a variant measured months ago on the same axes as one measured yesterday. The picker was visible in that mode only by accident: the author rule `.controls > label { display: flex }` beat the UA's `[hidden]`, so the control looked operable while the view ignored it.
- Both single-run views keep the run in the URL, and switching platform on a pinned run now stays on the same commit when that machine recorded it.

Cryptography memory footprint
- Re-measured every row on x64/.NET 10 by walking each instance's fields and summing the static tables per declaring type. KT128/KT256 are not constant at all (they buffer the whole message), SHA3-224 contradicted its own formula, the pooled SHA-2 state arrays are twice the logical size, Kupyna holds four arrays rather than two, and several cipher and static-table figures were out by up to 7x. Added the missing HMAC/Poly1305/CMAC/GMAC rows.

Specs page
- ParallelHash ships (with vectors in the same folder) but was listed as not implemented; BLAKE3 derive-key does not ship but was documented with a factory method that has never existed (see #237). Ascon is SP 800-232, not FIPS 207. Added the regional ciphers, Ascon-AEAD128, the KDFs, AES-CCM-192 and the HMAC-SHA3-384/512 variants.

NuGet READMEs
- Six code samples did not compile: ObjectPools.Create, owner.Object, Shake256 outputLength, HmacSha256.TryComputeHash, the cSHAKE argument list, and AsyncManualResetEvent's initialState. All samples now build against the packages.
- CHT010 is a Warning, not an Error; the Threading README no longer calls the analyzers "bundled" two paragraphs after saying they are not; the hardware list now mentions AVX-512 and the Arm64 paths.
- Repointed the links that 404 on the published site.

Site navigation
- AsyncKeyedLock reached the pages that never mentioned it, the quick examples show the timeout overloads, and Benchmarks is a top-level nav entry.
- Added api/index.md and packages/index.md so /api/ and /packages/ resolve instead of 404ing; .gitignore ignores api/* rather than api/ so the hand-written landing page can live beside the generated files.

## Type of change

- [x] 📝 Documentation only
