### PR TITLE
Fix order of AsyncRWLock cancellation token checks

### DIFF
--- a/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
+++ b/src/Threading/Async/Pooled/AsyncReaderWriterLock.cs
@@ -651,14 +651,14 @@ public sealed class AsyncReaderWriterLock : IResettable
                 }
             }
 
-            if (timeout == TimeSpan.Zero)
-            {
-                return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
-            }
-
             if (cancellationToken.IsCancellationRequested)
             {
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
+            }
+
+            if (timeout == TimeSpan.Zero)
+            {
+                return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
             }
 
             if (!_localReaderWaiter.TryGetValueTaskSource(out waiter))
@@ -783,14 +783,14 @@ public sealed class AsyncReaderWriterLock : IResettable
                 }
             }
 
-            if (timeout == TimeSpan.Zero)
-            {
-                return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
-            }
-
             if (cancellationToken.IsCancellationRequested)
             {
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
+            }
+
+            if (timeout == TimeSpan.Zero)
+            {
+                return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
             }
 
             if (!_localUpgradeableReaderWaiter.TryGetValueTaskSource(out waiter))
@@ -903,14 +903,14 @@ public sealed class AsyncReaderWriterLock : IResettable
                 return new ValueTask<Releaser>(new Releaser(this, Releaser.ReleaserType.Writer));
             }
 
-            if (timeout == TimeSpan.Zero)
-            {
-                return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
-            }
-
             if (cancellationToken.IsCancellationRequested)
             {
                 return new ValueTask<Releaser>(Task.FromCanceled<Releaser>(cancellationToken));
+            }
+
+            if (timeout == TimeSpan.Zero)
+            {
+                return new ValueTask<Releaser>(Task.FromException<Releaser>(new TimeoutException()));
             }
 
             if (!_localWriterWaiter.TryGetValueTaskSource(out waiter))

--- a/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncReaderWriterLockTests.cs
@@ -1893,6 +1893,79 @@ public class AsyncReaderWriterLockTests
             await upgr.UpgradeToWriterLockAsync(TimeSpan.Zero, ct).ConfigureAwait(false));
     }
 
+    // A caller passing both an already-cancelled token and TimeSpan.Zero gets
+    // OperationCanceledException, not TimeoutException: the token names why the wait was abandoned
+    // and a TimeoutException would not. Every other primitive in this package orders the two checks
+    // that way, and these pin the reader-writer lock to the same convention.
+
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task ReaderLockAsyncPreCancelledWithZeroTimeoutCancelsWhenContended(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var writer = await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
+
+        var cancelled = new CancellationToken(true);
+        // CatchAsync rather than ThrowsAsync: the cancelled task carries a TaskCanceledException,
+        // and what the contract promises is an OperationCanceledException naming the token.
+        var ex = Assert.CatchAsync<OperationCanceledException>(async () =>
+            await rwLock.ReaderLockAsync(TimeSpan.Zero, cancelled).ConfigureAwait(false));
+        Assert.That(ex!.CancellationToken, Is.EqualTo(cancelled));
+    }
+
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task WriterLockAsyncPreCancelledWithZeroTimeoutCancelsWhenContended(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var reader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
+
+        var cancelled = new CancellationToken(true);
+        var ex = Assert.CatchAsync<OperationCanceledException>(async () =>
+            await rwLock.WriterLockAsync(TimeSpan.Zero, cancelled).ConfigureAwait(false));
+        Assert.That(ex!.CancellationToken, Is.EqualTo(cancelled));
+    }
+
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task UpgradeableReaderLockAsyncPreCancelledWithZeroTimeoutCancelsWhenContended(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        using var writer = await rwLock.WriterLockAsync(ct).ConfigureAwait(false);
+
+        var cancelled = new CancellationToken(true);
+        var ex = Assert.CatchAsync<OperationCanceledException>(async () =>
+            await rwLock.UpgradeableReaderLockAsync(TimeSpan.Zero, cancelled).ConfigureAwait(false));
+        Assert.That(ex!.CancellationToken, Is.EqualTo(cancelled));
+    }
+
+    [Test, CancelAfter(CancelAfterMS)]
+    public async Task UpgradeToWriterLockAsyncPreCancelledWithZeroTimeoutCancelsWhenContended(CancellationToken ct)
+    {
+        using var pool = new TestObjectPool<AsyncReaderWriterLock.Releaser>();
+        var rwLock = new AsyncReaderWriterLock(
+            runContinuationAsynchronously: RunContinuationAsynchronously,
+            pool: pool);
+
+        // upgradeable reader + extra reader, so the immediate upgrade CompareExchange fails.
+        using var upgr = await rwLock.UpgradeableReaderLockAsync(ct).ConfigureAwait(false);
+        using var reader = await rwLock.ReaderLockAsync(ct).ConfigureAwait(false);
+
+        var cancelled = new CancellationToken(true);
+        var ex = Assert.CatchAsync<OperationCanceledException>(async () =>
+            await upgr.UpgradeToWriterLockAsync(TimeSpan.Zero, cancelled).ConfigureAwait(false));
+        Assert.That(ex!.CancellationToken, Is.EqualTo(cancelled));
+    }
+
     [Test, CancelAfter(CancelAfterMS)]
     [Repeat(5)]
     public async Task LastReaderNextReaderRaceDoesNotAdmitWriterEarlyAsync(


### PR DESCRIPTION
## Description

- timeout was still checked before ct. Reordered, fixed and tests added.

## Type of change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [x] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [ ] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

## Notes for reviewers

<!--
  Cryptography: cross-validated against a reference implementation and known-answer test vectors?
  Threading:    ValueTask contract respected (no CHT00x analyzer violations)?
  Perf-sensitive: benchmark numbers before/after?
-->
