### PR TITLE
Fix .NET Framework builds

### DIFF
--- a/CryptoHives .NET Foundation.sln
+++ b/CryptoHives .NET Foundation.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "github ci", "github ci", "{
 		.github\in-solidarity.yml = .github\in-solidarity.yml
 		.github\workflows\sbom.yml = .github\workflows\sbom.yml
 		.github\workflows\stale.yml = .github\workflows\stale.yml
+		.github\workflows\test-published-packages.yml = .github\workflows\test-published-packages.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memory", "src\Memory\Memory.csproj", "{8F353D5E-D8D8-58B2-82A6-933750A0A2D0}"

--- a/tests/Threading/Async/Pooled/AsyncKeyedLockTests.cs
+++ b/tests/Threading/Async/Pooled/AsyncKeyedLockTests.cs
@@ -554,6 +554,9 @@ public class AsyncKeyedLockTests
         }
     }
 
+#if !NETFRAMEWORK
+    // GC.GetAllocatedBytesForCurrentThread does not exist on .NET Framework, so the allocation
+    // assertions below are measured on the .NET targets only.
     [Test]
     public async Task RepeatedLockOnCachedKeyDoesNotAllocate()
     {
@@ -647,6 +650,7 @@ public class AsyncKeyedLockTests
             using (await handles[i].ConfigureAwait(false)) { }
         }
     }
+#endif
 
     [Test]
     public async Task TimedOutEntryIsNotReusedBeforeItsWaiterIsReset()
@@ -907,6 +911,7 @@ public class AsyncKeyedLockTests
         }
     }
 
+#if !NETFRAMEWORK
     [Test]
     public async Task QueueBeyondMaxRetainedWaitersAllocates()
     {
@@ -972,6 +977,7 @@ public class AsyncKeyedLockTests
 
         return (double)allocated / waiters;
     }
+#endif
 
     private static TaskCompletionSource<TResult> CreateAsyncTaskSource<TResult>()
     {


### PR DESCRIPTION
<!--
  Thanks for contributing to CryptoHives.Foundation!
  Security fix? Please coordinate privately first — see SECURITY.md.
-->

## Description

if unsupported API in .NET framework in tests

## Type of change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature / algorithm (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing public API or behavior)
- [ ] 📝 Documentation only
- [x] 🏗️ Build / CI / tooling
- [ ] ♻️ Refactor / performance (no functional change)

## Affected package(s)

- [ ] CryptoHives.Foundation.Memory
- [ ] CryptoHives.Foundation.Security.Cryptography
- [ ] CryptoHives.Foundation.Threading
- [ ] CryptoHives.Foundation.Threading.Analyzers
- [ ] Build / CI / NuGet packaging / docs

## Checklist

- [ ] The solution builds clean with `TreatWarningsAsErrors=true`.
- [ ] `dotnet test "CryptoHives .NET Foundation.sln"` passes across the target frameworks.
- [ ] I added or updated tests covering the change.
- [ ] Public API changes are documented (XML docs, package `README.md`, and/or docfx).
- [ ] The code stays AOT-safe for the .NET 8+ targets (no new trim/AOT warnings).

## Notes for reviewers

<!--
  Cryptography: cross-validated against a reference implementation and known-answer test vectors?
  Threading:    ValueTask contract respected (no CHT00x analyzer violations)?
  Perf-sensitive: benchmark numbers before/after?
-->
