### PR TITLE
Fix crlf issue in the analyzer suggestion

### DIFF
--- a/src/Threading.Analyzers/AsyncValueTaskBoxingCodeFixProvider.cs
+++ b/src/Threading.Analyzers/AsyncValueTaskBoxingCodeFixProvider.cs
@@ -199,10 +199,12 @@ public sealed class AsyncValueTaskBoxingCodeFixProvider : CodeFixProvider
         }
 
         // Elastic trivia rather than a hardcoded newline, so the formatter substitutes the line ending
-        // the rest of the document uses.
+        // the rest of the document uses - and ElasticLineFeed rather than the CarriageReturnLineFeed
+        // spelling, which the formatter declines to shorten to "\n" and so leaves a lone CRLF line in
+        // an LF document.
         UsingDirectiveSyntax directive = SyntaxFactory
             .UsingDirective(SyntaxFactory.ParseName(CompilerServicesNamespace))
-            .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
+            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         return unit.WithUsings(unit.Usings.Add(directive));

--- a/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockCodeFixProvider.cs
+++ b/src/Threading.Analyzers/SemaphoreSlimAsAsyncLockCodeFixProvider.cs
@@ -142,13 +142,15 @@ public sealed class SemaphoreSlimAsAsyncLockCodeFixProvider : CodeFixProvider
             return root;
         }
 
-        // The annotation is what makes the elastic trivia elastic in practice: CodeAction's post
-        // processing formats only annotated nodes, so without it the trivia is emitted with the
-        // literal "\r\n" its name carries, regardless of what the rest of the document uses. That
-        // matched on Windows and inserted a lone CRLF line into an LF document everywhere else.
+        // Two things are needed for the formatter to supply the document's own line ending here, and
+        // neither is sufficient alone. The annotation, because CodeAction's post processing formats
+        // annotated nodes only. And ElasticLineFeed rather than ElasticCarriageReturnLineFeed,
+        // because the formatter leaves a "\r\n" it is asked to shorten to "\n" alone - so the CRLF
+        // spelling is elastic only in the direction that happens to match Windows, and inserts a
+        // lone CRLF line into an LF document. "\n" is rewritten in both directions.
         var newUsing = SyntaxFactory.UsingDirective(
                 SyntaxFactory.ParseName(" " + namespaceName))
-            .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
+            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         // Insert after the last existing using directive, or at the top of the file.

--- a/tests/Threading.Analyzers/CodeFixTestBase.cs
+++ b/tests/Threading.Analyzers/CodeFixTestBase.cs
@@ -72,29 +72,48 @@ public abstract class CodeFixTestBase<TAnalyzer, TCodeFix>
             CodeActionIndex = codeActionIndex
         };
 
+        test.TestState.AnalyzerConfigFiles.Add((EditorConfigPath, EditorConfig));
+
         test.ExpectedDiagnostics.AddRange(expected);
         await test.RunAsync().ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Rewrites a test source to <see cref="Environment.NewLine"/>, which is what Roslyn's formatter
-    /// emits for anything a fix inserts or reformats.
+    /// Path of the analyzer config file handed to the testing harness.
     /// </summary>
     /// <remarks>
-    /// <para>
+    /// The harness compiles a virtual document at <c>/0/Test0.cs</c> in an in-memory workspace, so
+    /// the repository's on-disk <c>.editorconfig</c> is not part of that solution and has no effect
+    /// on it. The pin has to be handed to the harness in code, at a path that is a prefix of the
+    /// virtual document's.
+    /// </remarks>
+    private const string EditorConfigPath = "/.editorconfig";
+
+    /// <summary>
+    /// Pins the newline Roslyn's formatter emits, so the expectations below are absolute rather than
+    /// relative to the machine the suite runs on.
+    /// </summary>
+    /// <remarks>
+    /// Without this the formatter takes its newline from <see cref="Environment.NewLine"/>, and only
+    /// for the lines a fix inserts or reformats - the rest of the document keeps whatever the input
+    /// had. That mismatch is invisible on Windows and fails on Linux and macOS, on the one or two
+    /// lines each fix rewrites: the opening brace of a reformatted block, or an inserted directive.
+    /// An analyzer config file overrides the environment, so <c>end_of_line = lf</c> makes the
+    /// formatter emit LF on every platform.
+    /// </remarks>
+    private const string EditorConfig = "root = true\n\n[*.cs]\nend_of_line = lf\n";
+
+    /// <summary>
+    /// Rewrites a test source to LF, matching the newline pinned by <see cref="EditorConfig"/>.
+    /// </summary>
+    /// <remarks>
     /// These sources are verbatim strings, so they carry whatever line endings the test file itself
-    /// has - LF in this repository, and whatever git's autocrlf leaves behind on a Windows checkout.
-    /// Without normalizing, every fix that adds a line would fail on line endings alone, which says
-    /// nothing about whether the fix is correct.
-    /// </para>
-    /// <para>
-    /// <see cref="Environment.NewLine"/> rather than a fixed <c>\r\n</c>: the formatter takes its
-    /// newline from the environment, not from the document it is rewriting, so only the lines a fix
-    /// touches pick it up while the rest keep whatever the input had. Hard-coding CRLF therefore
-    /// passed on Windows and failed on Linux, and only on the one or two lines each fix rewrote -
-    /// the opening brace of a reformatted block, or an inserted attribute.
-    /// </para>
+    /// has - LF in this repository, and CRLF on a Windows checkout, where <c>.gitattributes</c>'
+    /// <c>text=auto</c> makes the working tree platform-native. Without normalizing, every fix that
+    /// adds a line would fail on line endings alone, which says nothing about whether the fix is
+    /// correct. Both halves have to agree: pinning the formatter without pinning the expectations
+    /// just relocates the mismatch.
     /// </remarks>
     private static string NormalizeLineEndings(string source)
-        => source.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
+        => source.Replace("\r\n", "\n");
 }


### PR DESCRIPTION
## Description

Fix the analyzer suggested code CRLF.

Closes #222

## Type of change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [ ] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [x] CryptoHives.Foundation.Threading.Analyzers
- [ ] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

## Notes for reviewers

<!--
  Cryptography: cross-validated against a reference implementation and known-answer test vectors?
  Threading:    ValueTask contract respected (no CHT00x analyzer violations)?
  Perf-sensitive: benchmark numbers before/after?
-->
