### PR TITLE
Add a weekly workflow that tests the packages published on nuget.org

### DIFF
--- a/.github/workflows/test-published-packages.yml
+++ b/.github/workflows/test-published-packages.yml
@@ -1,0 +1,215 @@
+name: Test Published NuGet Packages
+
+# Runs the test suite against the packages actually published on nuget.org, the same way
+# .azurepipelines/nuget.yml validates the packages it has just built (UsePackedNuGetPackages
+# swaps every ProjectReference for a PackageReference at the pinned version).
+#
+# The difference is when it runs: this one runs weekly, long after release, so it catches the
+# things that only break with time — a dependency that changed or got unlisted, a new .NET SDK
+# or runtime that the shipped assemblies do not work with, or a package that simply cannot be
+# restored any more.
+#
+# By default it checks out the git tag matching the published version, so the tests are the ones
+# that shipped with that package. Point `ref` at a branch to run newer tests against the released
+# packages instead — expect compile errors there whenever main has grown API the release lacks.
+
+on:
+  schedule:
+    # Mondays, 05:00 UTC.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'NuGet version to test. Empty = newest version published for all four packages.'
+        type: string
+        default: ''
+      include_prerelease:
+        description: 'Consider pre-release versions when resolving the newest one.'
+        type: boolean
+        default: false
+      ref:
+        description: 'Git ref supplying the tests. Empty = the tag matching the version under test.'
+        type: string
+        default: ''
+      run_macos:
+        description: 'Include the macOS (arm64) leg.'
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve published version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      ref: ${{ steps.ref.outputs.ref }}
+      signing: ${{ steps.signing.outputs.signing }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        # Tags are how a published version maps back to the sources that produced it.
+        fetch-depth: 0
+
+    - name: Resolve version
+      id: version
+      shell: pwsh
+      # Dispatch inputs go through the environment rather than string interpolation, so nothing
+      # a dispatcher types can be parsed as script.
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        if ($env:INPUT_VERSION) {
+          "version=$env:INPUT_VERSION" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Using the version from the dispatch input: $env:INPUT_VERSION"
+        }
+        else {
+          ./scripts/get-published-version.ps1 -IncludePrerelease:$${{ inputs.include_prerelease || false }} -Verbose
+        }
+
+    - name: Resolve test sources
+      id: ref
+      shell: pwsh
+      env:
+        INPUT_REF: ${{ inputs.ref }}
+        RESOLVED_VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        $requested = $env:INPUT_REF
+        if ($requested) {
+          "ref=$requested" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "::notice::Testing $requested against the published packages. Sources newer than the release may not compile against it."
+          exit 0
+        }
+
+        # Release tags carry the full assembly version (0.6.51.25133) while NuGet drops the
+        # fourth part (0.6.51), so match on the first three plus any pre-release label.
+        $version = $env:RESOLVED_VERSION
+        $release, $pre = $version -split '-', 2
+        $candidates = @(git tag --list "$release.*" | Where-Object {
+          $tagRelease, $tagPre = $_ -split '-', 2
+          ($tagRelease -split '\.')[0..2] -join '.' -eq $release -and $tagPre -eq $pre
+        } | Sort-Object)
+
+        if ($candidates.Count -eq 0) {
+          Write-Host "::error::No git tag matches the published version $version. Dispatch the workflow with a 'ref' input to choose the sources explicitly."
+          exit 1
+        }
+
+        $tag = $candidates[-1]
+        Write-Host "::notice::Testing package $version against its release tag $tag."
+        "ref=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Check for the strong-name key
+      id: signing
+      shell: pwsh
+      env:
+        STRONG_NAME_KEY: ${{ secrets.STRONG_NAME_KEY }}
+      run: |
+        # The published assemblies are strong-named, and their InternalsVisibleTo names a public
+        # key, so the Threading and Cryptography suites only compile when the test assembly is
+        # signed with the same key. Memory's tests touch no internals and run either way.
+        if ($env:STRONG_NAME_KEY) {
+          "signing=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Strong-name key available - running the full suite."
+        }
+        else {
+          "signing=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "::warning::Secret STRONG_NAME_KEY is not set, so only the Memory suite runs. Add the base64 of CryptoHives.Foundation.Key.snk as a repository secret to cover Threading and Cryptography, whose tests use InternalsVisibleTo against the signed packages."
+        }
+
+  test:
+    name: ${{matrix.csproj.name}}-${{matrix.os}}-${{matrix.framework}}
+    needs: resolve
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS (arm64) runners are costly, so the leg is optional - it is the only one that
+        # exercises the Arm crypto and NEON paths in the published binaries.
+        os: ${{ (github.event_name == 'schedule' || inputs.run_macos) && fromJSON('["ubuntu-latest", "windows-latest", "macOS-latest"]') || fromJSON('["ubuntu-latest", "windows-latest"]') }}
+        # Without the strong-name key only Memory can be built against the signed packages,
+        # so the matrix narrows to it rather than failing every leg on CS0281.
+        csproj: ${{ needs.resolve.outputs.signing == 'true' && fromJSON('[{"name":"Threading","folder":"./tests"},{"name":"Memory","folder":"./tests"},{"name":"Cryptography","folder":"./tests/Security"}]') || fromJSON('[{"name":"Memory","folder":"./tests"}]') }}
+        # The packages ship net462/net472/netstandard2.0/netstandard2.1/net8.0/net10.0; these
+        # three TFMs cover the modern assets plus the .NET Framework ones (through net48).
+        framework:
+          - 'net10.0'
+          - 'net8.0'
+          - 'net48'
+        exclude:
+          # .NET Framework only builds on Windows.
+          - os: ubuntu-latest
+            framework: 'net48'
+          - os: macOS-latest
+            framework: 'net48'
+          # Same split as buildandtest.yml: only the SIMD-heavy Cryptography suite earns the
+          # macOS runner; Threading and Memory add little arm64-specific coverage.
+          - os: macOS-latest
+            csproj:
+              name: Threading
+              folder: './tests'
+          - os: macOS-latest
+            csproj:
+              name: Memory
+              folder: './tests'
+
+    env:
+      CSPROJECT: "${{ matrix.csproj.folder }}/${{ matrix.csproj.name }}/${{ matrix.csproj.name }}.Tests.csproj"
+      TESTRESULTS: "TestResults-${{matrix.csproj.name}}-${{matrix.os}}-${{matrix.framework}}"
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve.outputs.ref }}
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: |
+          8.0.x
+          10.0.x
+
+    - name: Restore the strong-name key
+      if: ${{ needs.resolve.outputs.signing == 'true' }}
+      shell: pwsh
+      env:
+        STRONG_NAME_KEY: ${{ secrets.STRONG_NAME_KEY }}
+      run: |
+        # common.props turns signing on merely because this file exists, which is what makes the
+        # test assemblies match the InternalsVisibleTo public key baked into the published ones.
+        [IO.File]::WriteAllBytes('CryptoHives.Foundation.Key.snk', [Convert]::FromBase64String($env:STRONG_NAME_KEY))
+        Write-Host "Strong-name key restored."
+
+    - name: Build against ${{ needs.resolve.outputs.version }}
+      # EnableExperimentalAlgorithms=false matches how the packages are built: the #if EXPERIMENTAL
+      # paths are not in them, so the tests must not expect them either.
+      run: >
+        dotnet build ${{ env.CSPROJECT }} --force --configuration Release
+        /p:UsePackedNuGetPackages=true
+        /p:NuGetPackageVersion=${{ needs.resolve.outputs.version }}
+        /p:CustomTestTarget=${{ matrix.framework }}
+        /p:EnableExperimentalAlgorithms=false
+
+    - name: Test
+      run: >
+        dotnet test ${{ env.CSPROJECT }} --no-build --configuration Release --logger trx
+        /p:UsePackedNuGetPackages=true
+        /p:NuGetPackageVersion=${{ needs.resolve.outputs.version }}
+        /p:CustomTestTarget=${{ matrix.framework }}
+        /p:EnableExperimentalAlgorithms=false
+        --results-directory ${{ env.TESTRESULTS }}
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v7
+      if: ${{ always() }}
+      with:
+        name: published-package-results-${{matrix.csproj.name}}-${{matrix.os}}-${{matrix.framework}}
+        path: ${{ env.TESTRESULTS }}

--- a/.gitignore
+++ b/.gitignore
@@ -274,7 +274,9 @@ orleans.codegen.cs
 
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
-#*.snk
+# The signing key is supplied out of band - as a secure file in Azure Pipelines and as the
+# STRONG_NAME_KEY secret in GitHub Actions - and must never be committed.
+*.snk
 
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,5 +164,6 @@ Diagnostics:
 
 - **Nerdbank.GitVersioning** controls package versions (local builds only; CI injects versions separately via `.azurepipelines/set-version.ps1`)
 - CI pipelines: `.azurepipelines/test.yml` (test matrix across Windows/Linux/macOS), `azure-pipelines-nuget.yml` (NuGet packaging on main)
+- `.github/workflows/test-published-packages.yml` runs weekly (and on demand) against the packages published on nuget.org: `scripts/get-published-version.ps1` resolves the newest version all four packages share, the run checks out that version's release tag, and the tests build with `/p:UsePackedNuGetPackages=true` so they consume the published artifacts. The Threading and Cryptography suites need the `STRONG_NAME_KEY` secret (base64 of the signing key) because the published assemblies grant `InternalsVisibleTo` to a signed test assembly; without it the run narrows to Memory
 - `ContinuousIntegrationBuild=true` is set automatically in CI (enables deterministic builds, source linking); disabled when `CollectCoverage=true`
 - Deterministic builds require `CryptoHives.Foundation.Key.snk` to be present for strong-name signing

--- a/scripts/get-published-version.ps1
+++ b/scripts/get-published-version.ps1
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026 The Keepers of the CryptoHives
+# SPDX-License-Identifier: MIT
+
+<#
+ .SYNOPSIS
+    Resolves the newest version published on nuget.org for every CryptoHives.Foundation package.
+
+ .DESCRIPTION
+    Queries the NuGet flat container for each package and returns the highest version that all of
+    them have published. The intersection matters: the packages are released together today, but if
+    one ever lags behind, testing against a version only some of them have would fail at restore
+    with a confusing error rather than telling you what is actually going on.
+
+    Prints the version to stdout, and appends `version=<value>` to $env:GITHUB_OUTPUT when running
+    inside GitHub Actions.
+
+ .PARAMETER IncludePrerelease
+    Consider pre-release versions (e.g. 0.7.1-preview) as well as stable ones.
+
+ .PARAMETER PackageId
+    Package ids to consider. Defaults to the four shipped packages.
+
+ .EXAMPLE
+    ./scripts/get-published-version.ps1
+    ./scripts/get-published-version.ps1 -IncludePrerelease
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$IncludePrerelease,
+
+    [string[]]$PackageId = @(
+        'CryptoHives.Foundation.Memory',
+        'CryptoHives.Foundation.Threading',
+        'CryptoHives.Foundation.Threading.Analyzers',
+        'CryptoHives.Foundation.Security.Cryptography'
+    )
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Sorts semver strings the way NuGet does for the bit we care about: numeric release parts first,
+# and a version with a pre-release label ranks below the same version without one.
+function ConvertTo-SortKey([string]$version) {
+    $release, $pre = $version -split '-', 2
+    $parts = @($release -split '\.' | ForEach-Object { [int]$_ })
+    while ($parts.Count -lt 4) { $parts += 0 }
+    return [PSCustomObject]@{
+        Release    = $parts
+        IsStable   = [string]::IsNullOrEmpty($pre)
+        Prerelease = $pre
+    }
+}
+
+function Compare-Version([string]$a, [string]$b) {
+    $x = ConvertTo-SortKey $a
+    $y = ConvertTo-SortKey $b
+    for ($i = 0; $i -lt 4; $i++) {
+        if ($x.Release[$i] -ne $y.Release[$i]) { return $x.Release[$i] - $y.Release[$i] }
+    }
+    if ($x.IsStable -ne $y.IsStable) { return $(if ($x.IsStable) { 1 } else { -1 }) }
+    return [string]::Compare($x.Prerelease, $y.Prerelease, [StringComparison]::OrdinalIgnoreCase)
+}
+
+$common = $null
+foreach ($id in $PackageId) {
+    $uri = "https://api.nuget.org/v3-flatcontainer/$($id.ToLowerInvariant())/index.json"
+    try {
+        $versions = (Invoke-RestMethod -Uri $uri -MaximumRetryCount 3 -RetryIntervalSec 5).versions
+    }
+    catch {
+        throw "Failed to query nuget.org for '$id': $($_.Exception.Message)"
+    }
+
+    if (-not $IncludePrerelease) {
+        $versions = @($versions | Where-Object { $_ -notmatch '-' })
+    }
+    if (-not $versions -or $versions.Count -eq 0) {
+        throw "No matching versions published for '$id'$(if (-not $IncludePrerelease) { ' (stable only - try -IncludePrerelease)' })."
+    }
+
+    Write-Verbose "$id : $($versions.Count) version(s), newest $($versions[-1])"
+    $common = if ($null -eq $common) { $versions } else { $common | Where-Object { $versions -contains $_ } }
+}
+
+$common = @($common)
+if ($common.Count -eq 0) {
+    throw "The packages have no version in common on nuget.org: $($PackageId -join ', '). " +
+          "Pass an explicit version to test one package set anyway."
+}
+
+$latest = $common[0]
+foreach ($candidate in $common) {
+    if ((Compare-Version $candidate $latest) -gt 0) { $latest = $candidate }
+}
+
+Write-Verbose "Newest version published for all $($PackageId.Count) packages: $latest"
+Write-Output $latest
+
+if ($env:GITHUB_OUTPUT) {
+    "version=$latest" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}


### PR DESCRIPTION
## Description

The packages are validated at release time against the artifacts the pipeline has just built. Nothing re-checks them afterwards, so the failures that only appear with time - a dependency that moved or was unlisted, a new SDK or runtime the shipped assemblies do not work with, a package that no longer restores - would go unnoticed until a user hit them.

The workflow runs Mondays and on demand. `scripts/get-published-version.ps1` resolves the newest version that all four packages have published (the intersection matters: a lagging package would otherwise fail at restore with a confusing error), the run checks out that version's release tag, and the tests build with the same `/p:UsePackedNuGetPackages=true /p:NuGetPackageVersion=… /p:EnableExperimentalAlgorithms=false` switches that .azurepipelines/nuget.yml uses. nuget.config clears every source but nuget.org, so restore really does pull the published artifacts.

Testing the release tag rather than main is deliberate: main's tests routinely use API that the last release does not have - today AsyncKeyedLock alone would fail the build - which would make the workflow permanently red for a reason that is not about the packages. Dispatch it with a `ref` input when the drift check is what you want.

Coverage is Threading/Memory/Cryptography x ubuntu/windows/macOS x net10.0/net8.0/net48, with net48 on Windows only and macOS limited to the SIMD-heavy Cryptography suite, matching buildandtest.yml.

The Threading and Cryptography suites only compile when the test assembly is signed with the key the published assemblies name in their InternalsVisibleTo, so the workflow restores it from the STRONG_NAME_KEY secret; common.props enables signing simply because the file exists. Without the secret the matrix narrows to Memory - whose tests touch no internals - and warns, rather than failing every leg on CS0281.

Also uncomments *.snk in .gitignore. The signing key is meant to sit in the repo root without being committed, and the rule that prevents that was disabled.

Verified against the published 0.6.51 at tag 0.6.51.25133: Memory passes on net10.0, net8.0 and net48 (292 tests each), Threading passes with the key in place (870 tests), and Cryptography compiles.

## Type of change

- [ ] 🏗️ Build / CI / tooling

## Affected package(s)

- [ ] Build / CI / NuGet packaging / docs


